### PR TITLE
`k6 login cloud` command

### DIFF
--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -47,8 +47,6 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 
                 switch {
                 case show.Bool:
-                        printToken(conf)
-                        return nil
                 case token != "":
                         conf.Token = token
                 default:

--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -7,17 +7,18 @@ import (
 	"github.com/loadimpact/k6/stats/cloud"
 	"github.com/loadimpact/k6/ui"
 	"github.com/pkg/errors"
-        "github.com/spf13/cobra"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
 )
 
 // loginCloudCommand represents the 'login cloud' command
 var loginCloudCommand = &cobra.Command{
-        Use:   "cloud",
+	Use:   "cloud",
 	Short: "Authenticate with Load Impact",
-        Long: `Authenticate with Load Impact.
+	Long: `Authenticate with Load Impact.
 
 This will set the default token used when just "k6 run -o cloud" is passed.`,
-        Example: `
+	Example: `
   # Show the stored token.
   k6 login cloud -s
 
@@ -26,63 +27,64 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 
   # Log in with an email/password.
   k6 login cloud`[1:],
-        Args: cobra.NoArgs,
-        RunE: func(cmd *cobra.Command, args []string) error {
-                config, cdir, err := readDiskConfig()
-                if err != nil {
-                        return err
-                }
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fs := afero.NewOsFs()
+		config, cdir, err := readDiskConfig(fs)
+		if err != nil {
+			return err
+		}
 
-                show := getNullBool(cmd.Flags(), "show")
-                token := getNullString(cmd.Flags(), "token")
+		show := getNullBool(cmd.Flags(), "show")
+		token := getNullString(cmd.Flags(), "token")
 
-                conf := config.Collectors.Cloud
+		conf := config.Collectors.Cloud
 
-                switch {
-                case show.Bool:
-                case token.Valid:
-                        conf.Token = token.String
-                default:
-                        form := ui.Form{
-                                Fields: []ui.Field{
-                                        ui.StringField{
-                                                Key:   "Email",
-                                                Label: "Email",
+		switch {
+		case show.Bool:
+		case token.Valid:
+			conf.Token = token.String
+		default:
+			form := ui.Form{
+				Fields: []ui.Field{
+					ui.StringField{
+						Key:   "Email",
+						Label: "Email",
 					},
-                                        ui.StringField{
-                                                Key:   "Password",
-                                                Label: "Password",
-                                        },
-                                },
-                        }
-                        vals, err := form.Run(os.Stdin, stdout)
-                        if err != nil {
-                                return err
-                        }
-                        email := vals["Email"].(string)
-                        password := vals["Password"].(string)
+					ui.StringField{
+						Key:   "Password",
+						Label: "Password",
+					},
+				},
+			}
+			vals, err := form.Run(os.Stdin, stdout)
+			if err != nil {
+				return err
+			}
+			email := vals["Email"].(string)
+			password := vals["Password"].(string)
 
-                        client := cloud.NewClient("", conf.Host, Version)
-                        res, err := client.Login(email, password)
-                        if err != nil {
-                                return err
-                        }
+			client := cloud.NewClient("", conf.Host, Version)
+			res, err := client.Login(email, password)
+			if err != nil {
+				return err
+			}
 
-                        if res.Token == "" {
-                                return errors.New(`Your account has no API token, please generate one: "https://app.loadimpact.com/account/token".`)
-                        }
+			if res.Token == "" {
+				return errors.New(`Your account has no API token, please generate one: "https://app.loadimpact.com/account/token".`)
+			}
 
-                        conf.Token = res.Token
-                }
+			conf.Token = res.Token
+		}
 
-                config.Collectors.Cloud = conf
-                if err := writeDiskConfig(cdir, config); err != nil {
-                        return err
-                }
+		config.Collectors.Cloud = conf
+		if err := writeDiskConfig(fs, cdir, config); err != nil {
+			return err
+		}
 
-                fmt.Fprintf(stdout, "  token: %s\n", ui.ValueColor.Sprint(conf.Token))
-                return nil
-        },
+		fmt.Fprintf(stdout, "  token: %s\n", ui.ValueColor.Sprint(conf.Token))
+		return nil
+	},
 }
 
 func init() {

--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -33,25 +33,16 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
                         return err
                 }
 
-                flags := cmd.Flags()
-                show := getNullBool(flags, "show")
-                token, err := flags.GetString("token")
-                if err != nil {
-                        return err
-                }
+                show := getNullBool(cmd.Flags(), "show")
+                token := getNullString(cmd.Flags(), "token")
 
-                printToken := func(conf cloud.Config) {
-                        fmt.Fprintf(stdout, "  token: %s\n", ui.ValueColor.Sprint(conf.Token))
-                }
                 conf := config.Collectors.Cloud
 
                 switch {
                 case show.Bool:
-                case token != "":
-                        conf.Token = token
+                case token.Valid:
+                        conf.Token = token.String
                 default:
-                        printToken(conf)
-
                         form := ui.Form{
                                 Fields: []ui.Field{
                                         ui.StringField{
@@ -77,11 +68,11 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
                                 return err
                         }
 
-                        if res.APIToken == "" {
+                        if res.Token == "" {
                                 return errors.New("Your account has no API token, please generate one: \"https://app.loadimpact.com/account/token\".")
                         }
 
-                        conf.Token = res.APIToken
+                        conf.Token = res.Token
                 }
 
                 config.Collectors.Cloud = conf
@@ -89,9 +80,9 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
                         return err
                 }
 
-                printToken(conf)
-		return nil
-	},
+                fmt.Fprintf(stdout, "  token: %s\n", ui.ValueColor.Sprint(conf.Token))
+                return nil
+        },
 }
 
 func init() {

--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -1,13 +1,27 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
+	"github.com/fatih/color"
+	"github.com/loadimpact/k6/stats/cloud"
 	"github.com/loadimpact/k6/ui"
-	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
+
+var (
+	token string
+	show  bool
+)
+
+func printToken(conf cloud.Config) {
+	label := "Token"
+	displayLabel := " " + color.New(color.Faint, color.FgCyan).Sprint("["+label+"]")
+	fmt.Fprintf(stdout, " "+displayLabel+": "+conf.Token+"\n")
+}
 
 // loginCloudCommand represents the 'login cloud' command
 var loginCloudCommand = &cobra.Command{
@@ -15,7 +29,18 @@ var loginCloudCommand = &cobra.Command{
 	Short: "Authenticate with Load Impact",
 	Long: `Authenticate with Load Impact.
 
-This will set the default server used when just "-o cloud" is passed.`,
+This will set the default Token used when just "k6 run -o cloud" is passed.`,
+
+	Example: `
+  # Show the stored token.
+  k6 login cloud -s
+
+  # Set up the token.
+  k6 login cloud -t YOUR_TOKEN
+
+  # Ask for your Load Impact user email and password to automatically set up the token.
+  k6 login cloud`[1:],
+
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fs := afero.NewOsFs()
@@ -23,30 +48,66 @@ This will set the default server used when just "-o cloud" is passed.`,
 		if err != nil {
 			return err
 		}
-
 		conf := config.Collectors.Cloud
-		form := ui.Form{
-			Fields: []ui.Field{
-				ui.StringField{
-					Key:     "token",
-					Label:   "API Token",
-					Default: conf.Token,
+
+		if show {
+			printToken(conf)
+			return nil
+		}
+
+		if token != "" {
+			conf.Token = token
+		} else {
+			printToken(conf)
+
+			form := ui.Form{
+				Fields: []ui.Field{
+					ui.StringField{
+						Key:   "Email",
+						Label: "Email",
+					},
+					ui.StringField{
+						Key:   "Password",
+						Label: "Password",
+					},
 				},
-			},
-		}
-		vals, err := form.Run(os.Stdin, stdout)
-		if err != nil {
-			return err
-		}
-		if err := mapstructure.Decode(vals, &conf); err != nil {
-			return err
+			}
+
+			vals, err := form.Run(os.Stdin, stdout)
+			if err != nil {
+				return err
+			}
+
+			email := vals["Email"].(string)
+			password := vals["Password"].(string)
+			client := cloud.NewClient("", conf.Host, Version)
+			response, err := client.Login(email, password)
+			if err != nil {
+				return errors.New("Failed to login.")
+			}
+
+			if response.APIToken == "" {
+				// TODO: instead of `Login`, we must create an endpoint `GetorCreateAPIToken`:
+				//       Given an email and password, it will return your Token or create a new one.
+				return errors.New("You have to create an API Token with your Load Impact account.")
+			}
+
+			conf.Token = response.APIToken
 		}
 
 		config.Collectors.Cloud = conf
-		return writeDiskConfig(fs, cdir, config)
+		if err := writeDiskConfig(cdir, config); err != nil {
+			return err
+		}
+
+		printToken(conf)
+		return nil
+
 	},
 }
 
 func init() {
 	loginCmd.AddCommand(loginCloudCommand)
+	loginCloudCommand.Flags().StringVarP(&token, "token", "t", token, "setup the Load Impact Token")
+	loginCloudCommand.Flags().BoolVarP(&show, "show", "s", false, "show the saved Load Impact Token")
 }

--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -69,7 +69,7 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
                         }
 
                         if res.Token == "" {
-                                return errors.New("Your account has no API token, please generate one: \"https://app.loadimpact.com/account/token\".")
+                                return errors.New(`Your account has no API token, please generate one: "https://app.loadimpact.com/account/token".`)
                         }
 
                         conf.Token = res.Token

--- a/stats/cloud/api.go
+++ b/stats/cloud/api.go
@@ -56,7 +56,7 @@ type CreateTestRunResponse struct {
 }
 
 type LoginResponse struct {
-        APIToken string `json:"token"`
+	APIToken string `json:"token"`
 }
 
 func (c *Client) CreateTestRun(testRun *TestRun) (*CreateTestRunResponse, error) {
@@ -118,28 +118,26 @@ func (c *Client) TestFinished(referenceID string, thresholds ThresholdResult, ta
 }
 
 func (c *Client) Login(email string, password string) (*LoginResponse, error) {
-        url := fmt.Sprintf("%s/login", c.baseURL)
+	url := fmt.Sprintf("%s/login", c.baseURL)
 
-        data := struct {
-                Email    string `json:"email"`
-                Password string `json:"password"`
-        }{
-                email,
-                password,
-        }
+	data := struct {
+		Email    string `json:"email"`
+		Password string `json:"password"`
+	}{
+		email,
+		password,
+	}
 
-        req, err := c.NewRequest("POST", url, data)
-        if err != nil {
-                return nil, err
-        }
+	req, err := c.NewRequest("POST", url, data)
+	if err != nil {
+		return nil, err
+	}
 
-        lr := LoginResponse{}
-        err = c.Do(req, &lr)
-        if err != nil {
-                // if wrong email or password, it will throw an Error
-                // `client.Do` should handle this in a better way
-                return nil, err
-        }
+	lr := LoginResponse{}
+	err = c.Do(req, &lr)
+	if err != nil {
+		return nil, errors.New("Failed to login.")
+	}
 
-        return &lr, nil
+	return &lr, nil
 }

--- a/stats/cloud/api.go
+++ b/stats/cloud/api.go
@@ -136,7 +136,7 @@ func (c *Client) Login(email string, password string) (*LoginResponse, error) {
 	lr := LoginResponse{}
 	err = c.Do(req, &lr)
 	if err != nil {
-		return nil, errors.New("Failed to login.")
+                return nil, err
 	}
 
 	return &lr, nil

--- a/stats/cloud/api.go
+++ b/stats/cloud/api.go
@@ -56,7 +56,7 @@ type CreateTestRunResponse struct {
 }
 
 type LoginResponse struct {
-	APIToken string `json:"token"`
+        Token string `json:"token"`
 }
 
 func (c *Client) CreateTestRun(testRun *TestRun) (*CreateTestRunResponse, error) {

--- a/stats/cloud/api.go
+++ b/stats/cloud/api.go
@@ -56,7 +56,7 @@ type CreateTestRunResponse struct {
 }
 
 type LoginResponse struct {
-        Token string `json:"token"`
+	Token string `json:"token"`
 }
 
 func (c *Client) CreateTestRun(testRun *TestRun) (*CreateTestRunResponse, error) {
@@ -136,7 +136,7 @@ func (c *Client) Login(email string, password string) (*LoginResponse, error) {
 	lr := LoginResponse{}
 	err = c.Do(req, &lr)
 	if err != nil {
-                return nil, err
+		return nil, err
 	}
 
 	return &lr, nil

--- a/stats/cloud/api.go
+++ b/stats/cloud/api.go
@@ -55,6 +55,10 @@ type CreateTestRunResponse struct {
 	ReferenceID string `json:"reference_id"`
 }
 
+type LoginResponse struct {
+        APIToken string `json:"token"`
+}
+
 func (c *Client) CreateTestRun(testRun *TestRun) (*CreateTestRunResponse, error) {
 	url := fmt.Sprintf("%s/tests", c.baseURL)
 	req, err := c.NewRequest("POST", url, testRun)
@@ -111,4 +115,31 @@ func (c *Client) TestFinished(referenceID string, thresholds ThresholdResult, ta
 
 	err = c.Do(req, nil)
 	return err
+}
+
+func (c *Client) Login(email string, password string) (*LoginResponse, error) {
+        url := fmt.Sprintf("%s/login", c.baseURL)
+
+        data := struct {
+                Email    string `json:"email"`
+                Password string `json:"password"`
+        }{
+                email,
+                password,
+        }
+
+        req, err := c.NewRequest("POST", url, data)
+        if err != nil {
+                return nil, err
+        }
+
+        lr := LoginResponse{}
+        err = c.Do(req, &lr)
+        if err != nil {
+                // if wrong email or password, it will throw an Error
+                // `client.Do` should handle this in a better way
+                return nil, err
+        }
+
+        return &lr, nil
 }


### PR DESCRIPTION
Will close #367

`k6 login cloud` has three options:


-  `k6 login cloud -s`: show the stored token.
- `k6 login cloud -t YOUR_TOKEN`: set up the token.
- `k6 login cloud`:  ask for your Load Impact user email and password to automatically set up the token.



@liclac 

From a functional perspective, it looks ready.

Some possible next steps:
- hidden the password. Found this [post](https://stackoverflow.com/questions/2137357/getpasswd-functionality-in-go). Thoughts?
- replace the `login` request for a new endpoint request to avoid the error: `You have to create an API Token with your Load Impact account.` 