### PR TITLE
Handle gzip encoded response bodies

### DIFF
--- a/js/modules/k6/http/http_request.go
+++ b/js/modules/k6/http/http_request.go
@@ -22,6 +22,7 @@ package http
 
 import (
 	"bytes"
+	"compress/gzip"
 	"compress/zlib"
 	"context"
 	"io"
@@ -264,6 +265,9 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 	if resErr == nil && res != nil {
 		if res.Header.Get("Content-Encoding") == "deflate" {
 			res.Body, resErr = zlib.NewReader(res.Body)
+		}
+		if res.Header.Get("Content-Encoding") == "gzip" {
+			res.Body, resErr = gzip.NewReader(res.Body)
 		}
 	}
 	if resErr == nil && res != nil {

--- a/js/modules/k6/http/http_request.go
+++ b/js/modules/k6/http/http_request.go
@@ -263,10 +263,10 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 	tracer := netext.Tracer{}
 	res, resErr := client.Do(req.WithContext(netext.WithTracer(ctx, &tracer)))
 	if resErr == nil && res != nil {
-		if res.Header.Get("Content-Encoding") == "deflate" {
+		switch res.Header.Get("Content-Encoding") {
+		case "deflate":
 			res.Body, resErr = zlib.NewReader(res.Body)
-		}
-		if res.Header.Get("Content-Encoding") == "gzip" {
+		case "gzip":
 			res.Body, resErr = gzip.NewReader(res.Body)
 		}
 	}

--- a/js/modules/k6/http/http_request_test.go
+++ b/js/modules/k6/http/http_request_test.go
@@ -249,6 +249,28 @@ func TestRequestAndBatch(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	})
+	t.Run("CompressionWithAcceptEncodingHeader", func(t *testing.T) {
+		t.Run("gzip", func(t *testing.T) {
+			_, err := common.RunString(rt, `
+				let params = { headers: { "Accept-Encoding": "gzip" } };
+				let res = http.get("http://httpbin.org/gzip", params);
+				if (res.json()['gzipped'] != true) {
+					throw new Error("unexpected body data: " + res.json()['gzipped'])
+				}
+			`)
+			assert.NoError(t, err)
+		})
+		t.Run("deflate", func(t *testing.T) {
+			_, err := common.RunString(rt, `
+				let params = { headers: { "Accept-Encoding": "deflate" } };
+				let res = http.get("http://httpbin.org/deflate", params);
+				if (res.json()['deflated'] != true) {
+					throw new Error("unexpected body data: " + res.json()['deflated'])
+				}
+			`)
+			assert.NoError(t, err)
+		})
+	})
 	t.Run("Cancelled", func(t *testing.T) {
 		hook := logtest.NewLocal(state.Logger)
 		defer hook.Reset()

--- a/js/runner.go
+++ b/js/runner.go
@@ -151,7 +151,8 @@ func (r *Runner) newVU() (*VU, error) {
 			NameToCertificate:  nameToCert,
 			Renegotiation:      tls.RenegotiateFreelyAsClient,
 		},
-		DialContext: dialer.DialContext,
+		DialContext:        dialer.DialContext,
+		DisableCompression: true,
 	}
 	_ = http2.ConfigureTransport(transport)
 


### PR DESCRIPTION
If PR #419 works for zlib encoded response with a "deflate" HTTP "Content-Encoding" header, I see anything about the "gzip" encoding ([www.gzip.org/zlib/zlib_faq.html#faq38](www.gzip.org/zlib/zlib_faq.html#faq38)).

My Apache HTTP Server 2.4 only deliver gzip content and when I use k6 (without this fix) to test some URLs, I've got binary data instead of JSON content.