### PR TITLE
(WIP) Add cookie API 

### DIFF
--- a/js/api_http.go
+++ b/js/api_http.go
@@ -96,11 +96,16 @@ func (a JSAPI) HTTPRequest(method, url, body string, paramData string) map[strin
 	for k, v := range res.Header {
 		headers[k] = strings.Join(v, ", ")
 	}
+	cookies := make(map[string]string)
+	for _, v := range a.vu.CookieJar.Cookies(res.Request.URL) {
+		cookies[v.Name] = v.Value
+	}
 	return map[string]interface{}{
 		"url":     res.Request.URL.String(),
 		"status":  res.StatusCode,
 		"body":    string(resBody),
 		"headers": headers,
+		"cookies": cookies,
 		"timings": map[string]float64{
 			"duration":   stats.D(trail.Duration),
 			"blocked":    stats.D(trail.Blocked),

--- a/samples/cookies.js
+++ b/samples/cookies.js
@@ -1,0 +1,49 @@
+import http from "k6/http";
+import { check, group } from "k6";
+
+export default function() {
+    group("Simple cookies", function() {
+        // Simple key/value cookies
+        let cookies = {
+            key: "value",
+            key2: "value2"
+        };
+
+        // Send a request that will have the server set cookies in the response
+        let r = http.get("http://httpbin.org/cookies", { cookies: cookies });
+
+        // Verify response
+        check(r, {
+            "status is 200": (r) => r.status === 200,
+            "cookie one is set": (r) => r.cookies["key"] === "value",
+            "cookie two is set": (r) => r.cookies["key2"] === "value2",
+        });
+    });
+
+    group("Advanced cookies", function() {
+        // Set cookies with more advanced options
+        let cookieJar = new http.CookieJar();
+        cookieJar.set("key3", "value3", { domain: "httpbin.org", path: "/cookies" });
+        cookieJar.set("key4", "value4", { domain: "httpbin.org", path: "/cookies", secure: true, httpOnly: true });
+
+        // Send a request to cookie echoing service, not using TLS
+        let r = http.get("http://httpbin.org/cookies", { cookies: cookieJar });
+
+        // Verify response
+        check(r, {
+            "status is 200": (r) => r.status === 200,
+            "cookie three is set": (r) => r.cookies["key3"] === "value3",
+            "cookie four is not set": (r) => r.cookies["key4"] === undefined,  // since it's not "secure"!
+        });
+
+        // Send a request to cookie echoing service, using TLS
+        r = http.get("https://httpbin.org/cookies", { cookies: cookieJar });
+
+        // Verify response
+        check(r, {
+            "status is 200": (r) => r.status === 200,
+            "cookie three is set": (r) => r.cookies["key3"] === "value3",
+            "cookie four is set": (r) => r.cookies["key4"] === "value4",
+        });
+    });
+}


### PR DESCRIPTION
This is my initial take on implementing https://github.com/loadimpact/k6/issues/68. I've switched out our own simple Go CookieJar implementation for the stdlib one since we need more standards compliance and goroutine thread-safety (is that what you call it in Go?).

## Sample:
```js
import http from "k6/http";
import { check, group } from "k6";

export default function() {
    group("Simple cookies", function() {
        let cookies = {
            name: "value1",
            name2: "value2"
        };
        let res = http.get("http://httpbin.org/cookies", { cookies: cookies });
        check(res, {
            "status is 200": (r) => r.status === 200,
            "has cookie": (r) => r.cookies["name"]
        });
    });

    group("Advanced cookies", function() {
        let jar = new http.CookieJar();
        jar.set("name3", "value3", { domain: "httpbin.org", path: "/cookies" });
        let res = http.get("http://httpbin.org/cookies", { cookies: jar });
        check(res, {
            "status is 200": (r) => r.status === 200,
            "has cookie": (r) => r.cookies["name3"]
        });
    });
}
```

## Comments:
`res.cookies` will expose cookies in VU cookie jar matching request URL, which means cookies:
- added manually in JS through this cookie API or
- received by server in `Set-Cookie` header(s)

It will **NOT** however expose ones manually specified in Cookie headers:
```js
http.get("http://httpbin.org/cookies", { headers: { "Cookie": "key=value" } });
```

## Some things I'd like feedback on in terms of the `http.CookieJar` class:
- Is it weird that the JS http.CookieJar API is a class that is new'ed while only being a wrapper around a VU global cookie jar?
- Should the `http.CookieJar` class be skipped in favor of a purely JS object based API?
- Or should the cookie jar be exposed as a global API `http.getCookieJar()`?