### PR TITLE
Implement http.batch()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@
 /js/node_modules
 /docs
 
+.vscode
 *.sublime-workspace
 .vagrant

--- a/js/api_http_test.go
+++ b/js/api_http_test.go
@@ -1,0 +1,104 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2016 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package js
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTPBatchShort(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	snippet := `
+	import { _assert } from "k6"
+	import http from "k6/http"
+
+	export default function() {
+		let responses = http.batch([
+			"http://httpbin.org/status/200",
+			"http://httpbin.org/status/404",
+			"http://httpbin.org/status/500"
+		])
+		_assert(responses[0].status === 200)
+		_assert(responses[1].status === 404)
+		_assert(responses[2].status === 500)
+	}
+	`
+
+	assert.NoError(t, runSnippet(snippet))
+}
+
+func TestHTTPBatchLong(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	snippet := `
+	import { _assert } from "k6"
+	import http from "k6/http"
+
+	export default function() {
+		let responses = http.batch([
+			"http://httpbin.org/status/200",
+			"http://httpbin.org/status/404",
+			{
+				"method": "GET",
+				"url": "http://httpbin.org/status/500",
+				"body": null,
+				"params": {}
+			}
+		])
+		_assert(responses[0].status === 200)
+		_assert(responses[1].status === 404)
+		_assert(responses[2].status === 500)
+	}
+	`
+
+	assert.NoError(t, runSnippet(snippet))
+}
+
+func TestHTTPBatchObject(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	snippet := `
+	import { _assert } from "k6"
+	import http from "k6/http"
+
+	export default function() {
+		let responses = http.batch({
+			"twohundred": "http://httpbin.org/status/200",
+			"fourohfour": "http://httpbin.org/status/404",
+			"fivehundred": "http://httpbin.org/status/500"
+		})
+		_assert(responses.twohundred.status === 200)
+		_assert(responses.fourohfour.status === 404)
+		_assert(responses.fivehundred.status === 500)
+	}
+	`
+
+	assert.NoError(t, runSnippet(snippet))
+}

--- a/js/lib/k6/http.js
+++ b/js/lib/k6/http.js
@@ -164,21 +164,29 @@ export function trace(url, body, params) {
  * @return {Array.<module:k6/http.Response>|Object}
  */
 export function batch(requests) {
+	function stringToObject(str) {
+		return {
+			"method": "GET",
+			"url": str,
+			"body": null,
+			"params": JSON.stringify({})
+		}
+	}
+
+	function formatObject(obj) {
+		obj.params = !obj.params ? {} :obj.params
+		obj.body = parseBody(obj.body)
+		obj.params = JSON.stringify(obj.params)
+		return obj
+	}
+
 	let result
 	if (requests.length > 0) {
 		result = requests.map(e => {
 			if (typeof e === 'string') {
-				return {
-					"method": "GET",
-					"url": e,
-					"body": null,
-					"params": JSON.stringify({})
-				}
+				return stringToObject(e)
 			} else {
-				e.params = !e.params ? {} : e.params
-				e.body = parseBody(e.body)
-				e.params = JSON.stringify(e.params)
-				return e
+				return formatObject(e)
 			}
 		})
 	} else {
@@ -186,17 +194,9 @@ export function batch(requests) {
 		Object.keys(requests).map(e => {
 			let val = requests[e]
 			if (typeof val === 'string') {
-				result[e] = {
-					"method": "GET",
-					"url": val,
-					"body": null,
-					"params": JSON.stringify({})
-				}
+				result[e] = stringToObject(val)
 			} else {
-				val.params = !val.params ? {} : val.params
-				val.body = parseBody(val.body)
-				val.params = JSON.stringify(val.params)
-				result[e] = val
+				result[e] = formatObject(val)
 			}
 		})
 	}

--- a/js/lib/k6/http.js
+++ b/js/lib/k6/http.js
@@ -164,26 +164,45 @@ export function trace(url, body, params) {
  * @return {Array.<module:k6/http.Response>|Object}
  */
 export function batch(requests) {
-	let reqObjects = requests.map(e => {
-		let res;
-		if (typeof e === 'string') {
-			res = {
-				"method": "GET",
-				"url": e,
-				"body": null,
-				"params": {},
+	let result
+	if (requests.length > 0) {
+		result = requests.map(e => {
+			if (typeof e === 'string') {
+				return {
+					"method": "GET",
+					"url": e,
+					"body": null,
+					"params": JSON.stringify({})
+				}
+			} else {
+				e.params = !e.params ? {} : e.params
+				e.body = parseBody(e.body)
+				e.params = JSON.stringify(e.params)
+				return e
 			}
-		} else {
-			res = e;
-			res.params = !res.params ? {} : res.params;
-			res.body = parseBody(res.body);
-		}
-		res.params = JSON.stringify(res.params);
-		return res;
-	});
+		})
+	} else {
+		result = {}
+		Object.keys(requests).map(e => {
+			let val = requests[e]
+			if (typeof val === 'string') {
+				result[e] = {
+					"method": "GET",
+					"url": val,
+					"body": null,
+					"params": JSON.stringify({})
+				}
+			} else {
+				val.params = !val.params ? {} : val.params
+				val.body = parseBody(val.body)
+				val.params = JSON.stringify(val.params)
+				result[e] = val
+			}
+		})
+	}
 	
-	let response = __jsapi__.BatchHTTPRequest(reqObjects);
-	return response.map(e => new Response(e));
+	let response = __jsapi__.BatchHTTPRequest(result);
+	return response
 };
 
 export default {

--- a/js/lib/k6/http.js
+++ b/js/lib/k6/http.js
@@ -171,7 +171,7 @@ export function batch(requests) {
 				"method": "GET",
 				"url": e,
 				"body": null,
-				"params": {}
+				"params": {},
 			}
 		} else {
 			res = e;
@@ -187,12 +187,12 @@ export function batch(requests) {
 };
 
 export default {
-	Response: Response,
-	request: request,
-	get: get,
-	post: post,
-	put: put,
-	del: del,
-	patch: patch,
-	batch: batch,
+	Response,
+	request,
+	get,
+	post,
+	put,
+	del,
+	patch,
+	batch,
 };

--- a/js/lib/k6/http.js
+++ b/js/lib/k6/http.js
@@ -164,10 +164,6 @@ export function trace(url, body, params) {
  * @return {Array.<module:k6/http.Response>}
  */
 export function batch(requests) {
-	if (!Array.isArray(requests)) {
-		throw new TypeError('first argument must be an array')
-	}
-
 	let reqObjects = requests.map(e => {
 		let res;
 		if (typeof e === 'string') {
@@ -187,7 +183,7 @@ export function batch(requests) {
 	});
 	
 	let response = __jsapi__.BatchHTTPRequest(reqObjects);
-	return response.map(e => new Response(e));
+	return response.map(e => new Response(e))
 };
 
 export default {

--- a/js/lib/k6/http.js
+++ b/js/lib/k6/http.js
@@ -160,8 +160,8 @@ export function trace(url, body, params) {
 /**
  * Batches multiple requests together.
  * @see    module:k6/http.request
- * @param  {Array} requests	An array of requests, in string or object form.
- * @return {Array.<module:k6/http.Response>}
+ * @param  {Array|Object} requests	An array or object of requests, in string or object form.
+ * @return {Array.<module:k6/http.Response>|Object}
  */
 export function batch(requests) {
 	let reqObjects = requests.map(e => {

--- a/js/lib/k6/http.js
+++ b/js/lib/k6/http.js
@@ -30,6 +30,24 @@ export class Response {
 	}
 }
 
+function parseBody(body) {
+	if (body) {
+		if (typeof body === "object") {
+			let formstring = "";
+			for (let key in body) {
+				if (formstring !== "") {
+					formstring += "&";
+				}
+				formstring += key + "=" + encodeURIComponent(body[key]);
+			}
+			return formstring;
+		}
+		return body;
+	} else {
+		return '';
+	}
+}
+
 /**
  * Makes an HTTP request.
  * @param  {string} method      HTTP Method (eg. "GET")
@@ -40,20 +58,7 @@ export class Response {
  */
 export function request(method, url, body, params = {}) {
 	method = method.toUpperCase();
-	if (body) {
-		if (typeof body === "object") {
-			let formstring = "";
-			for (let key in body) {
-				if (formstring !== "") {
-					formstring += "&";
-				}
-				formstring += key + "=" + encodeURIComponent(body[key]);
-			}
-			body = formstring;
-		}
-	} else {
-		body = ''
-	}
+	body = parseBody(body);
 	return new Response(__jsapi__.HTTPRequest(method, url, body, JSON.stringify(params)));
 };
 
@@ -164,7 +169,19 @@ export function batch(requests) {
 	}
 
 	let reqObjects = requests.map(e => {
-		let res = typeof e === 'string' ? {"method": "GET", "url": e, "body": null, "params": {}} : e
+		let res;
+		if (typeof e === 'string') {
+			res = {
+				"method": "GET",
+				"url": e,
+				"body": null,
+				"params": {}
+			}
+		} else {
+			res = e;
+			res.params = !res.params ? {} : res.params
+			res.body = parseBody(res.body);
+		}
 		res.params = JSON.stringify(res.params)
 		return res
 	});

--- a/js/lib/k6/http.js
+++ b/js/lib/k6/http.js
@@ -152,6 +152,25 @@ export function trace(url, body, params) {
 	return request("TRACE", url, body, params);
 };
 
+/**
+ * Batches multiple requests together.
+ * @see    module:k6/http.request
+ * @param  {Array} requests	An array of requests, in string or object form.
+ * @return {Array.<module:k6/http.Response>}
+ */
+export function batch(requests) {
+	if (!Array.isArray(requests)) {
+		throw new TypeError('first argument must be an array')
+	}
+
+	let reqObjects = requests.map(e => {
+		let res = typeof e === 'string' ? {"method": "GET", "url": e, "body": null, "params": {}} : e
+		res.params = JSON.stringify(res.params)
+		return res
+	});
+	return __jsapi__.BatchHTTPRequest(reqObjects);
+};
+
 export default {
 	Response: Response,
 	request: request,
@@ -160,4 +179,5 @@ export default {
 	put: put,
 	del: del,
 	patch: patch,
+	batch: batch,
 };

--- a/js/lib/k6/http.js
+++ b/js/lib/k6/http.js
@@ -179,15 +179,15 @@ export function batch(requests) {
 			}
 		} else {
 			res = e;
-			res.params = !res.params ? {} : res.params
+			res.params = !res.params ? {} : res.params;
 			res.body = parseBody(res.body);
 		}
-		res.params = JSON.stringify(res.params)
-		return res
+		res.params = JSON.stringify(res.params);
+		return res;
 	});
 	
 	let response = __jsapi__.BatchHTTPRequest(reqObjects);
-	return response.map(e => new Response(e))
+	return response.map(e => new Response(e));
 };
 
 export default {

--- a/js/lib/k6/http.js
+++ b/js/lib/k6/http.js
@@ -168,7 +168,9 @@ export function batch(requests) {
 		res.params = JSON.stringify(res.params)
 		return res
 	});
-	return __jsapi__.BatchHTTPRequest(reqObjects);
+	
+	let response = __jsapi__.BatchHTTPRequest(reqObjects);
+	return response.map(e => new Response(e))
 };
 
 export default {

--- a/js/lib/k6/http.js
+++ b/js/lib/k6/http.js
@@ -183,7 +183,7 @@ export function batch(requests) {
 	});
 	
 	let response = __jsapi__.BatchHTTPRequest(reqObjects);
-	return response.map(e => new Response(e))
+	return response.map(e => new Response(e));
 };
 
 export default {

--- a/samples/http_batch.js
+++ b/samples/http_batch.js
@@ -5,6 +5,10 @@ export default function() {
   const responses = http.batch([
     "http://test.loadimpact.com",
     "http://test.loadimpact.com/pi.php",
+    {
+      "method": "GET",
+      "url": "http://test.loadimpact.com/pi.php?decimals=50"
+    }
   ]);
 
   check(responses[0], {
@@ -13,5 +17,11 @@ export default function() {
 
   check(responses[1], {
     "pi page 200": res => res.status === 200,
+  })
+
+  check(responses[2], {
+    "pi page has 50 digits": res => {
+      return res.body === "3.14159265358979323846264338327950288"
+    }
   })
 };

--- a/samples/http_batch.js
+++ b/samples/http_batch.js
@@ -1,18 +1,18 @@
-import { check } from 'k6'
-import http from 'k6/http'
+import { check } from 'k6';
+import http from 'k6/http';
 
 export default function() {
   const responses = http.batch([
     "http://test.loadimpact.com",
-    "http://test.loadimpact.com/pi.php"
+    "http://test.loadimpact.com/pi.php",
   ]);
 
   check(responses[0], {
     "main page 200": res => res.status === 200,
-  })
+  });
 
   check(responses[1], {
     "pi page 200": res => res.status === 200,
-    "pi page has right content": res => res.body === "3.14"
-  })
+    "pi page has right content": res => res.body === "3.14",
+  });
 };

--- a/samples/http_batch.js
+++ b/samples/http_batch.js
@@ -1,0 +1,17 @@
+import { check } from 'k6'
+import http from 'k6/http'
+
+export default function() {
+  const responses = http.batch([
+    "http://test.loadimpact.com",
+    "http://test.loadimpact.com/pi.php",
+  ]);
+
+  check(responses[0], {
+    "main page 200": res => res.status === 200,
+  })
+
+  check(responses[1], {
+    "pi page 200": res => res.status === 200,
+  })
+};

--- a/samples/http_batch.js
+++ b/samples/http_batch.js
@@ -2,17 +2,20 @@ import { check } from 'k6';
 import http from 'k6/http';
 
 export default function() {
-  const responses = http.batch([
-    "http://test.loadimpact.com",
-    "http://test.loadimpact.com/pi.php",
-  ]);
-
-  check(responses[0], {
-    "main page 200": res => res.status === 200,
+  const responses = http.batch({
+    "main": "http://test.loadimpact.com"
   });
 
-  check(responses[1], {
-    "pi page 200": res => res.status === 200,
-    "pi page has right content": res => res.body === "3.14",
-  });
+  check(responses.main, {
+    "main page 200": res => res.status === 200
+  })
+
+  // check(responses[0], {
+  //   "main page 200": res => res.status === 200,
+  // });
+
+  // check(responses[1], {
+  //   "pi page 200": res => res.status === 200,
+  //   "pi page has right content": res => res.body === "3.14",
+  // });
 };

--- a/samples/http_batch.js
+++ b/samples/http_batch.js
@@ -4,11 +4,7 @@ import http from 'k6/http'
 export default function() {
   const responses = http.batch([
     "http://test.loadimpact.com",
-    "http://test.loadimpact.com/pi.php",
-    {
-      "method": "GET",
-      "url": "http://test.loadimpact.com/pi.php?decimals=50"
-    }
+    "http://test.loadimpact.com/pi.php"
   ]);
 
   check(responses[0], {
@@ -17,11 +13,6 @@ export default function() {
 
   check(responses[1], {
     "pi page 200": res => res.status === 200,
-  })
-
-  check(responses[2], {
-    "pi page has 50 digits": res => {
-      return res.body === "3.14159265358979323846264338327950288"
-    }
+    "pi page has right content": res => res.body === "3.14"
   })
 };

--- a/samples/http_batch.js
+++ b/samples/http_batch.js
@@ -2,20 +2,17 @@ import { check } from 'k6';
 import http from 'k6/http';
 
 export default function() {
-  const responses = http.batch({
-    "main": "http://test.loadimpact.com"
+  const responses = http.batch([
+    "http://test.loadimpact.com",
+    "http://test.loadimpact.com/pi.php"
+  ]);
+
+  check(responses[0], {
+    "main page 200": res => res.status === 200,
   });
 
-  check(responses.main, {
-    "main page 200": res => res.status === 200
-  })
-
-  // check(responses[0], {
-  //   "main page 200": res => res.status === 200,
-  // });
-
-  // check(responses[1], {
-  //   "pi page 200": res => res.status === 200,
-  //   "pi page has right content": res => res.body === "3.14",
-  // });
+  check(responses[1], {
+    "pi page 200": res => res.status === 200,
+    "pi page has right content": res => res.body === "3.14",
+  });
 };


### PR DESCRIPTION
[WORK IN PROGRESS]

this implements #72. api is as described in the original issue:

```js
let responses = http.batch([
  "http://test.com",
  {
    "method": "GET",
    "url": "http://test.com?cool=1"
    // optionally, body or params
  }
])
```

the only problem that currently exists with this implementation is that the array of responses is jumbled, making is pretty difficult to `check()` single requests. i wanted to gather some opinions on how to best solve this here before attempting to do so myself, as i'm not quite sure how to go about this