### PR TITLE
Update docker-compose with the new k6 version call

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,4 +24,4 @@ services:
       - "6565:6565"
     environment:
       - K6_OUT=influxdb=http://influxdb:8086/k6
-    command: '--version'
+    command: 'version'


### PR DESCRIPTION
With the new CLI we can obtain the version with `k6 version`.
`k6 --version` doesn't work