### PR TITLE
Update Slack links because of new invitation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is how load testing should look in the 21st century.
 
 - Documentation: [http://docs.k6.io](http://docs.k6.io)
 
-- Check out k6 on [Slack](https://slackin-defaimlmsd.now.sh/)!
+- Check out k6 on [Slack](https://k6.io/slack)!
 
 
 Introduction
@@ -102,9 +102,9 @@ Types of questions and where to ask:
 - I got this error, why? -- [Stack Overflow](https://stackoverflow.com/questions/tagged/k6)
 - I got this error and I'm sure it's a bug -- [file an issue](https://github.com/loadimpact/k6/issues)
 - I have an idea/request -- [file an issue](https://github.com/loadimpact/k6/issues)
-- Why do you? -- [Slack](https://slackin-defaimlmsd.now.sh/)
-- When will you? -- [Slack](https://slackin-defaimlmsd.now.sh/)
-- I want to contribute/help with development -- [Start here](https://github.com/loadimpact/k6/blob/master/CONTRIBUTING.md), then [Slack](https://slackin-defaimlmsd.now.sh/) and [issues](https://github.com/loadimpact/k6/issues)
+- Why do you? -- [Slack](https://k6.io/slack)
+- When will you? -- [Slack](https://k6.io/slack)
+- I want to contribute/help with development -- [Start here](https://github.com/loadimpact/k6/blob/master/CONTRIBUTING.md), then [Slack](https://k6.io/slack) and [issues](https://github.com/loadimpact/k6/issues)
 
 ---
 


### PR DESCRIPTION
Since our current Slack invitation flow has been blocked by Slack (because of hitting an invite acceptance rate limit with very unclear answers on if/how/when it would be lifted) we have to use an alternative flow, using time limited shared invite links.

We've set up a page on k6.io/slack for managing the rotation of this invite link. This PR updates the README to point to that page instead of the current invite flow.