### PR TITLE
Handle deflate encoded response bodies

### DIFF
--- a/js/modules/k6/http/http_request_test.go
+++ b/js/modules/k6/http/http_request_test.go
@@ -229,6 +229,26 @@ func TestRequestAndBatch(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	})
+	t.Run("Compression", func(t *testing.T) {
+		t.Run("gzip", func(t *testing.T) {
+			_, err := common.RunString(rt, `
+				let res = http.get("http://httpbin.org/gzip");
+				if (res.json()['gzipped'] != true) {
+					throw new Error("unexpected body data: " + res.json()['gzipped'])
+				}
+			`)
+			assert.NoError(t, err)
+		})
+		t.Run("deflate", func(t *testing.T) {
+			_, err := common.RunString(rt, `
+				let res = http.get("http://httpbin.org/deflate");
+				if (res.json()['deflated'] != true) {
+					throw new Error("unexpected body data: " + res.json()['deflated'])
+				}
+			`)
+			assert.NoError(t, err)
+		})
+	})
 	t.Run("Cancelled", func(t *testing.T) {
 		hook := logtest.NewLocal(state.Logger)
 		defer hook.Reset()


### PR DESCRIPTION
The Go stdlib handles gzip compressed response bodies automatically. This PR adds automatic decompression of deflate compressed response bodies as well, as specified in [RFC 1950](https://tools.ietf.org/html/rfc1950) (so might not be compatible with some older servers that don't follow the [HTTP/1.1 spec](https://tools.ietf.org/html/rfc2616#section-3.5) and instead send raw deflate data).