### PR TITLE
HTTP/2 check on BBC Homepage

### DIFF
--- a/samples/http_2.js
+++ b/samples/http_2.js
@@ -1,0 +1,9 @@
+import http from "k6/http";
+import { check } from "k6";
+
+export default function() {
+  check(http.get("https://www.bbc.co.uk/"), {
+    "status is 200": (r) => r.status == 200,
+    "protocol is HTTP/2": (r) => r.proto == "HTTP/2.0",
+  });
+}


### PR DESCRIPTION
Hi @liclac

I created a branch, pushed upstream and then created a PR. 

I am getting ```proto``` from here: 
https://github.com/loadimpact/k6/blob/80c201125846f9954312e8f65cc40111b04c5fc4/js/modules/k6/http/http_test.go#L219

I tried ```r.h2``` and it failed

Apologies for being a retard!!!