### PR TITLE
Fix progress bar when using the option `duration`.

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -287,7 +287,7 @@ a commandline interface for interacting with it.`,
 				atT := engine.Executor.GetTime()
 				stagesEndT := lib.SumStages(engine.Executor.GetStages())
 				endT := engine.Executor.GetEndTime()
-				if !endT.Valid || endT.Duration > stagesEndT.Duration {
+				if !endT.Valid || (stagesEndT.Valid && endT.Duration > stagesEndT.Duration) {
 					endT = stagesEndT
 				}
 				if endT.Valid {
@@ -336,7 +336,7 @@ a commandline interface for interacting with it.`,
 				} else {
 					stagesEndT := lib.SumStages(engine.Executor.GetStages())
 					endT := engine.Executor.GetEndTime()
-					if !endT.Valid || endT.Duration > stagesEndT.Duration {
+					if !endT.Valid || (stagesEndT.Valid && endT.Duration > stagesEndT.Duration) {
 						endT = stagesEndT
 					}
 					if endT.Valid {


### PR DESCRIPTION
The progress bar was not working correctly when using the `duration` option.

The bug was introduced at 330b0a678a795595de7d59b8864dcf57339be6e2