### PR TITLE
Fix data received/sent metrics for HTTP

### DIFF
--- a/lib/netext/dialer.go
+++ b/lib/netext/dialer.go
@@ -44,7 +44,7 @@ func NewDialer(dialer net.Dialer) *Dialer {
 	}
 }
 
-func (d Dialer) DialContext(ctx context.Context, proto, addr string) (net.Conn, error) {
+func (d *Dialer) DialContext(ctx context.Context, proto, addr string) (net.Conn, error) {
 	delimiter := strings.LastIndex(addr, ":")
 	ip, err := d.Resolver.FetchOne(addr[:delimiter])
 	if err != nil {


### PR DESCRIPTION
Data received and sent metrics were not collected for HTTP requests.
This is because the DialContext method required a non-pointer receiver,
which meant that the BytesRead and BytesWritten references were not
carried to the connection created from the Dialer.