### PR TITLE
Replace 'test' with 'check' in group example

### DIFF
--- a/tutorials/getting-started.md
+++ b/tutorials/getting-started.md
@@ -123,11 +123,11 @@ let commonTests = {
 
 export default function() {
     group("front page", function() {
-        test(http.get("http://test.loadimpact.com/"), commonTests);
+        check(http.get("http://test.loadimpact.com/"), commonTests);
     });
     
     group("pi digits", function() {
-        test(http.get("http://test.loadimpact.com/pi.php?decimals=2"), {
+        check(http.get("http://test.loadimpact.com/pi.php?decimals=2"), {
             "pi is 3.14": (res) => res.body === "3.14",
         }, commonTests);
     });


### PR DESCRIPTION
I am assuming `test` was the old function and `check` is the new one as the example didn't work for me.