### PR TITLE
Support K6CLOUD_TOKEN with deprecation message

### DIFF
--- a/stats/cloud/collector.go
+++ b/stats/cloud/collector.go
@@ -78,6 +78,11 @@ func New(conf Config, src *lib.SourceData, opts lib.Options, version string) (*C
 		duration = int64(time.Duration(opts.Duration.Duration).Seconds())
 	}
 
+	if conf.Token == "" && conf.DeprecatedToken != "" {
+		log.Warn("K6CLOUD_TOKEN is deprecated and will be removed. Use K6_CLOUD_TOKEN instead.")
+		conf.Token = conf.DeprecatedToken
+	}
+
 	return &Collector{
 		config:     conf,
 		thresholds: thresholds,

--- a/stats/cloud/config.go
+++ b/stats/cloud/config.go
@@ -25,10 +25,11 @@ import (
 )
 
 type ConfigFields struct {
-	Token     string `json:"token" mapstructure:"token" envconfig:"CLOUD_TOKEN"`
-	Name      string `json:"name" mapstructure:"name" envconfig:"CLOUD_NAME"`
-	Host      string `json:"host" mapstructure:"host" envconfig:"CLOUD_HOST"`
-	ProjectID int    `json:"project_id" mapstructure:"project_id" envconfig:"CLOUD_PROJECT_ID"`
+	Token           string `json:"token" mapstructure:"token" envconfig:"CLOUD_TOKEN"`
+	Name            string `json:"name" mapstructure:"name" envconfig:"CLOUD_NAME"`
+	Host            string `json:"host" mapstructure:"host" envconfig:"CLOUD_HOST"`
+	ProjectID       int    `json:"project_id" mapstructure:"project_id" envconfig:"CLOUD_PROJECT_ID"`
+	DeprecatedToken string `envconfig:"K6CLOUD_TOKEN"`
 }
 
 type Config ConfigFields


### PR DESCRIPTION
Continue support for K6CLOUD_TOKEN and add a deprecation message

> K6CLOUD_TOKEN will be deprecated soon. Use K6_CLOUD_TOKEN instead.

closes #349