### PR TITLE
Cloud: `K6_CLOUD_COMPRESS` enables gzip compression when pushing metrics

### DIFF
--- a/stats/cloud/api_test.go
+++ b/stats/cloud/api_test.go
@@ -72,7 +72,7 @@ func TestPublishMetric(t *testing.T) {
 			},
 		},
 	}
-	err := client.PushMetric("1", samples)
+	err := client.PushMetric("1", false, samples)
 
 	assert.Nil(t, err)
 }

--- a/stats/cloud/collector.go
+++ b/stats/cloud/collector.go
@@ -190,7 +190,7 @@ func (c *Collector) pushMetrics() {
 		"samples": len(buffer),
 	}).Debug("Pushing metrics to cloud")
 
-	err := c.client.PushMetric(c.referenceID, buffer)
+	err := c.client.PushMetric(c.referenceID, c.config.Compress, buffer)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"error": err,

--- a/stats/cloud/config.go
+++ b/stats/cloud/config.go
@@ -28,6 +28,7 @@ type ConfigFields struct {
 	Token           string `json:"token" mapstructure:"token" envconfig:"CLOUD_TOKEN"`
 	Name            string `json:"name" mapstructure:"name" envconfig:"CLOUD_NAME"`
 	Host            string `json:"host" mapstructure:"host" envconfig:"CLOUD_HOST"`
+	Compress        bool   `json:"compress" mapstructure:"compress" envconfig:"CLOUD_COMPRESS"`
 	ProjectID       int    `json:"project_id" mapstructure:"project_id" envconfig:"CLOUD_PROJECT_ID"`
 	DeprecatedToken string `envconfig:"K6CLOUD_TOKEN"`
 }


### PR DESCRIPTION
`K6_CLOUD_COMPRESS` enables gzip compression on metric push. 

Default false.

When compression becomes the default protocol, the setting should be changed.