### PR TITLE
Proposal: binary format

### DIFF
--- a/cmd/collectors.go
+++ b/cmd/collectors.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/stats/binary"
 	"github.com/loadimpact/k6/stats/cloud"
 	"github.com/loadimpact/k6/stats/influxdb"
 	jsonc "github.com/loadimpact/k6/stats/json"
@@ -37,6 +38,7 @@ const (
 	collectorInfluxDB = "influxdb"
 	collectorJSON     = "json"
 	collectorCloud    = "cloud"
+	collectorBinary   = "bin"
 )
 
 func parseCollector(s string) (t, arg string) {
@@ -77,6 +79,8 @@ func newCollector(t, arg string, src *lib.SourceData, conf Config) (lib.Collecto
 			return nil, err
 		}
 		return cloud.New(config, src, conf.Options, Version)
+	case collectorBinary:
+		return binary.New(afero.NewOsFs(), arg)
 	default:
 		return nil, errors.Errorf("unknown output type: %s", t)
 	}

--- a/stats/binary/collector.go
+++ b/stats/binary/collector.go
@@ -1,0 +1,118 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2016 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package binary
+
+import (
+	"bufio"
+	"context"
+	"encoding/gob"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/loadimpact/k6/stats"
+	"github.com/spf13/afero"
+)
+
+// Collection represents a binary collector that writes
+// samples to a gob binary file
+type Collector struct {
+	file    io.WriteCloser
+	writer  *bufio.Writer
+	encoder *gob.Encoder
+	recvr   chan []stats.Sample
+
+	closed bool
+	lock   sync.Mutex
+}
+
+func init() {
+	// register type passed as interface{}
+	gob.Register(stats.CounterSink{})
+	gob.Register(stats.GaugeSink{})
+	gob.Register(stats.TrendSink{})
+	gob.Register(stats.RateSink{})
+	gob.Register(stats.DummySink{})
+}
+
+// New returns a collector ready to start writing samples
+func New(fs afero.Fs, fname string) (*Collector, error) {
+	if fname == "" || fname == "-" {
+		return &Collector{
+			file:  os.Stdout,
+			recvr: make(chan []stats.Sample),
+		}, nil
+	}
+
+	logfile, err := fs.Create(fname)
+	if err != nil {
+		return nil, err
+	}
+	return &Collector{
+		file:  logfile,
+		recvr: make(chan []stats.Sample),
+	}, nil
+}
+
+// Init prepares the bufio writer and the gob encoder
+func (c *Collector) Init() error {
+	c.writer = bufio.NewWriter(c.file)
+	c.encoder = gob.NewEncoder(c.writer)
+	return nil
+}
+
+// Run writes samples received via the receiver channel and handle
+// the flush of data to file once the iterations are completed
+func (c *Collector) Run(ctx context.Context) {
+	for {
+		select {
+		case samples := <-c.recvr:
+			if err := c.encoder.Encode(samples); err != nil {
+				fmt.Println(err)
+			}
+		case <-ctx.Done():
+			// HACK: For some reasons the Done is called twice causing
+			// a panic closing the c.recvr channel twice /cc Emily
+			if c.closed {
+				return
+			}
+
+			c.lock.Lock()
+			c.closed = true
+			c.lock.Unlock()
+
+			close(c.recvr)
+			c.writer.Flush()
+		}
+	}
+}
+
+// Collect receives chunk of new sample that are sent to the
+// receiver channel for processing
+func (c *Collector) Collect(samples []stats.Sample) {
+	c.recvr <- samples
+}
+
+// Link returns nothing as this does not creates a linkable resource
+func (c *Collector) Link() string {
+	return ""
+}

--- a/stats/binary/collector_test.go
+++ b/stats/binary/collector_test.go
@@ -1,0 +1,52 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2016 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package binary
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	testdata := map[string]bool{
+		"/nonexistent/badplacetolog.k6": false,
+		"./okplacetolog.k6":             true,
+		"okplacetolog.k6":               true,
+	}
+
+	for path, succ := range testdata {
+		t.Run("path="+path, func(t *testing.T) {
+			defer func() { _ = os.Remove(path) }()
+
+			collector, err := New(afero.NewOsFs(), path)
+			if succ {
+				assert.NoError(t, err)
+				assert.NotNil(t, collector)
+			} else {
+				assert.Error(t, err)
+				assert.Nil(t, collector)
+			}
+		})
+	}
+}

--- a/stats/thresholds.go
+++ b/stats/thresholds.go
@@ -83,7 +83,7 @@ func (t *Threshold) Run() (bool, error) {
 }
 
 type Thresholds struct {
-	Runtime    *goja.Runtime
+	runtime    *goja.Runtime
 	Thresholds []*Threshold
 }
 
@@ -105,11 +105,11 @@ func NewThresholds(sources []string) (Thresholds, error) {
 }
 
 func (ts *Thresholds) UpdateVM(sink Sink, t time.Duration) error {
-	ts.Runtime.Set("__sink__", sink)
+	ts.runtime.Set("__sink__", sink)
 	f := sink.Format(t)
 	fmt.Println(f)
 	for k, v := range f {
-		ts.Runtime.Set(k, v)
+		ts.runtime.Set(k, v)
 	}
 	return nil
 }

--- a/stats/thresholds_test.go
+++ b/stats/thresholds_test.go
@@ -95,7 +95,7 @@ func TestNewThresholds(t *testing.T) {
 			assert.Equal(t, sources[i], th.Source)
 			assert.False(t, th.Failed)
 			assert.NotNil(t, th.pgm)
-			assert.Equal(t, ts.Runtime, th.rt)
+			assert.Equal(t, ts.runtime, th.rt)
 		}
 	})
 }
@@ -104,7 +104,7 @@ func TestThresholdsUpdateVM(t *testing.T) {
 	ts, err := NewThresholds(nil)
 	assert.NoError(t, err)
 	assert.NoError(t, ts.UpdateVM(DummySink{"a": 1234.5}, 0))
-	assert.Equal(t, 1234.5, ts.Runtime.Get("a").ToFloat())
+	assert.Equal(t, 1234.5, ts.runtime.Get("a").ToFloat())
 }
 
 func TestThresholdsRunAll(t *testing.T) {


### PR DESCRIPTION
This address the needs to export samples to a binary format discussed in #321.

I suggest using `gob` with `bufio` to output a `k6` binary file:

```sh
k6 run -o bin:results.k6 script.js
``` 

From there k6 could offer a `convert` option to export this binary data to JSON, CSV, XML etc.

This should close #321 - depending if the `convert` option is required / desired, I could investigate this as well.

Note to @liclac 

The `ctx.Done()` in the `Run` function of the collector is called twice. I had issue closing a closed channel (the `recvr` channel) - so I noticed the `Done` channel was called two times, is that normal?
