### PR TITLE
Add support for base64 URL and raw-URL output encoding to hashers

### DIFF
--- a/js/modules/k6/crypto/crypto.go
+++ b/js/modules/k6/crypto/crypto.go
@@ -142,6 +142,12 @@ func (hasher *Hasher) Digest(outputEncoding string) string {
 	case "base64":
 		return base64.StdEncoding.EncodeToString(sum)
 
+	case "base64url":
+		return base64.URLEncoding.EncodeToString(sum)
+
+	case "base64rawurl":
+		return base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(sum)
+
 	case "hex":
 		return hex.EncodeToString(sum)
 

--- a/js/modules/k6/crypto/crypto_test.go
+++ b/js/modules/k6/crypto/crypto_test.go
@@ -226,6 +226,8 @@ func TestOutputEncoding(t *testing.T) {
 		_, err := common.RunString(rt, `
 		const correctHex = "5eb63bbbe01eeed093cb22bb8f5acdc3";
 		const correctBase64 = "XrY7u+Ae7tCTyyK7j1rNww==";
+		const correctBase64URL = "XrY7u-Ae7tCTyyK7j1rNww=="
+		const correctBase64RawURL = "XrY7u-Ae7tCTyyK7j1rNww";
 
 		let hasher = crypto.createHash("md5");
 		hasher.update("hello world");
@@ -238,7 +240,18 @@ func TestOutputEncoding(t *testing.T) {
 		const resultBase64 = hasher.digest("base64");
 		if (resultBase64 !== correctBase64) {
 			throw new Error("Base64 encoding mismatch: " + resultBase64);
-		}`)
+		}
+
+		const resultBase64URL = hasher.digest("base64url");
+		if (resultBase64URL !== correctBase64URL) {
+			throw new Error("Base64 URL encoding mismatch: " + resultBase64URL);
+		}
+
+		const resultBase64RawURL = hasher.digest("base64rawurl");
+		if (resultBase64RawURL !== correctBase64RawURL) {
+			throw new Error("Base64 raw URL encoding mismatch: " + resultBase64RawURL);
+		}
+		`)
 
 		assert.NoError(t, err)
 	})


### PR DESCRIPTION
Adds two base64 variants as possible output encodings of k6/crypto `hasher.digest(...)`. Use cases includes JSON Web Token (JWT), see: https://gist.github.com/robingustafsson/7dd6463d85efdddbb0e4bcd3ecc706e1