### PR TITLE
Add base64 JS API

### DIFF
--- a/js/modules/index.go
+++ b/js/modules/index.go
@@ -23,6 +23,7 @@ package modules
 import (
 	"github.com/loadimpact/k6/js/modules/k6"
 	"github.com/loadimpact/k6/js/modules/k6/crypto"
+	"github.com/loadimpact/k6/js/modules/k6/encoding"
 	"github.com/loadimpact/k6/js/modules/k6/html"
 	"github.com/loadimpact/k6/js/modules/k6/http"
 	"github.com/loadimpact/k6/js/modules/k6/metrics"
@@ -31,10 +32,11 @@ import (
 
 // Index of module implementations.
 var Index = map[string]interface{}{
-	"k6":         &k6.K6{},
-	"k6/crypto":  &crypto.Crypto{},
-	"k6/http":    &http.HTTP{},
-	"k6/metrics": &metrics.Metrics{},
-	"k6/html":    &html.HTML{},
-	"k6/ws":      &ws.WS{},
+	"k6":          &k6.K6{},
+	"k6/crypto":   &crypto.Crypto{},
+	"k6/encoding": &encoding.Encoding{},
+	"k6/http":     &http.HTTP{},
+	"k6/metrics":  &metrics.Metrics{},
+	"k6/html":     &html.HTML{},
+	"k6/ws":       &ws.WS{},
 }

--- a/js/modules/k6/encoding/encoding.go
+++ b/js/modules/k6/encoding/encoding.go
@@ -1,0 +1,69 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2017 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package encoding
+
+import (
+	"context"
+	"encoding/base64"
+
+	"github.com/loadimpact/k6/js/common"
+)
+
+type Encoding struct{}
+
+func (e *Encoding) B64encode(ctx context.Context, input []byte, encoding string) string {
+	switch encoding {
+	case "rawstd":
+		return base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString(input)
+	case "std":
+		return base64.StdEncoding.EncodeToString(input)
+	case "rawurl":
+		return base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(input)
+	case "url":
+		return base64.URLEncoding.EncodeToString(input)
+	default:
+		return base64.StdEncoding.EncodeToString(input)
+	}
+}
+
+func (e *Encoding) B64decode(ctx context.Context, input string, encoding string) string {
+	var output []byte
+	var err error
+
+	switch encoding {
+	case "rawstd":
+		output, err = base64.StdEncoding.WithPadding(base64.NoPadding).DecodeString(input)
+	case "std":
+		output, err = base64.StdEncoding.DecodeString(input)
+	case "rawurl":
+		output, err = base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(input)
+	case "url":
+		output, err = base64.URLEncoding.DecodeString(input)
+	default:
+		output, err = base64.StdEncoding.DecodeString(input)
+	}
+
+	if err != nil {
+		common.Throw(common.GetRuntime(ctx), err)
+	}
+
+	return string(output)
+}

--- a/js/modules/k6/encoding/encoding_test.go
+++ b/js/modules/k6/encoding/encoding_test.go
@@ -1,0 +1,153 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2017 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package encoding
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dop251/goja"
+	"github.com/loadimpact/k6/js/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncodingAlgorithms(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	rt := goja.New()
+	rt.SetFieldNameMapper(common.FieldNameMapper{})
+	ctx := context.Background()
+	ctx = common.WithRuntime(ctx, rt)
+	rt.Set("encoding", common.Bind(rt, &Encoding{}, &ctx))
+
+	t.Run("Base64", func(t *testing.T) {
+		t.Run("DefaultEnc", func(t *testing.T) {
+			_, err := common.RunString(rt, `
+			const correct = "aGVsbG8gd29ybGQ=";
+			let encoded = encoding.b64encode("hello world");
+			if (encoded !== correct) {
+				throw new Error("Encoding mismatch: " + encoded);
+			}`)
+			assert.NoError(t, err)
+		})
+		t.Run("DefaultDec", func(t *testing.T) {
+			_, err := common.RunString(rt, `
+			const correct = "hello world";
+			let decoded = encoding.b64decode("aGVsbG8gd29ybGQ=");
+			if (decoded !== correct) {
+				throw new Error("Decoding mismatch: " + decoded);
+			}`)
+			assert.NoError(t, err)
+		})
+		t.Run("DefaultUnicodeEnc", func(t *testing.T) {
+			_, err := common.RunString(rt, `
+			const correct = "44GT44KT44Gr44Gh44Gv5LiW55WM";
+			let encoded = encoding.b64encode("こんにちは世界", "std");
+			if (encoded !== correct) {
+				throw new Error("Encoding mismatch: " + encoded);
+			}`)
+			assert.NoError(t, err)
+		})
+		t.Run("DefaultUnicodeDec", func(t *testing.T) {
+			_, err := common.RunString(rt, `
+			const correct = "こんにちは世界";
+			let decoded = encoding.b64decode("44GT44KT44Gr44Gh44Gv5LiW55WM");
+			if (decoded !== correct) {
+				throw new Error("Decoding mismatch: " + decoded);
+			}`)
+			assert.NoError(t, err)
+		})
+		t.Run("StdEnc", func(t *testing.T) {
+			_, err := common.RunString(rt, `
+			const correct = "aGVsbG8gd29ybGQ=";
+			let encoded = encoding.b64encode("hello world", "std");
+			if (encoded !== correct) {
+				throw new Error("Encoding mismatch: " + encoded);
+			}`)
+			assert.NoError(t, err)
+		})
+		t.Run("StdDec", func(t *testing.T) {
+			_, err := common.RunString(rt, `
+			const correct = "hello world";
+			let decoded = encoding.b64decode("aGVsbG8gd29ybGQ=", "std");
+			if (decoded !== correct) {
+				throw new Error("Decoding mismatch: " + decoded);
+			}`)
+			assert.NoError(t, err)
+		})
+		t.Run("RawStdEnc", func(t *testing.T) {
+			_, err := common.RunString(rt, `
+			const correct = "aGVsbG8gd29ybGQ";
+			let encoded = encoding.b64encode("hello world", "rawstd");
+			if (encoded !== correct) {
+				throw new Error("Encoding mismatch: " + encoded);
+			}`)
+			assert.NoError(t, err)
+		})
+		t.Run("RawStdDec", func(t *testing.T) {
+			_, err := common.RunString(rt, `
+			const correct = "hello world";
+			let decoded = encoding.b64decode("aGVsbG8gd29ybGQ", "rawstd");
+			if (decoded !== correct) {
+				throw new Error("Decoding mismatch: " + decoded);
+			}`)
+			assert.NoError(t, err)
+		})
+		t.Run("URLEnc", func(t *testing.T) {
+			_, err := common.RunString(rt, `
+			const correct = "5bCP6aO85by-Li4=";
+			let encoded = encoding.b64encode("小飼弾..", "url");
+			if (encoded !== correct) {
+				throw new Error("Encoding mismatch: " + encoded);
+			}`)
+			assert.NoError(t, err)
+		})
+		t.Run("URLDec", func(t *testing.T) {
+			_, err := common.RunString(rt, `
+			const correct = "小飼弾..";
+			let decoded = encoding.b64decode("5bCP6aO85by-Li4=", "url");
+			if (decoded !== correct) {
+				throw new Error("Decoding mismatch: " + decoded);
+			}`)
+			assert.NoError(t, err)
+		})
+		t.Run("RawURLEnc", func(t *testing.T) {
+			_, err := common.RunString(rt, `
+			const correct = "5bCP6aO85by-Li4";
+			let encoded = encoding.b64encode("小飼弾..", "rawurl");
+			if (encoded !== correct) {
+				throw new Error("Encoding mismatch: " + encoded);
+			}`)
+			assert.NoError(t, err)
+		})
+		t.Run("RawURLDec", func(t *testing.T) {
+			_, err := common.RunString(rt, `
+			const correct = "小飼弾..";
+			let decoded = encoding.b64decode("5bCP6aO85by-Li4", "rawurl");
+			if (decoded !== correct) {
+				throw new Error("Decoding mismatch: " + decoded);
+			}`)
+			assert.NoError(t, err)
+		})
+	})
+}

--- a/samples/base64.js
+++ b/samples/base64.js
@@ -1,0 +1,36 @@
+import { check } from "k6";
+import encoding from "k6/encoding";
+
+export default function() {
+    // Standard base64 encoding/decoding with '=' padding
+    let str = "hello world";
+    let enc = "aGVsbG8gd29ybGQ=";
+    check(null, {
+        "is std encoding correct": () => encoding.b64encode(str) === enc,
+        "is std decoding correct": () => encoding.b64decode(enc) === str
+    });
+
+    // Standard base64 encoding/decoding without '=' padding
+    str = "hello world";
+    enc = "aGVsbG8gd29ybGQ";
+    check(null, {
+        "is rawstd encoding correct": () => encoding.b64encode(str, 'rawstd') === enc,
+        "is rawstd decoding correct": () => encoding.b64decode(enc, 'rawstd') === str
+    });
+
+    // URL-safe base64 encoding/decoding with '=' padding
+    str = "小飼弾..";
+    enc = "5bCP6aO85by-Li4=";
+    check(null, {
+        "is url encoding correct": () => encoding.b64encode(str, 'url') === enc,
+        "is url decoding correct": () => encoding.b64decode(enc, 'url') === str
+    });
+
+    // URL-safe base64 encoding/decoding without '=' padding
+    str = "小飼弾..";
+    enc = "5bCP6aO85by-Li4";
+    check(null, {
+        "is rawurl encoding correct": () => encoding.b64encode(str, 'rawurl') === enc,
+        "is rawurl decoding correct": () => encoding.b64decode(enc, 'rawurl') === str
+    });
+};

--- a/samples/http_basic_auth.js
+++ b/samples/http_basic_auth.js
@@ -1,9 +1,20 @@
+import encoding from "k6/encoding";
 import http from "k6/http";
 import { check } from "k6";
 
 export default function() {
     // Passing username and password as part of URL will authenticate using HTTP Basic Auth
     let res = http.get("http://user:passwd@httpbin.org/basic-auth/user/passwd");
+
+    // Verify response
+    check(res, {
+        "status is 200": (r) => r.status === 200,
+        "is authenticated": (r) => r.json().authenticated === true,
+        "is correct user": (r) => r.json().user === "user"
+    });
+
+    // Alternatively you can create the header yourself to authenticate using HTTP Basic Auth
+    res = http.get("http://httpbin.org/basic-auth/user/passwd", { headers: { "Authorization": "Basic " + encoding.b64encode("user:passwd") }});
 
     // Verify response
     check(res, {


### PR DESCRIPTION
PR to add base64 encoding/decoding capabilities to k6 JS API. See included sample for full usage, simple sample:

```js
import { check } from "k6";
import encoding from "k6/encoding";

export default function() {
    let str = "hello world";
    let enc = "aGVsbG8gd29ybGQ=";
    check(null, {
        "is encoding correct": () => encoding.b64encode(str) === enc,
        "is decoding correct": () => encoding.b64decode(enc) === str
    });
}
```

HTTP Basic Auth example:
```js
import encoding from "k6/encoding";
import http from "k6/http";
import { check } from "k6";

export default function() {
    let res = http.get("http://httpbin.org/basic-auth/user/passwd", { headers: { "Authorization": "Basic " + encoding.b64encode("user:passwd") }});

    // Verify response
    check(res, {
        "status is 200": (r) => r.status === 200,
        "is authenticated": (r) => r.json().authenticated === true,
        "is correct user": (r) => r.json().user === "user"
    });
}
```