### PR TITLE
Add form-urlencode header when auto encoding body

### DIFF
--- a/js/api_http_test.go
+++ b/js/api_http_test.go
@@ -102,3 +102,22 @@ func TestHTTPBatchObject(t *testing.T) {
 
 	assert.NoError(t, runSnippet(snippet))
 }
+
+func TestHTTPFormURLEncodeHeader(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	snippet := `
+	import { _assert } from "k6"
+	import http from "k6/http"
+
+	export default function() {
+		let response = http.post("http://httpbin.org/post", { field: "value" })
+		_assert(response.json()["form"].hasOwnProperty("field"))
+		_assert(response.json()["form"]["field"] === "value")
+	}
+	`
+
+	assert.NoError(t, runSnippet(snippet))
+}

--- a/js/lib/k6/http.js
+++ b/js/lib/k6/http.js
@@ -58,6 +58,12 @@ function parseBody(body) {
  */
 export function request(method, url, body, params = {}) {
 	method = method.toUpperCase();
+	if (typeof body === "object") {
+		if (typeof params["headers"] !== "object") {
+			params["headers"] = {};
+		}
+		params["headers"]["Content-Type"] = "application/x-www-form-urlencoded";
+	}
 	body = parseBody(body);
 	return new Response(__jsapi__.HTTPRequest(method, url, body, JSON.stringify(params)));
 };


### PR DESCRIPTION
Automatically add `application/x-www-form-urlencoded` Content-Type header when user passed in JS object as data parameter.

This is basically a convenience patch to shorten this:
```js
http.post("http://httpbin.org/post", {field: "value"}, { headers: {"Content-Type": "application/x-www-form-urlencoded"} });
```
to
```js
http.post("http://httpbin.org/post", {field: "value"});
```