### PR TITLE
don't build docs from running make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION := 0.2.1
 
-all: build web docs
+all: build web
 
 .PHONY: build
 build: js web


### PR DESCRIPTION
running `make` right now puts a dependency on having `jsdoc` installed. besides, in the year 2017, few people want to locally install docs.