### PR TITLE
Handle lists/checkbox form input when form urlencoding

### DIFF
--- a/js/api_http_test.go
+++ b/js/api_http_test.go
@@ -121,3 +121,22 @@ func TestHTTPFormURLEncodeHeader(t *testing.T) {
 
 	assert.NoError(t, runSnippet(snippet))
 }
+
+func TestHTTPFormURLEncodeList(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	snippet := `
+	import { _assert } from "k6"
+	import http from "k6/http"
+
+	export default function() {
+		let response = http.post("http://httpbin.org/post", { field: ["value1", "value2", "value3"] }, { headers: {"Content-Type": "application/x-www-form-urlencoded"} })
+		_assert(response.json()["form"].hasOwnProperty("field"))
+		_assert(JSON.stringify(response.json()["form"]["field"]) === JSON.stringify(["value1", "value2", "value3"]))
+	}
+	`
+
+	assert.NoError(t, runSnippet(snippet))
+}

--- a/js/lib/k6/http.js
+++ b/js/lib/k6/http.js
@@ -38,7 +38,17 @@ function parseBody(body) {
 				if (formstring !== "") {
 					formstring += "&";
 				}
-				formstring += key + "=" + encodeURIComponent(body[key]);
+				if (Array.isArray(body[key])) {
+					let l = body[key].length;
+					for (let i = 0; i < l; i++) {
+						formstring += key + "=" + encodeURIComponent(body[key][i]);
+						if (formstring !== "") {
+							formstring += "&";
+						}
+					}
+				} else {
+					formstring += key + "=" + encodeURIComponent(body[key]);
+				}
 			}
 			return formstring;
 		}


### PR DESCRIPTION
Dependant on https://github.com/loadimpact/k6/pull/168.

Adds handling of lists/arrays being passed as Object properties in `data` parameter,  automatically encodes the list items as multiple entries with same key.

Given:
``` js
let form = {topping: ["cheese", "lettuce", "kebab", "tomatoes"]};
let r = http.post("http://httpbin.org/post", form);
console.log(r.json()["form"]["topping"]);
``` 
this patch will change the behavior of the automatic form urlencoding so that the contents of the `topping` field will be changed from:

`topping=cheese,lettuce,kebab,tomatoes` to `topping=cheese&topping=lettuce&topping=kebab&topping=tomatoes`

and the output of the above script will change from:

`"cheese, lettuce, kebab, tomatoes"` to `["cheese", "lettuce", "kebab", "tomatoes"]`

This to match how multiple (checkbox) `<input>` fields with same `name` are sent according to [HTML spec](https://html.spec.whatwg.org/multipage/forms.html#configuring-a-form-to-communicate-with-a-server).