### PR TITLE
[fix] find root group by name

### DIFF
--- a/web/app/routes/index.js
+++ b/web/app/routes/index.js
@@ -8,6 +8,6 @@ export default Ember.Route.extend({
     });
   },
   afterModel(model) {
-    model["defaultGroup"] = this.get('store').peekRecord('group', 0);
+    model["defaultGroup"] = this.get('store').peekAll('group').findBy('name', '');
   },
 });


### PR DESCRIPTION
Updated web application to find root group by using `name` instead. Could be checking if `parent` relationship is empty instead. What do you think @uppfinnarn ?