### PR TITLE
HAR converter WIP

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -1,0 +1,120 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2017 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package cmd
+
+import (
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/loadimpact/k6/converter/har"
+)
+
+var (
+	output           string
+	enableChecks     bool
+	threshold        uint
+	only             []string
+	skip             []string
+	maxRequestsBatch uint
+)
+
+var convertCmd = &cobra.Command{
+	Use:   "convert",
+	Short: "Converts a HAR file to a k6 js script",
+	Long: `Converts a HAR (HTTP Archive) file to a k6 script.
+  
+  By default the HTTP requests are grouped by their start time in intervals
+  of 500ms. You can modify this value with the flag --batch-inclusion-threshold.
+  
+  --only and --skip flags allow you to filter HAR HTTP requests and generate a
+  k6 script with the desired requests: --only domain.com`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return errors.New("Must specify a HAR file as parameter!")
+		}
+
+		// handles absolute/relative paths
+		abs, err := filepath.Abs(args[0])
+		if err != nil {
+			return errors.New(err.Error())
+		}
+
+		// parse HAR file
+		h, err := har.Read(abs)
+		if err != nil {
+			return errors.New(err.Error())
+		}
+
+		var b bytes.Buffer
+		w := bufio.NewWriter(&b)
+
+		err = har.WriteK6Script(
+			w,
+			h,
+			enableChecks,
+			threshold,
+			only,
+			skip,
+			maxRequestsBatch,
+		)
+		if err != nil {
+			return errors.New(err.Error())
+		}
+
+		// output filename
+		if output == "" {
+			basename := filepath.Base(abs)
+			output = fmt.Sprintf("%v.js", basename[0:len(basename)-len(filepath.Ext(basename))])
+		}
+
+		f, err := os.Create(output)
+		if err != nil {
+			return errors.New("Can't create output filename")
+		}
+		if _, err = f.Write(b.Bytes()); err != nil {
+			return errors.New(err.Error())
+		}
+		if err = f.Sync(); err != nil {
+			return errors.New(err.Error())
+		}
+		if err = f.Close(); err != nil {
+			return errors.New(err.Error())
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(convertCmd)
+	convertCmd.Flags().StringVarP(&output, "output", "o", "", "filename for the output k6 script file")
+	convertCmd.Flags().BoolVarP(&enableChecks, "enable-status-code-checks", "", false, "add a status code check in every request")
+	convertCmd.Flags().UintVarP(&threshold, "batch-inclusion-threshold", "", 500, "batch inclusion threshold")
+	convertCmd.Flags().StringSliceVarP(&only, "only", "", []string{}, "include only requests from the given domains")
+	convertCmd.Flags().StringSliceVarP(&skip, "skip", "", []string{}, "skip requests from the given domains")
+	convertCmd.Flags().UintVarP(&maxRequestsBatch, "max-requests-batch", "", 5, "max number of requests in a batch statement")
+}

--- a/converter/har/har.go
+++ b/converter/har/har.go
@@ -1,0 +1,288 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2017 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package har
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"time"
+)
+
+// HAR is the top level object of a HAR log.
+type HAR struct {
+	Log *Log `json:"log"`
+}
+
+// Log is the HAR HTTP request and response log.
+type Log struct {
+	// Version number of the HAR format.
+	Version string `json:"version"`
+	// Creator holds information about the log creator application.
+	Creator *Creator `json:"creator"`
+	// Browser
+	Browser *Browser `json:"browser,omitempty"`
+	// Pages
+	Pages []Page `json:"pages,omitempty"`
+	// Entries is a list containing requests and responses.
+	Entries []*Entry `json:"entries"`
+	//
+	Comment string `json:"comment,omitempty"`
+}
+
+// Creator is the program responsible for generating the log. Martian, in this case.
+type Creator struct {
+	// Name of the log creator application.
+	Name string `json:"name"`
+	// Version of the log creator application.
+	Version string `json:"version"`
+}
+
+// Browser that created the log
+type Browser struct {
+	// Required. The name of the browser that created the log.
+	Name string `json:"name"`
+	// Required. The version number of the browser that created the log.
+	Version string `json:"version"`
+	// Optional. A comment provided by the user or the browser.
+	Comment string `json:"comment"`
+}
+
+// Page object for every exported web page and one <entry> object for every HTTP request.
+// In case when an HTTP trace tool isn't able to group requests by a page,
+// the <pages> object is empty and individual requests doesn't have a parent page.
+type Page struct {
+	/* There is one <page> object for every exported web page and one <entry>
+	object for every HTTP request. In case when an HTTP trace tool isn't able to
+	group requests by a page, the <pages> object is empty and individual
+	requests doesn't have a parent page.
+	*/
+
+	// Date and time stamp for the beginning of the page load
+	// (ISO 8601 YYYY-MM-DDThh:mm:ss.sTZD, e.g. 2009-07-24T19:20:30.45+01:00).
+	StartedDateTime time.Time `json:"startedDateTime"`
+	// Unique identifier of a page within the . Entries use it to refer the parent page.
+	ID string `json:"id"`
+	// Page title.
+	Title string `json:"title"`
+	// (new in 1.2) A comment provided by the user or the application.
+	Comment string `json:"comment,omitempty"`
+}
+
+// Entry is a individual log entry for a request or response.
+type Entry struct {
+	Pageref string `json:"pageref,omitempty"`
+	// ID is the unique ID for the entry.
+	ID string `json:"_id"`
+	// StartedDateTime is the date and time stamp of the request start (ISO 8601).
+	StartedDateTime time.Time `json:"startedDateTime"`
+	// Time is the total elapsed time of the request in milliseconds.
+	Time float32 `json:"time"`
+	// Request contains the detailed information about the request.
+	Request *Request `json:"request"`
+	// Response contains the detailed information about the response.
+	Response *Response `json:"response,omitempty"`
+	// Cache contains information about a request coming from browser cache.
+	Cache *Cache `json:"cache"`
+	// Timings describes various phases within request-response round trip. All
+	// times are specified in milliseconds.
+	Timings *Timings `json:"timings"`
+}
+
+// Request holds data about an individual HTTP request.
+type Request struct {
+	// Method is the request method (GET, POST, ...).
+	Method string `json:"method"`
+	// URL is the absolute URL of the request (fragments are not included).
+	URL string `json:"url"`
+	// HTTPVersion is the Request HTTP version (HTTP/1.1).
+	HTTPVersion string `json:"httpVersion"`
+	// Cookies is a list of cookies.
+	Cookies []Cookie `json:"cookies"`
+	// Headers is a list of headers.
+	Headers []Header `json:"headers"`
+	// QueryString is a list of query parameters.
+	QueryString []QueryString `json:"queryString"`
+	// PostData is the posted data information.
+	PostData *PostData `json:"postData,omitempty"`
+	// HeaderSize is the Total number of bytes from the start of the HTTP request
+	// message until (and including) the double CLRF before the body. Set to -1
+	// if the info is not available.
+	HeadersSize int64 `json:"headersSize"`
+	// BodySize is the size of the request body (POST data payload) in bytes. Set
+	// to -1 if the info is not available.
+	BodySize int64 `json:"bodySize"`
+	// (new in 1.2) A comment provided by the user or the application.
+	Comment string `json:"comment"`
+}
+
+// Response holds data about an individual HTTP response.
+type Response struct {
+	// Status is the response status code.
+	Status int `json:"status"`
+	// StatusText is the response status description.
+	StatusText string `json:"statusText"`
+	// HTTPVersion is the Response HTTP version (HTTP/1.1).
+	HTTPVersion string `json:"httpVersion"`
+	// Cookies is a list of cookies.
+	Cookies []Cookie `json:"cookies"`
+	// Headers is a list of headers.
+	Headers []Header `json:"headers"`
+	// Content contains the details of the response body.
+	Content *Content `json:"content"`
+	// RedirectURL is the target URL from the Location response header.
+	RedirectURL string `json:"redirectURL"`
+	// HeadersSize is the total number of bytes from the start of the HTTP
+	// request message until (and including) the double CLRF before the body.
+	// Set to -1 if the info is not available.
+	HeadersSize int64 `json:"headersSize"`
+	// BodySize is the size of the request body (POST data payload) in bytes. Set
+	// to -1 if the info is not available.
+	BodySize int64 `json:"bodySize"`
+}
+
+// Cache contains information about a request coming from browser cache.
+type Cache struct {
+	// Has no fields as they are not supported, but HAR requires the "cache"
+	// object to exist.
+}
+
+// Timings describes various phases within request-response round trip. All
+// times are specified in milliseconds
+type Timings struct {
+	// Send is the time required to send HTTP request to the server.
+	Send float32 `json:"send"`
+	// Wait is the time spent waiting for a response from the server.
+	Wait float32 `json:"wait"`
+	// Receive is the time required to read entire response from server or cache.
+	Receive float32 `json:"receive"`
+}
+
+// Cookie is the data about a cookie on a request or response.
+type Cookie struct {
+	// Name is the cookie name.
+	Name string `json:"name"`
+	// Value is the cookie value.
+	Value string `json:"value"`
+	// Path is the path pertaining to the cookie.
+	Path string `json:"path,omitempty"`
+	// Domain is the host of the cookie.
+	Domain string `json:"domain,omitempty"`
+	// Expires contains cookie expiration time.
+	Expires time.Time `json:"-"`
+	// Expires8601 contains cookie expiration time in ISO 8601 format.
+	Expires8601 string `json:"expires,omitempty"`
+	// HTTPOnly is set to true if the cookie is HTTP only, false otherwise.
+	HTTPOnly bool `json:"httpOnly,omitempty"`
+	// Secure is set to true if the cookie was transmitted over SSL, false
+	// otherwise.
+	Secure bool `json:"secure,omitempty"`
+}
+
+// Header is an HTTP request or response header.
+type Header struct {
+	// Name is the header name.
+	Name string `json:"name"`
+	// Value is the header value.
+	Value string `json:"value"`
+}
+
+// QueryString is a query string parameter on a request.
+type QueryString struct {
+	// Name is the query parameter name.
+	Name string `json:"name"`
+	// Value is the query parameter value.
+	Value string `json:"value"`
+}
+
+// PostData describes posted data on a request.
+type PostData struct {
+	// MimeType is the MIME type of the posted data.
+	MimeType string `json:"mimeType"`
+	// Params is a list of posted parameters (in case of URL encoded parameters).
+	Params []Param `json:"params"`
+	// Text contains the plain text posted data.
+	Text string `json:"text"`
+}
+
+// Param describes an individual posted parameter.
+type Param struct {
+	// Name of the posted parameter.
+	Name string `json:"name"`
+	// Value of the posted parameter.
+	Value string `json:"value,omitempty"`
+	// Filename of a posted file.
+	Filename string `json:"fileName,omitempty"`
+	// ContentType is the content type of a posted file.
+	ContentType string `json:"contentType,omitempty"`
+}
+
+// Content describes details about response content.
+type Content struct {
+	// Size is the length of the returned content in bytes. Should be equal to
+	// response.bodySize if there is no compression and bigger when the content
+	// has been compressed.
+	Size int64 `json:"size"`
+	// MimeType is the MIME type of the response text (value of the Content-Type
+	// response header).
+	MimeType string `json:"mimeType"`
+	// Text contains the response body sent from the server or loaded from the
+	// browser cache. This field is populated with textual content only. The text
+	// field is either HTTP decoded text or a encoded (e.g. "base64")
+	// representation of the response body. Leave out this field if the
+	// information is not available.
+	Text string `json:"text,omitempty"`
+	// Encoding used for response text field e.g "base64". Leave out this field
+	// if the text field is HTTP decoded (decompressed & unchunked), than
+	// trans-coded from its original character set into UTF-8.
+	Encoding string `json:"encoding,omitempty"`
+}
+
+type byRequestDate []*Entry
+
+// Len returns the length of the slice of entries.
+func (e byRequestDate) Len() int { return len(e) }
+
+// Swap swaps entries by position.
+func (e byRequestDate) Swap(i, j int) { e[i], e[j] = e[j], e[i] }
+
+// Less returns whether the entry at i has a StartedDateTime before the entry at j.
+func (e byRequestDate) Less(i, j int) bool {
+	return e[i].StartedDateTime.Before(e[j].StartedDateTime)
+}
+
+func Read(filePath string) (*HAR, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, errors.New("Failed to read HAR file")
+	}
+
+	var h HAR
+	err = json.NewDecoder(f).Decode(&h)
+	if err != nil {
+		return nil, errors.New("Failed to parse HAR file")
+	}
+
+	if err = f.Close(); err != nil {
+		return nil, err
+	}
+
+	return &h, nil
+}

--- a/converter/har/k6helper.go
+++ b/converter/har/k6helper.go
@@ -1,0 +1,336 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2017 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package har
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	Get   = "get"
+	Post  = "post"
+	Del   = "del"
+	Put   = "put"
+	Patch = "patch"
+)
+
+// build a K6 request
+func BuildK6Request(method, uri, data string, headers []Header, cookies []Cookie) (string, error) {
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+
+	// method and url
+	method = strings.ToLower(method)
+	switch method {
+	case Get, Post, Put, Patch:
+		fmt.Fprintf(w, "http.%v(\"%v\"", method, uri)
+	case "delete":
+		fmt.Fprintf(w, "http.del(\"%v\"", uri)
+	default:
+		fmt.Fprintf(w, "http.request(\"%v\",\"%v\"", method, uri)
+	}
+
+	// data
+	if data != "" {
+		fmt.Fprintf(w, ",\n\t\"%s\"", url.QueryEscape(data))
+	} else if method != Get {
+		fmt.Fprint(w, ",\n\tnull")
+	}
+
+	// Add cookie as header
+	c := BuildK6CookiesValues(cookies)
+	if c != "" {
+		headers = append(headers, Header{Name: "Cookie", Value: c})
+	}
+
+	if header := BuildK6Headers(headers); len(header) > 0 {
+		fmt.Fprintf(w, ",\n\t{ %v }", header)
+	}
+
+	fmt.Fprint(w, "\n);\n")
+
+	if err := w.Flush(); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+// Build a K6 request object for batch requests
+func BuildK6RequestObject(method, uri, data string, headers []Header, cookies []Cookie) (string, error) {
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+
+	fmt.Fprint(w, "{\n")
+
+	method = strings.ToLower(method)
+	if method == "delete" {
+		method = Del
+	}
+	fmt.Fprintf(w, "\"method\": %q,\n\"url\": %q", method, uri)
+
+	// data
+	if data != "" && method != Get {
+		fmt.Fprintf(w, ", \"body\": \n%q\n", data)
+	}
+
+	// Add cookie as header
+	if c := BuildK6CookiesValues(cookies); c != "" {
+		headers = append(headers, Header{Name: "Cookie", Value: c})
+	}
+
+	if header := BuildK6Headers(headers); len(header) > 0 {
+		fmt.Fprintf(w, ", \"params\": {\n%s\n}\n", header)
+	}
+
+	fmt.Fprint(w, "}")
+	if err := w.Flush(); err != nil {
+		return "", err
+	}
+
+	// json indentation
+	var buffer bytes.Buffer
+	err := json.Indent(&buffer, b.Bytes(), "", "    ")
+	if err != nil {
+		return "", err
+	}
+
+	return buffer.String(), nil
+}
+
+// Build the string representation of a K6 headers object from a given HAR.NVP array
+func BuildK6Headers(headers []Header) string {
+	if len(headers) == 0 {
+		return ""
+	}
+	m := make(map[string]Header)
+
+	var h []string
+	for _, header := range headers {
+		if header.Name[0] != ':' { // avoid SPDY's colon headers
+			// avoid header duplicity
+			_, exists := m[strings.ToLower(header.Name)]
+			if !exists {
+				m[strings.ToLower(header.Name)] = header
+				h = append(h, fmt.Sprintf("%q : %q", header.Name, header.Value))
+			}
+		}
+	}
+
+	return fmt.Sprintf("\"headers\" : { %v }", strings.Join(h, ", "))
+}
+
+// Build the string representation of K6 cookie values from a given HAR.Cookie array
+func BuildK6CookiesValues(cookies []Cookie) string {
+	if len(cookies) == 0 {
+		return ""
+	}
+
+	var c []string
+	for _, cookie := range cookies {
+		c = append(c, fmt.Sprintf("%v=%v", cookie.Name, cookie.Value))
+	}
+
+	return strings.Join(c, "; ")
+}
+
+// Returns true if the given url is allowed from the only (only domains) and skip (skip domains) values, otherwise false
+func IsAllowedURL(url string, only, skip []string) bool {
+	if len(only) != 0 {
+		for _, v := range only {
+			v = strings.Trim(v, " ")
+			if v != "" && strings.Contains(url, v) {
+				return true
+			}
+		}
+		return false
+	}
+	if len(skip) != 0 {
+		for _, v := range skip {
+			v = strings.Trim(v, " ")
+			if v != "" && strings.Contains(url, v) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func WriteK6Script(w *bufio.Writer, h *HAR, includeCodeCheck bool, batchTime uint, only, skip []string, maxRequestsBatch uint) error {
+	if includeCodeCheck {
+		fmt.Fprint(w, "import { group, check, sleep } from 'k6';\n")
+	} else {
+		fmt.Fprint(w, "import { group, sleep } from 'k6';\n")
+	}
+	fmt.Fprint(w, "import http from 'k6/http';\n\n")
+
+	fmt.Fprintf(w, "// Version: %v\n", h.Log.Version)
+	fmt.Fprintf(w, "// Creator: %v\n", h.Log.Creator.Name)
+
+	if h.Log.Browser != nil { // browser is optional
+		fmt.Fprintf(w, "// Browser: %v\n", h.Log.Browser.Name)
+	}
+	if h.Log.Comment != "" {
+		fmt.Fprintf(w, "// %v\n", h.Log.Comment)
+	}
+
+	fmt.Fprint(w, "\nexport default function() {\n\nlet res;\n\n")
+
+	// name used by group entries
+	pagenames := make(map[string]string)
+	for _, e := range h.Log.Pages {
+		pagenames[e.ID] = fmt.Sprintf("%s - %s", e.ID, e.Title)
+	}
+
+	// grouping by page and URL filtering
+	groups := make(map[string][]*Entry)
+	var nameGroups []string
+	for _, e := range h.Log.Entries {
+
+		// URL filtering
+		u, err := url.Parse(e.Request.URL)
+		if err != nil {
+			return err
+		}
+		if !IsAllowedURL(u.Host, only, skip) {
+			continue
+		}
+
+		// avoid multipart/form-data requests until k6 scripts can support binary data
+		if e.Request.PostData != nil && strings.HasPrefix(e.Request.PostData.MimeType, "multipart/form-data") {
+			continue
+		}
+
+		// create new group o adding page to a existing one
+		if _, ok := groups[e.Pageref]; !ok {
+			groups[e.Pageref] = append([]*Entry{}, e)
+			nameGroups = append(nameGroups, e.Pageref)
+		} else {
+			groups[e.Pageref] = append(groups[e.Pageref], e)
+		}
+	}
+
+	for _, n := range nameGroups {
+
+		// sort entries by requests started date time
+		sort.Sort(byRequestDate(groups[n]))
+
+		fmt.Fprintf(w, "group(\"%v\", function() {\n", pagenames[n])
+
+		if batchTime > 0 {
+			// batch mode, multiple HTTP requests together
+			entries := groupHarEntriesByIntervals(groups[n], groups[n][0].StartedDateTime, batchTime, maxRequestsBatch)
+
+			fmt.Fprint(w, "\tlet req\n")
+
+			for _, e := range entries {
+				var statuses []int
+
+				fmt.Fprint(w, "\treq = [\n")
+				for _, r := range e {
+					var data string
+					if r.Request.PostData != nil {
+						data = r.Request.PostData.Text
+					}
+					b, err := BuildK6RequestObject(r.Request.Method, r.Request.URL, data, r.Request.Headers, r.Request.Cookies)
+					if err != nil {
+						return err
+					}
+					fmt.Fprintf(w, "%v,\n", b)
+					statuses = append(statuses, r.Response.Status)
+				}
+				fmt.Fprint(w, "];\n")
+
+				fmt.Fprint(w, "\tres = http.batch(req);\n")
+				if includeCodeCheck {
+					for i, s := range statuses {
+						if s > 0 { // avoid empty responses, browsers with adblockers, antivirus.. can block HTTP requests
+							fmt.Fprintf(w, "\tcheck(res[%v], {\n\t\t\"status is %v\": (r) => r.status === %v,\n\t});\n", i, s, s)
+						}
+					}
+				}
+			}
+		} else {
+			// no batch mode
+			for _, e := range groups[n] {
+				var data string
+				if e.Request.PostData != nil {
+					data = e.Request.PostData.Text
+				}
+				b, err := BuildK6Request(e.Request.Method, e.Request.URL, data, e.Request.Headers, e.Request.Cookies)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(w, "res = %v", b)
+				if includeCodeCheck {
+					if e.Response.Status > 0 { // avoid empty responses, browsers with adblockers, antivirus.. can block HTTP requests
+						fmt.Fprintf(w, "check(res, {\n\"status is %v\": (r) => r.status === %v,\n});\n", e.Response.Status, e.Response.Status)
+					}
+				}
+			}
+		}
+
+		// random sleep from 100ms to 500ms
+		fmt.Fprintf(w, "\tsleep(%.1f);\n", float64(rand.Intn(500)+100)/1000)
+
+		fmt.Fprint(w, "});\n")
+	}
+
+	fmt.Fprint(w, "\n}\n")
+	err := w.Flush()
+
+	return err
+}
+
+func groupHarEntriesByIntervals(entries []*Entry, starttime time.Time, interval uint, maxentries uint) [][]*Entry {
+	var ordered [][]*Entry
+	var j int
+
+	if interval > 0 {
+		t := starttime
+		d := time.Duration(interval) * time.Millisecond
+
+		for _, e := range entries {
+			// new interval by date
+			if e.StartedDateTime.Sub(t) >= d {
+				t = t.Add(d)
+				j++
+			}
+			if len(ordered) == j {
+				ordered = append(ordered, []*Entry{})
+			}
+			// new interval by maxentries value
+			if len(ordered[j]) == int(maxentries) {
+				ordered = append(ordered, []*Entry{})
+				j++
+			}
+			ordered[j] = append(ordered[j], e)
+		}
+	}
+
+	return ordered
+}

--- a/converter/har/k6helper_test.go
+++ b/converter/har/k6helper_test.go
@@ -1,0 +1,156 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2017 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package har
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/loadimpact/k6/js"
+	"github.com/loadimpact/k6/lib"
+	"github.com/spf13/afero"
+)
+
+func TestBuildK6Cookies(t *testing.T) {
+	var cookies = []struct {
+		values   []Cookie
+		expected string
+	}{
+		{[]Cookie{{Name: "a", Value: "b"}}, "a=b"},
+		{[]Cookie{{Name: "a", Value: "b"}, {Name: "c", Value: "d"}}, "a=b; c=d"},
+	}
+
+	for _, pair := range cookies {
+		v := BuildK6CookiesValues(pair.values)
+		if v != pair.expected {
+			t.Errorf("BuildK6Cookies(%v): expected %v, actual %v", pair.values, pair.expected, v)
+		}
+	}
+}
+
+func TestBuildK6Headers(t *testing.T) {
+	var headers = []struct {
+		values   []Header
+		expected string
+	}{
+		{[]Header{{"name", "1"}, {"name", "2"}}, "\"headers\" : { \"name\" : \"1\" }"},
+		{[]Header{{"name", "1"}, {"Name", "2"}}, "\"headers\" : { \"name\" : \"1\" }"},
+		{[]Header{{"Name", "1"}, {"name", "2"}}, "\"headers\" : { \"Name\" : \"1\" }"},
+		{[]Header{{"name", "value"}, {"name2", "value2"}}, "\"headers\" : { \"name\" : \"value\", \"name2\" : \"value2\" }"},
+		{[]Header{{"accept-language", "es-ES,es;q=0.8"}}, "\"headers\" : { \"accept-language\" : \"es-ES,es;q=0.8\" }"},
+		{[]Header{{":host", "localhost"}}, "\"headers\" : {  }"}, // avoid SPDY’s colon headers
+	}
+
+	for _, pair := range headers {
+		v := BuildK6Headers(pair.values)
+		if v != pair.expected {
+			t.Errorf("BuildK6Headers(%v): expected %v, actual %v", pair.values, pair.expected, v)
+		}
+	}
+}
+
+func TestBuildK6Request(t *testing.T) {
+	v, err := BuildK6Request("get", "http://www.google.es", "", []Header{{"accept-language", "es-ES,es;q=0.8"}}, []Cookie{{Name: "a", Value: "b"}})
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = js.New(&lib.SourceData{
+		Filename: "/script.js",
+		Data:     []byte(fmt.Sprintf("export default function() { %v }", v)),
+	}, afero.NewMemMapFs())
+
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestBuildK6RequestObject(t *testing.T) {
+	v, err := BuildK6RequestObject("get", "http://www.google.es", "", []Header{{"accept-language", "es-ES,es;q=0.8"}}, []Cookie{{Name: "a", Value: "b"}})
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = js.New(&lib.SourceData{
+		Filename: "/script.js",
+		Data:     []byte(fmt.Sprintf("export default function() { res = http.batch([%v]); }", v)),
+	}, afero.NewMemMapFs())
+
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestIsAllowedURL(t *testing.T) {
+	var allowed = []struct {
+		url      string
+		only     []string
+		skip     []string
+		expected bool
+	}{
+		{"http://www.google.com/", []string{}, []string{}, true},
+		{"http://www.google.com/", []string{"google.com"}, []string{}, true},
+		{"https://www.google.com/", []string{"google.com"}, []string{}, true},
+		{"https://www.google.com/", []string{"http://"}, []string{}, false},
+		{"http://www.google.com/?hl=en", []string{"http://www.google.com"}, []string{}, true},
+		{"http://www.google.com/?hl=en", []string{"google.com", "google.co.uk"}, []string{}, true},
+		{"http://www.google.com/?hl=en", []string{}, []string{"google.com"}, false},
+		{"http://www.google.com/?hl=en", []string{}, []string{"google.co.uk"}, true},
+	}
+
+	for _, s := range allowed {
+		v := IsAllowedURL(s.url, s.only, s.skip)
+		if v != s.expected {
+			t.Errorf("IsAllowedURL(%v, %v, %v): expected %v, actual %v", s.url, s.only, s.skip, s.expected, v)
+		}
+	}
+}
+
+func TestGroupHarEntriesByIntervals(t *testing.T) {
+	// max number of requests in a batch statement
+	const maxentries uint = 5
+
+	t1 := time.Date(2017, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	entries := []*Entry{}
+
+	// 10 time entries with increments of 100ms (from 0 a 1000ms)
+	for i := 0; i < 10; i++ {
+		entries = append(entries, &Entry{StartedDateTime: t1.Add(time.Duration(100*i) * time.Millisecond)})
+	}
+
+	splitValues := []struct {
+		diff, groups uint
+	}{
+		{0, 0},
+		{1000, 2},
+		{100, 10},
+		{500, 2},
+		{800, 3}, // group with 5 entries, group with 3 entries, group with 2 entries
+	}
+
+	for _, v := range splitValues {
+		result := groupHarEntriesByIntervals(entries, t1, v.diff, maxentries)
+		if len(result) != int(v.groups) {
+			t.Errorf("groupHarEntriesByIntervals(%v, %v, %v, %v) Expected %v, actual %v", entries, t1, v.diff, maxentries, v.groups, len(result))
+		}
+	}
+}


### PR DESCRIPTION
Closes #248

I still working on this, I am testing different HAR exportation tools and some scenarios more. The objective of this PR is to validate if I'm on the right track and the code meets the requirements. I would be grateful to receive guidelines on what things I need to add, change or remove.

The HAR struct is based from google/martian one but I have added some missing fields like Log.Browser, Log.Pages, Log.Comment, etc

There are some helper functions to build the k6 script parts (BuildK6Request, BuildK6RequestObject, BuildK6HeadersValues, BuildK6CookiesValues..), they use directly HAR objects (ex: Har.Header) as parameters to avoid extra load but if you need support to convert any other formats to a k6 script these helper functions can be easily converted to a generic ones.

The HAR entries (HTTP requests) are ordered as the specification recommends (http://w3c.github.io/web-performance/specs/HAR/Overview.html#sec-object-types-entries), although all tested HAR entries from exported files are already ordered.

I have detected that configured firewall/antimalware/adblockers block some requests and these exported HAR entries/requests have empty responses, they are ignored for status code checks.

By default the requests are grouped by page and batched in 500ms (what do you think?) intervals by their started time (you can change this value with --batch-inclusion-threshold 200). For batch requests I define a []req object with all k6 requests objects and this object is passed to the http.batch call.

I like the http.request and http.<verb> calls, you can disable batch mode using --batch-inclusion-threshold 0 (maybe it isn't the best way) and the convert command creates a k6 script with these request types instead of the http.batch ones. Batch mode can be the preferred mode for HAR files but this option can be interesting for debugging. Should I keep this functionality/mode (no batch mode)?

The --only <text> and --skip <text> options filters HAR requests, these flags checks if the URL.Host contains the given string so you can do things like --only https:// or --skip :8080 besides --only domain.com,cdn.domain.com (they works like "OR" conditions, domain.com or cdn.domain.com)

TODO/Issues:
- Complete TestBuildK6Request and TestBuildK6RequestObject tests cases
- Improve command description/help
- Add example HAR files to samples/har folder, include them in tests

- The SPDY's colon headers (ex: ":Host") are not valid header requests (https://github.com/golang/net/blob/master/lex/httplex/httplex.go#L201), so BuildK6Headers ignores them.

- The Firefox (54.0.1) exported HAR file from a multipart post request (example: uploading a file) includes the file content in binary mode. How can I build a k6 request body from that content? I mean the ideal way is this content was base64 encoded, should I parse/modify the boundary to a base64 one? (boundaries with content-transfer-encoding != base64 only. https://tools.ietf.org/html/rfc2045#section-6.1 https://golang.org/pkg/mime/multipart/#example_NewReader). FiddlerToLoadImpact tool (https://github.com/loadimpact/FiddlerToLoadImpact) creates external binary files, they are included to the k6 scripts with bin1 = open("bin1.bin").
What if you support base64 encoded body string parameter for the k6 http requests (I mean something like http.post(url, base64EncodedFormData, { base64: true });)? It's simpler just encode body requests parameter with no printable/binary content.
The file content is missing in the HAR exportation from Chrome 59.