### PR TITLE
Improve Checks console output

### DIFF
--- a/run.go
+++ b/run.go
@@ -602,16 +602,28 @@ loop:
 			for _, check := range g.Checks {
 				icon := "✓"
 				statusColor := color.GreenString
-				if check.Fails > 0 {
+				isCheckFailure := check.Fails > 0
+
+				if isCheckFailure {
 					icon = "✗"
 					statusColor = color.RedString
 				}
-				fmt.Fprint(color.Output, statusColor("%s  %s %2.2f%% - %s\n",
+
+				fmt.Fprint(color.Output, statusColor("%s  %s %s\n",
 					indent,
 					icon,
-					100*(float64(check.Passes)/float64(check.Passes+check.Fails)),
 					check.Name,
 				))
+
+				if isCheckFailure {
+					fmt.Fprint(color.Output, statusColor("%s        %2.2f%% (%v/%v) \n",
+						indent,
+						100*(float64(check.Fails)/float64(check.Passes+check.Fails)),
+						check.Fails,
+						check.Passes+check.Fails,
+					))
+				}
+
 			}
 			fmt.Fprintf(color.Output, "\n")
 		}


### PR DESCRIPTION
Ref #243

The change modifies the check console output to:

<img width="263" alt="screen shot 2017-06-16 at 06 07 48" src="https://user-images.githubusercontent.com/825430/27211580-890860e6-525a-11e7-8bbd-e208b7481d9c.png">


I tried the suggested format but I find better the one above.
<img width="249" alt="screen shot 2017-06-16 at 06 02 28" src="https://user-images.githubusercontent.com/825430/27211608-c92d152c-525a-11e7-9dab-42323bf4f64f.png">

Please, let me know any suggestion or change.


