### PR TITLE
Make the console format of percentiles to be consistent with thresholds syntax

### DIFF
--- a/stats/sink.go
+++ b/stats/sink.go
@@ -108,12 +108,12 @@ func (t *TrendSink) Format() map[string]float64 {
 	}
 
 	return map[string]float64{
-		"min": t.min,
-		"max": t.max,
-		"avg": t.avg,
-		"med": t.med,
-		"p90": t.P(0.90),
-		"p95": t.P(0.95),
+		"min":   t.min,
+		"max":   t.max,
+		"avg":   t.avg,
+		"med":   t.med,
+		"p(90)": t.P(0.90),
+		"p(95)": t.P(0.95),
 	}
 }
 


### PR DESCRIPTION
@liclac 

This commit changes the percentile output as `p(90), p(95)`:



![screen shot 2017-06-16 at 10 44 17](https://user-images.githubusercontent.com/825430/27219110-be86df56-5280-11e7-98c1-6a49a1d177e9.png)


The issue was discussed at #160 