### PR TITLE
Expose HTTP request information in response

### DIFF
--- a/js/modules/k6/http/http_request.go
+++ b/js/modules/k6/http/http_request.go
@@ -46,7 +46,7 @@ import (
 
 type HTTPRequest struct {
 	Method  string
-	URL     *neturl.URL
+	URL     string
 	Headers map[string][]string
 	Body    io.Closer
 	Cookies map[string]*HTTPRequestCookie
@@ -123,7 +123,7 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 	}
 	HTTPReq := &HTTPRequest{
 		Method: req.Method,
-		URL:    req.URL,
+		URL:    req.URL.String(),
 	}
 	if bodyBuf != nil {
 		req.Body = ioutil.NopCloser(bodyBuf)

--- a/js/modules/k6/http/http_request.go
+++ b/js/modules/k6/http/http_request.go
@@ -47,7 +47,7 @@ import (
 type HTTPRequest struct {
 	Method  string
 	URL     *neturl.URL
-	Headers http.Header
+	Headers map[string][]string
 	Body    io.Closer
 	Cookies map[string]*HTTPRequestCookie
 }

--- a/js/modules/k6/http/http_request.go
+++ b/js/modules/k6/http/http_request.go
@@ -50,7 +50,7 @@ type HTTPRequest struct {
 	URL     string
 	Headers map[string][]string
 	Body    io.Closer
-	Cookies []*http.Cookie
+	Cookies map[string][]*HTTPRequestCookie
 }
 
 func (http *HTTP) Get(ctx context.Context, url goja.Value, args ...goja.Value) (*HTTPResponse, error) {
@@ -245,7 +245,9 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 	}
 
 	if activeJar != nil {
-		h.setRequestCookies(req, activeJar, reqCookies)
+		mergedCookies := h.mergeCookies(req, activeJar, reqCookies)
+		respReq.Cookies = mergedCookies
+		h.setRequestCookies(req, mergedCookies)
 	}
 
 	// Check rate limit *after* we've prepared a request; no need to wait with that part.
@@ -256,7 +258,6 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 	}
 
 	respReq.Headers = req.Header
-	respReq.Cookies = req.Cookies()
 
 	resp := &HTTPResponse{ctx: ctx, URL: url.URLString, Request: *respReq}
 	client := http.Client{
@@ -269,7 +270,9 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 					activeJar.SetCookies(req.URL, respCookies)
 				}
 				req.Header.Del("Cookie")
-				h.setRequestCookies(req, activeJar, reqCookies)
+				mergedCookies := h.mergeCookies(req, activeJar, reqCookies)
+
+				h.setRequestCookies(req, mergedCookies)
 			}
 
 			if l := len(via); int64(l) > redirects.Int64 {

--- a/js/modules/k6/http/http_request.go
+++ b/js/modules/k6/http/http_request.go
@@ -25,6 +25,7 @@ import (
 	"compress/gzip"
 	"compress/zlib"
 	"context"
+	// "fmt"
 	"io"
 	"io/ioutil"
 	"net"
@@ -49,7 +50,7 @@ type HTTPRequest struct {
 	URL     string
 	Headers map[string][]string
 	Body    io.Closer
-	Cookies map[string]*HTTPRequestCookie
+	Cookies []*http.Cookie
 }
 
 func (http *HTTP) Get(ctx context.Context, url goja.Value, args ...goja.Value) (*HTTPResponse, error) {
@@ -255,7 +256,7 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 	}
 
 	respReq.Headers = req.Header
-	respReq.Cookies = reqCookies
+	respReq.Cookies = req.Cookies()
 
 	resp := &HTTPResponse{ctx: ctx, URL: url.URLString, Request: *respReq}
 	client := http.Client{

--- a/js/modules/k6/http/http_request.go
+++ b/js/modules/k6/http/http_request.go
@@ -121,14 +121,14 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 		URL:    url.URL,
 		Header: make(http.Header),
 	}
-	HTTPReq := &HTTPRequest{
+	respReq := &HTTPRequest{
 		Method: req.Method,
 		URL:    req.URL.String(),
 	}
 	if bodyBuf != nil {
 		req.Body = ioutil.NopCloser(bodyBuf)
 		req.ContentLength = int64(bodyBuf.Len())
-		HTTPReq.Body = req.Body
+		respReq.Body = req.Body
 	}
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
@@ -254,10 +254,10 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 		}
 	}
 
-	HTTPReq.Headers = req.Header
-	HTTPReq.Cookies = reqCookies
+	respReq.Headers = req.Header
+	respReq.Cookies = reqCookies
 
-	resp := &HTTPResponse{ctx: ctx, URL: url.URLString, Request: *HTTPReq}
+	resp := &HTTPResponse{ctx: ctx, URL: url.URLString, Request: *respReq}
 	client := http.Client{
 		Transport: state.HTTPTransport,
 		Timeout:   timeout,

--- a/js/modules/k6/http/http_request.go
+++ b/js/modules/k6/http/http_request.go
@@ -25,7 +25,6 @@ import (
 	"compress/gzip"
 	"compress/zlib"
 	"context"
-	// "fmt"
 	"io"
 	"io/ioutil"
 	"net"
@@ -49,7 +48,7 @@ type HTTPRequest struct {
 	Method  string
 	URL     string
 	Headers map[string][]string
-	Body    io.Closer
+	Body    string
 	Cookies map[string][]*HTTPRequestCookie
 }
 
@@ -129,7 +128,7 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 	if bodyBuf != nil {
 		req.Body = ioutil.NopCloser(bodyBuf)
 		req.ContentLength = int64(bodyBuf.Len())
-		respReq.Body = req.Body
+		respReq.Body = bodyBuf.String()
 	}
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)

--- a/js/modules/k6/http/http_request_test.go
+++ b/js/modules/k6/http/http_request_test.go
@@ -865,7 +865,8 @@ func TestRequestAndBatch(t *testing.T) {
 
 	t.Run("HTTPRequest", func(t *testing.T) {
 		_, err := common.RunString(rt, `
-			let res = http.get("https://httpbin.org/get?a=1&b=2");
+			let reqUrl = "https://httpbin.org/get?a=1&b=2"
+			let res = http.get(reqUrl);
 
 			if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 			if (res.json().args.a != "1") { throw new Error("wrong ?a: " + res.json().args.a); }
@@ -873,7 +874,7 @@ func TestRequestAndBatch(t *testing.T) {
 
 			if (res.request["method"] !== "GET") { throw new Error("http request method was not \"GET\": " + JSON.stringify(res.request)) }
 			if (res.request["body"] != null) { throw new Error("http request body was not null: " + JSON.stringify(res.request)) }
-			if (res.request["url"]["host"] != "httpbin.org" || res.request["url"]["path"] != "/get" || res.request["url"]["raw_query"] != "a=1&b=2") {
+			if (res.request["url"] != reqUrl) {
 				throw new Error("http request url was not null: " + JSON.stringify(res.request))
 			}
 			if (Object.keys(res.request["cookies"]).length != 0) { throw new Error("http request cookies was not empty: " + JSON.stringify(res.request)) }

--- a/js/modules/k6/http/http_request_test.go
+++ b/js/modules/k6/http/http_request_test.go
@@ -862,4 +862,23 @@ func TestRequestAndBatch(t *testing.T) {
 			assertRequestMetricsEmitted(t, state.Samples, "PUT", "https://httpbin.org/put", "", 200, "")
 		})
 	})
+
+	t.Run("HTTPRequest", func(t *testing.T) {
+		_, err := common.RunString(rt, `
+			let res = http.get("https://httpbin.org/get?a=1&b=2");
+
+			if (res.status != 200) { throw new Error("wrong status: " + res.status); }
+			if (res.json().args.a != "1") { throw new Error("wrong ?a: " + res.json().args.a); }
+			if (res.json().args.b != "2") { throw new Error("wrong ?b: " + res.json().args.b); }
+
+			if (res.request["method"] !== "GET") { throw new Error("http request method was not \"GET\": " + JSON.stringify(res.request)) }
+			if (res.request["body"] != null) { throw new Error("http request body was not null: " + JSON.stringify(res.request)) }
+			if (res.request["url"]["host"] != "httpbin.org" || res.request["url"]["path"] != "/get" || res.request["url"]["raw_query"] != "a=1&b=2") {
+				throw new Error("http request url was not null: " + JSON.stringify(res.request))
+			}
+			if (Object.keys(res.request["cookies"]).length != 0) { throw new Error("http request cookies was not empty: " + JSON.stringify(res.request)) }
+			if (res.request["headers"]["User-Agent"][0] != "TestUserAgent") { throw new Error("http request headers was not set properly: " + JSON.stringify(res.request)) }
+			`)
+		assert.NoError(t, err)
+	})
 }

--- a/js/modules/k6/http/http_request_test.go
+++ b/js/modules/k6/http/http_request_test.go
@@ -880,8 +880,7 @@ func TestRequestAndBatch(t *testing.T) {
 			if (res.request["url"] != reqUrl) {
 				throw new Error("wront http request url: " + JSON.stringify(res.request))
 			}
-			// TODO: this is kind of ugly, is there a way to simplify the cookies structure?
-			if (res.request["cookies"][1]["name"] != "key2") { throw new Error("wrong http request cookies: " + JSON.stringify(res.request["cookies"][1]["name"]) + " full request:  " + JSON.stringify(res.request)) }
+			if (res.request["cookies"]["key2"][0].name != "key2") { throw new Error("wrong http request cookies: " + JSON.stringify(JSON.stringify(res.request["cookies"]["key2"]))) }
 			if (res.request["headers"]["User-Agent"][0] != "TestUserAgent") { throw new Error("wrong http request headers: " + JSON.stringify(res.request)) }
 			`)
 		assert.NoError(t, err)

--- a/js/modules/k6/http/response.go
+++ b/js/modules/k6/http/response.go
@@ -63,6 +63,8 @@ type HTTPResponse struct {
 	OCSP           OCSP `js:"ocsp"`
 	Error          string
 
+	Request HTTPRequest
+
 	cachedJSON goja.Value
 }
 

--- a/js/modules/k6/http/response.go
+++ b/js/modules/k6/http/response.go
@@ -62,8 +62,7 @@ type HTTPResponse struct {
 	TLSCipherSuite string
 	OCSP           OCSP `js:"ocsp"`
 	Error          string
-
-	Request HTTPRequest
+	Request        HTTPRequest
 
 	cachedJSON goja.Value
 }


### PR DESCRIPTION
Fixes #440 

Adds HTTPRequest struct, includes the request as a field in the response, and finally a test for whether or not the request information is properly populated in a response.

cc: @robingustafsson @marklagendijk 