### PR TITLE
Fix cloud test `name`

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	"github.com/loadimpact/k6/stats/cloud"
 	"github.com/loadimpact/k6/ui"
+	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -108,7 +109,16 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 			return err
 		}
 
-		name := filepath.Base(filename)
+		if val, ok := arc.Options.External["loadimpact"]; ok {
+			if err := mapstructure.Decode(val, &cloudConfig); err != nil {
+				return err
+			}
+		}
+		name := cloudConfig.Name
+		if name == "" {
+			name = filepath.Base(filename)
+		}
+
 		refID, err := client.StartCloudTestRun(name, arc)
 		if err != nil {
 			return err


### PR DESCRIPTION
The fix allows sending the cloud test name when running `k6 cloud script.js`


```
export let options = {
  vus: 50,
  duration: "60s",
  ext: {
    loadimpact: {
      name: "my new test name",
      distribution: {
        one: {
          loadZone: "amazon:us:ashburn",
          percent: 100
        }
      }
    }
  }
};

```

cc @robingustafsson 