### PR TITLE
Very simple, UDP-based usage reports

### DIFF
--- a/lib/options.go
+++ b/lib/options.go
@@ -32,9 +32,10 @@ type Options struct {
 	Iterations null.Int    `json:"iterations"`
 	Stages     []Stage     `json:"stage"`
 
-	Linger       null.Bool  `json:"linger"`
-	AbortOnTaint null.Bool  `json:"abortOnTaint"`
-	Acceptance   null.Float `json:"acceptance"`
+	Linger        null.Bool  `json:"linger"`
+	AbortOnTaint  null.Bool  `json:"abortOnTaint"`
+	NoUsageReport null.Bool  `json:"usageReports"`
+	Acceptance    null.Float `json:"acceptance"`
 
 	MaxRedirects null.Int `json:"maxRedirects"`
 
@@ -69,6 +70,9 @@ func (o Options) Apply(opts Options) Options {
 	if opts.Acceptance.Valid {
 		o.Acceptance = opts.Acceptance
 	}
+	if opts.NoUsageReport.Valid {
+		o.NoUsageReport = opts.NoUsageReport
+	}
 	if opts.MaxRedirects.Valid {
 		o.MaxRedirects = opts.MaxRedirects
 	}
@@ -85,5 +89,6 @@ func (o Options) SetAllValid(valid bool) Options {
 	o.Duration.Valid = valid
 	o.Linger.Valid = valid
 	o.AbortOnTaint.Valid = valid
+	o.NoUsageReport.Valid = valid
 	return o
 }

--- a/lib/options.go
+++ b/lib/options.go
@@ -34,7 +34,7 @@ type Options struct {
 
 	Linger        null.Bool  `json:"linger"`
 	AbortOnTaint  null.Bool  `json:"abortOnTaint"`
-	NoUsageReport null.Bool  `json:"usageReports"`
+	NoUsageReport null.Bool  `json:"noUsageReport"`
 	Acceptance    null.Float `json:"acceptance"`
 
 	MaxRedirects null.Int `json:"maxRedirects"`

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -88,4 +88,9 @@ func TestOptionsApply(t *testing.T) {
 		assert.NotNil(t, opts.Thresholds)
 		assert.NotEmpty(t, opts.Thresholds)
 	})
+	t.Run("NoUsageReport", func(t *testing.T) {
+		opts := Options{}.Apply(Options{NoUsageReport: null.BoolFrom(true)})
+		assert.True(t, opts.NoUsageReport.Valid)
+		assert.True(t, opts.NoUsageReport.Bool)
+	})
 }

--- a/run.go
+++ b/run.go
@@ -37,6 +37,7 @@ import (
 	"gopkg.in/guregu/null.v3"
 	"gopkg.in/urfave/cli.v1"
 	"io/ioutil"
+	"net"
 	"os"
 	"os/signal"
 	"sort"
@@ -44,7 +45,6 @@ import (
 	"sync"
 	"syscall"
 	"time"
-	"net"
 )
 
 const (
@@ -110,8 +110,8 @@ var commandRun = cli.Command{
 			Usage: "read additional config files",
 		},
 		cli.BoolFlag{
-			Name:  "no-usage-report",
-			Usage: "don't send heartbeat to k6 project on test execution",
+			Name:   "no-usage-report",
+			Usage:  "don't send heartbeat to k6 project on test execution",
 			EnvVar: "K6_NO_USAGE_REPORT",
 		},
 	},
@@ -310,7 +310,7 @@ func actionRun(cc *cli.Context) error {
 	engine.Collector = collector
 
 	// Send usage report, if we're allowed to
-	if opts.NoUsageReport.Valid && !opts.NoUsageReport.Bool	{
+	if opts.NoUsageReport.Valid && !opts.NoUsageReport.Bool {
 		conn, err := net.Dial("udp", "k6reports.loadimpact.com:6565")
 		if err == nil {
 			// This is a best-effort attempt to send a usage report. We don't want

--- a/run.go
+++ b/run.go
@@ -112,6 +112,7 @@ var commandRun = cli.Command{
 		cli.BoolFlag{
 			Name:  "no-usage-report",
 			Usage: "don't send heartbeat to k6 project on test execution",
+			EnvVar: "K6_NO_USAGE_REPORT",
 		},
 	},
 	Action: actionRun,
@@ -309,11 +310,13 @@ func actionRun(cc *cli.Context) error {
 	engine.Collector = collector
 
 	// Send usage report, if we're allowed to
-	if opts.NoUsageReport.Valid && opts.NoUsageReport.Bool == false {
+	if opts.NoUsageReport.Valid && !opts.NoUsageReport.Bool	{
 		conn, err := net.Dial("udp", "k6reports.loadimpact.com:6565")
 		if err == nil {
-			conn.Write([]byte("nyoom"))
-			conn.Close()
+			// This is a best-effort attempt to send a usage report. We don't want
+			// to inconvenience users if this doesn't work, for whatever reason
+			_, _ = conn.Write([]byte("nyoom"))
+			_ = conn.Close()
 		}
 	}
 

--- a/run.go
+++ b/run.go
@@ -44,6 +44,7 @@ import (
 	"sync"
 	"syscall"
 	"time"
+	"net"
 )
 
 const (
@@ -107,6 +108,10 @@ var commandRun = cli.Command{
 		cli.StringSliceFlag{
 			Name:  "config, c",
 			Usage: "read additional config files",
+		},
+		cli.BoolFlag{
+			Name:  "no-usage-report",
+			Usage: "don't send heartbeat to k6 project on test execution",
 		},
 	},
 	Action: actionRun,
@@ -225,15 +230,16 @@ func actionRun(cc *cli.Context) error {
 	addr := cc.GlobalString("address")
 	out := cc.String("out")
 	cliOpts := lib.Options{
-		Paused:       cliBool(cc, "paused"),
-		VUs:          cliInt64(cc, "vus"),
-		VUsMax:       cliInt64(cc, "max"),
-		Duration:     cliDuration(cc, "duration"),
-		Iterations:   cliInt64(cc, "iterations"),
-		Linger:       cliBool(cc, "linger"),
-		AbortOnTaint: cliBool(cc, "abort-on-taint"),
-		Acceptance:   cliFloat64(cc, "acceptance"),
-		MaxRedirects: cliInt64(cc, "max-redirects"),
+		Paused:        cliBool(cc, "paused"),
+		VUs:           cliInt64(cc, "vus"),
+		VUsMax:        cliInt64(cc, "max"),
+		Duration:      cliDuration(cc, "duration"),
+		Iterations:    cliInt64(cc, "iterations"),
+		Linger:        cliBool(cc, "linger"),
+		AbortOnTaint:  cliBool(cc, "abort-on-taint"),
+		Acceptance:    cliFloat64(cc, "acceptance"),
+		MaxRedirects:  cliInt64(cc, "max-redirects"),
+		NoUsageReport: cliBool(cc, "no-usage-report"),
 	}
 	opts := cliOpts
 
@@ -301,6 +307,15 @@ func actionRun(cc *cli.Context) error {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	engine.Collector = collector
+
+	// Send usage report, if we're allowed to
+	if opts.NoUsageReport.Valid && opts.NoUsageReport.Bool == false {
+		conn, err := net.Dial("udp", "k6reports.loadimpact.com:6565")
+		if err == nil {
+			conn.Write([]byte("nyoom"))
+			conn.Close()
+		}
+	}
 
 	// Run the engine.
 	wg.Add(1)


### PR DESCRIPTION
Send a UDP datagram to k6reports.loadimpact.com:6565 whenever `k6 run` is invoked. Possible to disable this behaviour through a `--no-usage-report` flag.

(server side not implemented yet, but tcpdump always works...)