### PR TITLE
Update circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -37,3 +37,4 @@ deployment:
     commands:
       - docker tag loadimpact/k6 loadimpact/k6:${CIRCLE_TAG:1}
       - docker push loadimpact/k6:${CIRCLE_TAG:1}
+      - make docs && echo "long list of command"


### PR DESCRIPTION
PR to discuss publishing of docs to `gh-pages` for `tag` deployment phase, see issue #44.

Note: 
- This assumes CircleCI have a read/write deployment key, per https://circleci.com/docs/adding-read-write-deployment-key/ - I have not yet tested/confirmed this. 
- I'm unclear whether or not we also should push documentation for deployments of `latest`?

In line 40 in circle.yml where it now says `make docs && echo "long list of commands"`, I've tested the below set of commands to work as _one_ way to commit updates to `gh-pages` branch and by that, deploy a new site at http://docs.k6.io (there seems to be many ways this could be done, with no standardized best practice)

```
make docs
echo "docs.k6.io" > docs/CNAME
git add -f docs
git commit -m "doc commit"
git subtree split --prefix docs -b gh-pages
git push -f origin gh-pages:gh-pages
```