### PR TITLE
Made sample structs public in the cloud collector

### DIFF
--- a/stats/cloud/api.go
+++ b/stats/cloud/api.go
@@ -28,13 +28,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-type sample struct {
+type Sample struct {
 	Type   string     `json:"type"`
 	Metric string     `json:"metric"`
-	Data   sampleData `json:"data"`
+	Data   SampleData `json:"data"`
 }
 
-type sampleData struct {
+type SampleData struct {
 	Type  stats.MetricType  `json:"type"`
 	Time  time.Time         `json:"time"`
 	Value float64           `json:"value"`
@@ -75,7 +75,7 @@ func (c *Client) CreateTestRun(testRun *TestRun) (*CreateTestRunResponse, error)
 	return &ctrr, nil
 }
 
-func (c *Client) PushMetric(referenceID string, samples []*sample) error {
+func (c *Client) PushMetric(referenceID string, samples []*Sample) error {
 	url := fmt.Sprintf("%s/metrics/%s", c.baseURL, referenceID)
 
 	req, err := c.NewRequest("POST", url, samples)

--- a/stats/cloud/api_test.go
+++ b/stats/cloud/api_test.go
@@ -55,11 +55,11 @@ func TestPublishMetric(t *testing.T) {
 
 	client := NewClient("token", server.URL, "1.0")
 
-	samples := []*sample{
+	samples := []*Sample{
 		{
 			Type:   "Point",
 			Metric: "metric",
-			Data: sampleData{
+			Data: SampleData{
 				Type:  1,
 				Time:  time.Now(),
 				Value: 1.2,

--- a/stats/cloud/collector.go
+++ b/stats/cloud/collector.go
@@ -57,7 +57,7 @@ type Collector struct {
 	thresholds map[string][]*stats.Threshold
 	client     *Client
 
-	sampleBuffer []*sample
+	sampleBuffer []*Sample
 	sampleMu     sync.Mutex
 }
 
@@ -168,12 +168,12 @@ func (c *Collector) Collect(samples []stats.Sample) {
 		return
 	}
 
-	var cloudSamples []*sample
+	var cloudSamples []*Sample
 	for _, samp := range samples {
-		sampleJSON := &sample{
+		sampleJSON := &Sample{
 			Type:   "Point",
 			Metric: samp.Metric.Name,
-			Data: sampleData{
+			Data: SampleData{
 				Type:  samp.Metric.Type,
 				Time:  samp.Time,
 				Value: samp.Value,


### PR DESCRIPTION
Sample structs in the cloud collector have been made public so that they can be imported in other projects.