### PR TITLE
Include release checksums file, fix go.rice install instructions

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -7,7 +7,7 @@ eval $(go env)
 VERSION=${1:-$(git describe --tags --abbrev=0)}
 
 # Fail early if external dependencies aren't installed.
-rice --help > /dev/null || (echo "ERROR: rice is not installed, run: go get github.com/GeertJohan/go.rice"; exit 1)
+rice --help > /dev/null || (echo "ERROR: rice is not installed, run: go get github.com/GeertJohan/go.rice/rice"; exit 1)
 
 make_archive() {
 	FMT=$1
@@ -49,6 +49,22 @@ build_dist() {
 	rm -rf dist/$DIR
 }
 
+checksum() {
+	CHECKSUM_FILE=k6-${VERSION}-checksums.txt
+
+	if command -v sha256sum > /dev/null; then
+		CHECKSUM_CMD="sha256sum"
+	elif command -v shasum > /dev/null; then
+		CHECKSUM_CMD="shasum -a 256"
+	else
+		echo "ERROR: unable to find a command to compute sha-256 hash"
+		return 1
+	fi
+	
+	rm -f dist/$CHECKSUM_FILE
+	( cd dist && for x in $(ls -1); do $CHECKSUM_CMD $x >> $CHECKSUM_FILE; done )
+}
+
 echo "--- Building Release: ${VERSION}"
 
 echo "-> Building platform packages..."
@@ -59,3 +75,6 @@ build_dist win32 windows 386 zip .exe
 build_dist win64 windows amd64 zip .exe
 build_dist linux32 linux 386 tgz
 build_dist linux64 linux amd64 tgz
+
+echo "-> Generating checksum file..."
+checksum


### PR DESCRIPTION
I have included instructions to generate a k6-$VERSION-checksums.txt file.

@ppcano, about the #392 issue, the CHECKSUM var should be now:
```
CHECKSUM=${BINARY}-${VERSION}-checksums.txt
```