### PR TITLE
Avoid checkRedirect if there is no response

### DIFF
--- a/js/modules/k6/http/http.go
+++ b/js/modules/k6/http/http.go
@@ -304,6 +304,11 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 		Transport: state.HTTPTransport,
 		Timeout:   timeout,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			// Avoid checkRedirect if there is no response
+			if via[len(via)-1].Response == nil {
+				return nil
+			}
+
 			// Update active jar with cookies found in "Set-Cookie" header(s) of redirect response
 			if activeJar != nil {
 				if respCookies := req.Response.Cookies(); len(respCookies) > 0 {


### PR DESCRIPTION
closes #368
closes #369 

Configuring maxRedirect option with a high value can mask this bug. If there is no response (failed request like request cancelled by timeout, etc) k6 will break checking redirect of a nil response. This patch avoid this behaviour.