### PR TITLE
Setup & Teardown

### DIFF
--- a/api/v1/group_routes_test.go
+++ b/api/v1/group_routes_test.go
@@ -41,7 +41,7 @@ func TestGetGroups(t *testing.T) {
 	g2, err := g1.Group("group 2")
 	assert.NoError(t, err)
 
-	engine, err := core.NewEngine(local.New(lib.MiniRunner{Group: g0}), lib.Options{})
+	engine, err := core.NewEngine(local.New(&lib.MiniRunner{Group: g0}), lib.Options{})
 	assert.NoError(t, err)
 
 	t.Run("list", func(t *testing.T) {

--- a/api/v1/group_routes_test.go
+++ b/api/v1/group_routes_test.go
@@ -33,20 +33,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type groupDummyRunner struct {
-	Group *lib.Group
-}
-
-func (r groupDummyRunner) MakeArchive() *lib.Archive { return nil }
-
-func (r groupDummyRunner) NewVU() (lib.VU, error) { return nil, nil }
-
-func (r groupDummyRunner) GetDefaultGroup() *lib.Group { return r.Group }
-
-func (r groupDummyRunner) GetOptions() lib.Options { return lib.Options{} }
-
-func (r groupDummyRunner) SetOptions(opts lib.Options) {}
-
 func TestGetGroups(t *testing.T) {
 	g0, err := lib.NewGroup("", nil)
 	assert.NoError(t, err)
@@ -55,7 +41,7 @@ func TestGetGroups(t *testing.T) {
 	g2, err := g1.Group("group 2")
 	assert.NoError(t, err)
 
-	engine, err := core.NewEngine(local.New(groupDummyRunner{g0}), lib.Options{})
+	engine, err := core.NewEngine(local.New(lib.MiniRunner{Group: g0}), lib.Options{})
 	assert.NoError(t, err)
 
 	t.Run("list", func(t *testing.T) {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -69,7 +69,7 @@ func L(r lib.Runner) lib.Executor {
 }
 
 func LF(fn func(ctx context.Context) ([]stats.Sample, error)) lib.Executor {
-	return L(lib.MiniRunner{Fn: fn})
+	return L(&lib.MiniRunner{Fn: fn})
 }
 
 func TestNewEngine(t *testing.T) {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -69,7 +69,7 @@ func L(r lib.Runner) lib.Executor {
 }
 
 func LF(fn func(ctx context.Context) ([]stats.Sample, error)) lib.Executor {
-	return L(lib.RunnerFunc(fn))
+	return L(lib.MiniRunner{Fn: fn})
 }
 
 func TestNewEngine(t *testing.T) {

--- a/core/local/local.go
+++ b/core/local/local.go
@@ -87,6 +87,9 @@ type Executor struct {
 	runLock sync.Mutex
 	wg      sync.WaitGroup
 
+	runSetup    bool
+	runTeardown bool
+
 	vus       []*vuHandle
 	vusLock   sync.RWMutex
 	numVUs    int64
@@ -120,10 +123,12 @@ type Executor struct {
 
 func New(r lib.Runner) *Executor {
 	return &Executor{
-		Runner:   r,
-		Logger:   log.StandardLogger(),
-		endIters: -1,
-		endTime:  -1,
+		Runner:      r,
+		Logger:      log.StandardLogger(),
+		runSetup:    true,
+		runTeardown: true,
+		endIters:    -1,
+		endTime:     -1,
 	}
 }
 
@@ -131,7 +136,7 @@ func (e *Executor) Run(parent context.Context, out chan<- []stats.Sample) (reter
 	e.runLock.Lock()
 	defer e.runLock.Unlock()
 
-	if e.Runner != nil {
+	if e.Runner != nil && e.runSetup {
 		setupCtx, setupCancel := context.WithTimeout(parent, 10*time.Second)
 		if err := e.Runner.Setup(setupCtx); err != nil {
 			setupCancel()
@@ -152,7 +157,7 @@ func (e *Executor) Run(parent context.Context, out chan<- []stats.Sample) (reter
 
 	var cutoff time.Time
 	defer func() {
-		if e.Runner != nil {
+		if e.Runner != nil && e.runTeardown {
 			teardownCtx, teardownCancel := context.WithTimeout(parent, 10*time.Second)
 			reterr = e.Runner.Teardown(teardownCtx)
 			teardownCancel()
@@ -505,4 +510,12 @@ func (e *Executor) SetVUsMax(max int64) error {
 	atomic.StoreInt64(&e.numVUsMax, max)
 
 	return nil
+}
+
+func (e *Executor) SetRunSetup(r bool) {
+	e.runSetup = r
+}
+
+func (e *Executor) SetRunTeardown(r bool) {
+	e.runTeardown = r
 }

--- a/core/local/local.go
+++ b/core/local/local.go
@@ -137,6 +137,7 @@ func (e *Executor) Run(parent context.Context, out chan<- []stats.Sample) (reter
 	defer e.runLock.Unlock()
 
 	if e.Runner != nil && e.runSetup {
+		// TODO: make this timeout configurable
 		setupCtx, setupCancel := context.WithTimeout(parent, 10*time.Second)
 		if err := e.Runner.Setup(setupCtx); err != nil {
 			setupCancel()
@@ -158,6 +159,7 @@ func (e *Executor) Run(parent context.Context, out chan<- []stats.Sample) (reter
 	var cutoff time.Time
 	defer func() {
 		if e.Runner != nil && e.runTeardown {
+			// TODO: make this timeout configurable
 			teardownCtx, teardownCancel := context.WithTimeout(parent, 10*time.Second)
 			reterr = e.Runner.Teardown(teardownCtx)
 			teardownCancel()

--- a/core/local/local_test.go
+++ b/core/local/local_test.go
@@ -81,6 +81,22 @@ func TestExecutorSetupTeardownRun(t *testing.T) {
 			},
 		})
 		assert.EqualError(t, e.Run(context.Background(), nil), "setup error")
+
+		t.Run("Don't Run Setup", func(t *testing.T) {
+			e := New(lib.MiniRunner{
+				SetupFn: func(ctx context.Context) error {
+					return errors.New("setup error")
+				},
+				TeardownFn: func(ctx context.Context) error {
+					return errors.New("teardown error")
+				},
+			})
+			e.SetRunSetup(false)
+			e.SetEndIterations(null.IntFrom(1))
+			assert.NoError(t, e.SetVUsMax(1))
+			assert.NoError(t, e.SetVUs(1))
+			assert.EqualError(t, e.Run(context.Background(), nil), "teardown error")
+		})
 	})
 	t.Run("Teardown Error", func(t *testing.T) {
 		e := New(lib.MiniRunner{
@@ -95,6 +111,22 @@ func TestExecutorSetupTeardownRun(t *testing.T) {
 		assert.NoError(t, e.SetVUsMax(1))
 		assert.NoError(t, e.SetVUs(1))
 		assert.EqualError(t, e.Run(context.Background(), nil), "teardown error")
+
+		t.Run("Don't Run Teardown", func(t *testing.T) {
+			e := New(lib.MiniRunner{
+				SetupFn: func(ctx context.Context) error {
+					return nil
+				},
+				TeardownFn: func(ctx context.Context) error {
+					return errors.New("teardown error")
+				},
+			})
+			e.SetRunTeardown(false)
+			e.SetEndIterations(null.IntFrom(1))
+			assert.NoError(t, e.SetVUsMax(1))
+			assert.NoError(t, e.SetVUs(1))
+			assert.NoError(t, e.Run(context.Background(), nil))
+		})
 	})
 }
 

--- a/core/local/local_test.go
+++ b/core/local/local_test.go
@@ -52,7 +52,7 @@ func TestExecutorSetupTeardownRun(t *testing.T) {
 	t.Run("Normal", func(t *testing.T) {
 		setupC := make(chan struct{})
 		teardownC := make(chan struct{})
-		e := New(lib.MiniRunner{
+		e := New(&lib.MiniRunner{
 			SetupFn: func(ctx context.Context) error {
 				close(setupC)
 				return nil
@@ -72,7 +72,7 @@ func TestExecutorSetupTeardownRun(t *testing.T) {
 		assert.NoError(t, <-err)
 	})
 	t.Run("Setup Error", func(t *testing.T) {
-		e := New(lib.MiniRunner{
+		e := New(&lib.MiniRunner{
 			SetupFn: func(ctx context.Context) error {
 				return errors.New("setup error")
 			},
@@ -83,7 +83,7 @@ func TestExecutorSetupTeardownRun(t *testing.T) {
 		assert.EqualError(t, e.Run(context.Background(), nil), "setup error")
 
 		t.Run("Don't Run Setup", func(t *testing.T) {
-			e := New(lib.MiniRunner{
+			e := New(&lib.MiniRunner{
 				SetupFn: func(ctx context.Context) error {
 					return errors.New("setup error")
 				},
@@ -99,7 +99,7 @@ func TestExecutorSetupTeardownRun(t *testing.T) {
 		})
 	})
 	t.Run("Teardown Error", func(t *testing.T) {
-		e := New(lib.MiniRunner{
+		e := New(&lib.MiniRunner{
 			SetupFn: func(ctx context.Context) error {
 				return nil
 			},
@@ -113,7 +113,7 @@ func TestExecutorSetupTeardownRun(t *testing.T) {
 		assert.EqualError(t, e.Run(context.Background(), nil), "teardown error")
 
 		t.Run("Don't Run Teardown", func(t *testing.T) {
-			e := New(lib.MiniRunner{
+			e := New(&lib.MiniRunner{
 				SetupFn: func(ctx context.Context) error {
 					return nil
 				},
@@ -184,7 +184,7 @@ func TestExecutorEndTime(t *testing.T) {
 	assert.True(t, time.Now().After(startTime.Add(1*time.Second)), "test did not take 1s")
 
 	t.Run("Runtime Errors", func(t *testing.T) {
-		e := New(lib.MiniRunner{Fn: func(ctx context.Context) ([]stats.Sample, error) {
+		e := New(&lib.MiniRunner{Fn: func(ctx context.Context) ([]stats.Sample, error) {
 			return nil, errors.New("hi")
 		}})
 		assert.NoError(t, e.SetVUsMax(10))
@@ -206,7 +206,7 @@ func TestExecutorEndTime(t *testing.T) {
 	})
 
 	t.Run("End Errors", func(t *testing.T) {
-		e := New(lib.MiniRunner{Fn: func(ctx context.Context) ([]stats.Sample, error) {
+		e := New(&lib.MiniRunner{Fn: func(ctx context.Context) ([]stats.Sample, error) {
 			<-ctx.Done()
 			return nil, errors.New("hi")
 		}})
@@ -230,7 +230,7 @@ func TestExecutorEndIterations(t *testing.T) {
 	metric := &stats.Metric{Name: "test_metric"}
 
 	var i int64
-	e := New(lib.MiniRunner{Fn: func(ctx context.Context) ([]stats.Sample, error) {
+	e := New(&lib.MiniRunner{Fn: func(ctx context.Context) ([]stats.Sample, error) {
 		select {
 		case <-ctx.Done():
 		default:
@@ -316,7 +316,7 @@ func TestExecutorSetVUs(t *testing.T) {
 	})
 
 	t.Run("Raise", func(t *testing.T) {
-		e := New(lib.MiniRunner{Fn: func(ctx context.Context) ([]stats.Sample, error) {
+		e := New(&lib.MiniRunner{Fn: func(ctx context.Context) ([]stats.Sample, error) {
 			return nil, nil
 		}})
 		e.ctx = context.Background()

--- a/core/local/local_test.go
+++ b/core/local/local_test.go
@@ -102,9 +102,9 @@ func TestExecutorEndTime(t *testing.T) {
 	assert.True(t, time.Now().After(startTime.Add(1*time.Second)), "test did not take 1s")
 
 	t.Run("Runtime Errors", func(t *testing.T) {
-		e := New(lib.RunnerFunc(func(ctx context.Context) ([]stats.Sample, error) {
+		e := New(lib.MiniRunner{Fn: func(ctx context.Context) ([]stats.Sample, error) {
 			return nil, errors.New("hi")
-		}))
+		}})
 		assert.NoError(t, e.SetVUsMax(10))
 		assert.NoError(t, e.SetVUs(10))
 		e.SetEndTime(types.NullDurationFrom(100 * time.Millisecond))
@@ -124,10 +124,10 @@ func TestExecutorEndTime(t *testing.T) {
 	})
 
 	t.Run("End Errors", func(t *testing.T) {
-		e := New(lib.RunnerFunc(func(ctx context.Context) ([]stats.Sample, error) {
+		e := New(lib.MiniRunner{Fn: func(ctx context.Context) ([]stats.Sample, error) {
 			<-ctx.Done()
 			return nil, errors.New("hi")
-		}))
+		}})
 		assert.NoError(t, e.SetVUsMax(10))
 		assert.NoError(t, e.SetVUs(10))
 		e.SetEndTime(types.NullDurationFrom(100 * time.Millisecond))
@@ -148,14 +148,14 @@ func TestExecutorEndIterations(t *testing.T) {
 	metric := &stats.Metric{Name: "test_metric"}
 
 	var i int64
-	e := New(lib.RunnerFunc(func(ctx context.Context) ([]stats.Sample, error) {
+	e := New(lib.MiniRunner{Fn: func(ctx context.Context) ([]stats.Sample, error) {
 		select {
 		case <-ctx.Done():
 		default:
 			atomic.AddInt64(&i, 1)
 		}
 		return []stats.Sample{{Metric: metric, Value: 1.0}}, nil
-	}))
+	}})
 	assert.NoError(t, e.SetVUsMax(1))
 	assert.NoError(t, e.SetVUs(1))
 	e.SetEndIterations(null.IntFrom(100))
@@ -234,9 +234,9 @@ func TestExecutorSetVUs(t *testing.T) {
 	})
 
 	t.Run("Raise", func(t *testing.T) {
-		e := New(lib.RunnerFunc(func(ctx context.Context) ([]stats.Sample, error) {
+		e := New(lib.MiniRunner{Fn: func(ctx context.Context) ([]stats.Sample, error) {
 			return nil, nil
-		}))
+		}})
 		e.ctx = context.Background()
 
 		assert.NoError(t, e.SetVUsMax(100))
@@ -246,7 +246,7 @@ func TestExecutorSetVUs(t *testing.T) {
 			for i, handle := range e.vus {
 				num++
 				if assert.NotNil(t, handle.vu, "vu %d lacks impl", i) {
-					assert.Equal(t, int64(0), handle.vu.(*lib.RunnerFuncVU).ID)
+					assert.Equal(t, int64(0), handle.vu.(*lib.MiniRunnerVU).ID)
 				}
 				assert.Nil(t, handle.ctx, "vu %d has ctx", i)
 				assert.Nil(t, handle.cancel, "vu %d has cancel", i)
@@ -261,11 +261,11 @@ func TestExecutorSetVUs(t *testing.T) {
 			for i, handle := range e.vus {
 				if i < 50 {
 					assert.NotNil(t, handle.cancel, "vu %d lacks cancel", i)
-					assert.Equal(t, int64(i+1), handle.vu.(*lib.RunnerFuncVU).ID)
+					assert.Equal(t, int64(i+1), handle.vu.(*lib.MiniRunnerVU).ID)
 					num++
 				} else {
 					assert.Nil(t, handle.cancel, "vu %d has cancel", i)
-					assert.Equal(t, int64(0), handle.vu.(*lib.RunnerFuncVU).ID)
+					assert.Equal(t, int64(0), handle.vu.(*lib.MiniRunnerVU).ID)
 				}
 			}
 			assert.Equal(t, 50, num)
@@ -277,7 +277,7 @@ func TestExecutorSetVUs(t *testing.T) {
 			num := 0
 			for i, handle := range e.vus {
 				assert.NotNil(t, handle.cancel, "vu %d lacks cancel", i)
-				assert.Equal(t, int64(i+1), handle.vu.(*lib.RunnerFuncVU).ID)
+				assert.Equal(t, int64(i+1), handle.vu.(*lib.MiniRunnerVU).ID)
 				num++
 			}
 			assert.Equal(t, 100, num)
@@ -295,7 +295,7 @@ func TestExecutorSetVUs(t *testing.T) {
 					} else {
 						assert.Nil(t, handle.cancel, "vu %d has cancel", i)
 					}
-					assert.Equal(t, int64(i+1), handle.vu.(*lib.RunnerFuncVU).ID)
+					assert.Equal(t, int64(i+1), handle.vu.(*lib.MiniRunnerVU).ID)
 				}
 				assert.Equal(t, 50, num)
 			}
@@ -307,9 +307,9 @@ func TestExecutorSetVUs(t *testing.T) {
 					for i, handle := range e.vus {
 						assert.NotNil(t, handle.cancel, "vu %d lacks cancel", i)
 						if i < 50 {
-							assert.Equal(t, int64(i+1), handle.vu.(*lib.RunnerFuncVU).ID)
+							assert.Equal(t, int64(i+1), handle.vu.(*lib.MiniRunnerVU).ID)
 						} else {
-							assert.Equal(t, int64(50+i+1), handle.vu.(*lib.RunnerFuncVU).ID)
+							assert.Equal(t, int64(50+i+1), handle.vu.(*lib.MiniRunnerVU).ID)
 						}
 					}
 				}

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -120,7 +120,6 @@ func NewBundle(src *lib.SourceData, fs afero.Fs, rtOpts lib.RuntimeOptions) (*Bu
 			if _, ok := goja.AssertFunction(v); !ok {
 				return nil, errors.New("exported 'teardown' must be a function")
 			}
-		default:
 		}
 	}
 

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -42,6 +42,7 @@ type Bundle struct {
 	Program  *goja.Program
 	Options  lib.Options
 
+	Setup, Teardown goja.Callable
 	BaseInitContext *InitContext
 
 	Env map[string]string
@@ -83,7 +84,7 @@ func NewBundle(src *lib.SourceData, fs afero.Fs, rtOpts lib.RuntimeOptions) (*Bu
 		return nil, err
 	}
 
-	// Validate exports.
+	// Grab exports.
 	exportsV := rt.Get("exports")
 	if goja.IsNull(exportsV) || goja.IsUndefined(exportsV) {
 		return nil, errors.New("exports must be an object")
@@ -99,15 +100,33 @@ func NewBundle(src *lib.SourceData, fs afero.Fs, rtOpts lib.RuntimeOptions) (*Bu
 		return nil, errors.New("default export must be a function")
 	}
 
-	// Extract exported options.
-	optV := exports.Get("options")
-	if optV != nil && !goja.IsNull(optV) && !goja.IsUndefined(optV) {
-		optdata, err := json.Marshal(optV.Export())
-		if err != nil {
-			return nil, err
-		}
-		if err := json.Unmarshal(optdata, &bundle.Options); err != nil {
-			return nil, err
+	// Grab other exports.
+	for _, k := range exports.Keys() {
+		v := exports.Get(k)
+		switch k {
+		case "default": // Already checked above.
+		case "options":
+			data, err := json.Marshal(v.Export())
+			if err != nil {
+				return nil, err
+			}
+			if err := json.Unmarshal(data, &bundle.Options); err != nil {
+				return nil, err
+			}
+		case "setup":
+			fn, ok := goja.AssertFunction(v)
+			if !ok {
+				return nil, errors.New("exported 'setup' must be a function")
+			}
+			bundle.Setup = fn
+		case "teardown":
+			fn, ok := goja.AssertFunction(v)
+			if !ok {
+				return nil, errors.New("exported 'teardown' must be a function")
+			}
+			bundle.Teardown = fn
+		default:
+			return nil, errors.Errorf("unrecognised root-level export: %s", k)
 		}
 	}
 

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -42,7 +42,6 @@ type Bundle struct {
 	Program  *goja.Program
 	Options  lib.Options
 
-	Setup, Teardown goja.Callable
 	BaseInitContext *InitContext
 
 	Env map[string]string
@@ -100,7 +99,7 @@ func NewBundle(src *lib.SourceData, fs afero.Fs, rtOpts lib.RuntimeOptions) (*Bu
 		return nil, errors.New("default export must be a function")
 	}
 
-	// Grab other exports.
+	// Extract/validate other exports.
 	for _, k := range exports.Keys() {
 		v := exports.Get(k)
 		switch k {
@@ -114,19 +113,14 @@ func NewBundle(src *lib.SourceData, fs afero.Fs, rtOpts lib.RuntimeOptions) (*Bu
 				return nil, err
 			}
 		case "setup":
-			fn, ok := goja.AssertFunction(v)
-			if !ok {
+			if _, ok := goja.AssertFunction(v); !ok {
 				return nil, errors.New("exported 'setup' must be a function")
 			}
-			bundle.Setup = fn
 		case "teardown":
-			fn, ok := goja.AssertFunction(v)
-			if !ok {
+			if _, ok := goja.AssertFunction(v); !ok {
 				return nil, errors.New("exported 'teardown' must be a function")
 			}
-			bundle.Teardown = fn
 		default:
-			return nil, errors.Errorf("unrecognised root-level export: %s", k)
 		}
 	}
 

--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -353,26 +353,6 @@ func TestNewBundle(t *testing.T) {
 		}, afero.NewMemMapFs())
 		assert.EqualError(t, err, "unrecognised root-level export: boop")
 	})
-	t.Run("SetupTeardown", func(t *testing.T) {
-		b, err := NewBundle(&lib.SourceData{
-			Filename: "/script.js",
-			Data: []byte(`
-				export function setup() { return 1; }
-				export function teardown(data) { return data + 1; }
-				export default function() {}
-			`),
-		}, afero.NewMemMapFs())
-		if assert.NoError(t, err) {
-			v1, err := b.Setup(goja.Undefined())
-			if assert.NoError(t, err) {
-				assert.Equal(t, int64(1), v1.Export())
-			}
-			v2, err := b.Teardown(goja.Undefined(), v1)
-			if assert.NoError(t, err) {
-				assert.Equal(t, int64(2), v2.Export())
-			}
-		}
-	})
 }
 
 func TestNewBundleFromArchive(t *testing.T) {

--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -343,16 +343,6 @@ func TestNewBundle(t *testing.T) {
 			}
 		})
 	})
-	t.Run("UnrecognizedExorts", func(t *testing.T) {
-		_, err := NewBundle(&lib.SourceData{
-			Filename: "/script.js",
-			Data: []byte(`
-				export function boop() {};
-				export default function() {};
-			`),
-		}, afero.NewMemMapFs())
-		assert.EqualError(t, err, "unrecognised root-level export: boop")
-	})
 }
 
 func TestNewBundleFromArchive(t *testing.T) {

--- a/js/runner.go
+++ b/js/runner.go
@@ -23,6 +23,7 @@ package js
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"net"
 	"net/http"
 	"net/http/cookiejar"
@@ -55,8 +56,7 @@ type Runner struct {
 	Resolver   *dnscache.Resolver
 	RPSLimit   *rate.Limiter
 
-	// Value returned from setup(), if anything.
-	setupData goja.Value
+	setupData interface{}
 }
 
 func New(src *lib.SourceData, fs afero.Fs, rtOpts lib.RuntimeOptions) (*Runner, error) {
@@ -169,6 +169,7 @@ func (r *Runner) newVU() (*VU, error) {
 		Console:        NewConsole(),
 		BPool:          bpool.NewBufferPool(100),
 	}
+	vu.setupData = vu.Runtime.ToValue(r.setupData)
 	vu.Runtime.Set("console", common.Bind(vu.Runtime, vu.Console, vu.Context))
 
 	// Give the VU an initial sense of identity.
@@ -179,18 +180,21 @@ func (r *Runner) newVU() (*VU, error) {
 	return vu, nil
 }
 
-func (r *Runner) Setup() (err error) {
-	if setup := r.Bundle.Setup; setup != nil {
-		r.setupData, err = setup(goja.Undefined())
+func (r *Runner) Setup(ctx context.Context) error {
+	v, err := r.runPart(ctx, "setup", nil)
+	if err != nil {
+		return errors.Wrap(err, "setup")
 	}
-	return
+	data, err := json.Marshal(v.Export())
+	if err != nil {
+		return errors.Wrap(err, "setup")
+	}
+	return json.Unmarshal(data, &r.setupData)
 }
 
-func (r *Runner) Teardown() (err error) {
-	if teardown := r.Bundle.Teardown; teardown != nil {
-		_, err = teardown(goja.Undefined(), r.setupData)
-	}
-	return
+func (r *Runner) Teardown(ctx context.Context) error {
+	_, err := r.runPart(ctx, "teardown", r.setupData)
+	return err
 }
 
 func (r *Runner) GetDefaultGroup() *lib.Group {
@@ -210,6 +214,32 @@ func (r *Runner) SetOptions(opts lib.Options) {
 	}
 }
 
+// Runs an exported function in its own temporary VU, optionally with an argument. Execution is
+// interrupted if the context expires. No error is returned if the part does not exist.
+func (r *Runner) runPart(ctx context.Context, name string, arg interface{}) (goja.Value, error) {
+	vu, err := r.newVU()
+	if err != nil {
+		return goja.Undefined(), err
+	}
+	exp := vu.Runtime.Get("exports").ToObject(vu.Runtime)
+	if exp == nil {
+		return goja.Undefined(), nil
+	}
+	fn, ok := goja.AssertFunction(exp.Get(name))
+	if !ok {
+		return goja.Undefined(), nil
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	go func() {
+		<-ctx.Done()
+		vu.Runtime.Interrupt(errInterrupt)
+	}()
+	v, _, err := vu.runFn(ctx, fn, vu.Runtime.ToValue(arg))
+	cancel()
+	return v, err
+}
+
 type VU struct {
 	BundleInstance
 
@@ -222,6 +252,8 @@ type VU struct {
 	Console *Console
 	BPool   *bpool.BufferPool
 
+	setupData goja.Value
+
 	// A VU will track the last context it was called with for cancellation.
 	// Note that interruptTrackedCtx is the context that is currently being tracked, while
 	// interruptCancel cancels an unrelated context that terminates the tracking goroutine
@@ -231,6 +263,13 @@ type VU struct {
 	// goroutine per call.
 	interruptTrackedCtx context.Context
 	interruptCancel     context.CancelFunc
+}
+
+func (u *VU) Reconfigure(id int64) error {
+	u.ID = id
+	u.Iteration = 0
+	u.Runtime.Set("__VU", u.ID)
+	return nil
 }
 
 func (u *VU) RunOnce(ctx context.Context) ([]stats.Sample, error) {
@@ -251,9 +290,18 @@ func (u *VU) RunOnce(ctx context.Context) ([]stats.Sample, error) {
 		}()
 	}
 
-	cookieJar, err := cookiejar.New(nil)
+	// Call the default function.
+	_, state, err := u.runFn(ctx, u.Default, u.setupData)
 	if err != nil {
 		return nil, err
+	}
+	return state.Samples, nil
+}
+
+func (u *VU) runFn(ctx context.Context, fn goja.Callable, args ...goja.Value) (goja.Value, *common.State, error) {
+	cookieJar, err := cookiejar.New(nil)
+	if err != nil {
+		return goja.Undefined(), nil, err
 	}
 
 	state := &common.State{
@@ -281,7 +329,7 @@ func (u *VU) RunOnce(ctx context.Context) ([]stats.Sample, error) {
 	u.Iteration++
 
 	startTime := time.Now()
-	_, err = u.Default(goja.Undefined(), u.Runner.setupData) // Actually run the JS script
+	v, err := fn(goja.Undefined(), args...) // Actually run the JS script
 	t := time.Now()
 
 	tags := map[string]string{}
@@ -292,7 +340,7 @@ func (u *VU) RunOnce(ctx context.Context) ([]stats.Sample, error) {
 		tags["iter"] = strconv.FormatInt(iter, 10)
 	}
 
-	samples := append(state.Samples,
+    state.Samples := append(state.Samples,
 		stats.Sample{Time: t, Metric: metrics.DataSent, Value: float64(u.Dialer.BytesWritten), Tags: tags},
 		stats.Sample{Time: t, Metric: metrics.DataReceived, Value: float64(u.Dialer.BytesRead), Tags: tags},
 		stats.Sample{Time: t, Metric: metrics.IterationDuration, Value: stats.D(t.Sub(startTime)), Tags: tags},
@@ -301,12 +349,5 @@ func (u *VU) RunOnce(ctx context.Context) ([]stats.Sample, error) {
 	if u.Runner.Bundle.Options.NoConnectionReuse.Bool {
 		u.HTTPTransport.CloseIdleConnections()
 	}
-	return samples, err
-}
-
-func (u *VU) Reconfigure(id int64) error {
-	u.ID = id
-	u.Iteration = 0
-	u.Runtime.Set("__VU", u.ID)
-	return nil
+	return v, state, err
 }

--- a/js/runner.go
+++ b/js/runner.go
@@ -347,7 +347,7 @@ func (u *VU) runFn(ctx context.Context, fn goja.Callable, args ...goja.Value) (g
 		tags["iter"] = strconv.FormatInt(iter, 10)
 	}
 
-    state.Samples := append(state.Samples,
+	state.Samples = append(state.Samples,
 		stats.Sample{Time: t, Metric: metrics.DataSent, Value: float64(u.Dialer.BytesWritten), Tags: tags},
 		stats.Sample{Time: t, Metric: metrics.DataReceived, Value: float64(u.Dialer.BytesRead), Tags: tags},
 		stats.Sample{Time: t, Metric: metrics.IterationDuration, Value: stats.D(t.Sub(startTime)), Tags: tags},

--- a/js/runner.go
+++ b/js/runner.go
@@ -54,6 +54,9 @@ type Runner struct {
 	BaseDialer net.Dialer
 	Resolver   *dnscache.Resolver
 	RPSLimit   *rate.Limiter
+
+	// Value returned from setup(), if anything.
+	setupData goja.Value
 }
 
 func New(src *lib.SourceData, fs afero.Fs, rtOpts lib.RuntimeOptions) (*Runner, error) {
@@ -176,6 +179,20 @@ func (r *Runner) newVU() (*VU, error) {
 	return vu, nil
 }
 
+func (r *Runner) Setup() (err error) {
+	if setup := r.Bundle.Setup; setup != nil {
+		r.setupData, err = setup(goja.Undefined())
+	}
+	return
+}
+
+func (r *Runner) Teardown() (err error) {
+	if teardown := r.Bundle.Teardown; teardown != nil {
+		_, err = teardown(goja.Undefined(), r.setupData)
+	}
+	return
+}
+
 func (r *Runner) GetDefaultGroup() *lib.Group {
 	return r.defaultGroup
 }
@@ -264,7 +281,7 @@ func (u *VU) RunOnce(ctx context.Context) ([]stats.Sample, error) {
 	u.Iteration++
 
 	startTime := time.Now()
-	_, err = u.Default(goja.Undefined()) // Actually run the JS script
+	_, err = u.Default(goja.Undefined(), u.Runner.setupData) // Actually run the JS script
 	t := time.Now()
 
 	tags := map[string]string{}

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -67,6 +67,43 @@ func TestRunnerNew(t *testing.T) {
 		})
 	})
 
+	t.Run("SetupTeardown", func(t *testing.T) {
+		r, err := New(&lib.SourceData{
+			Filename: "/script.js",
+			Data: []byte(`
+				export function setup() {
+					return { v: 1 };
+				}
+				export function teardown(data) {
+					if (data.v != 1) {
+						throw new Error("teardown: wrong data: " + JSON.stringify(data))
+					}
+				}
+				export default function(data) {
+					if (data.v != 1) {
+						throw new Error("default: wrong data: " + JSON.stringify(data))
+					}
+				}
+			`),
+		}, afero.NewMemMapFs())
+		if !assert.NoError(t, err) {
+			return
+		}
+		if !assert.NoError(t, r.Setup()) {
+			return
+		}
+
+		t.Run("VU", func(t *testing.T) {
+			vu, err := r.NewVU()
+			if assert.NoError(t, err) {
+				_, err := vu.RunOnce(context.Background())
+				assert.NoError(t, err)
+			}
+		})
+
+		assert.NoError(t, r.Teardown())
+	})
+
 	t.Run("Invalid", func(t *testing.T) {
 		_, err := New(&lib.SourceData{
 			Filename: "/script.js",

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -138,12 +138,12 @@ func TestSetupTeardown(t *testing.T) {
 				}
 			}
 		`),
-	}, afero.NewMemMapFs())
+	}, afero.NewMemMapFs(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	r2, err := NewFromArchive(r1.MakeArchive())
+	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/lib/executor.go
+++ b/lib/executor.go
@@ -80,4 +80,8 @@ type Executor interface {
 	// speaking better to preallocate too many than too few.
 	GetVUsMax() int64
 	SetVUsMax(max int64) error
+
+	// Set whether or not to run setup/teardown phases. Default is to run all of them.
+	SetRunSetup(r bool)
+	SetRunTeardown(r bool)
 }

--- a/lib/runner.go
+++ b/lib/runner.go
@@ -45,6 +45,12 @@ type Runner interface {
 	// of a test - RunOnce() may be called hundreds of thousands of times, and must be fast.
 	NewVU() (VU, error)
 
+	// Runs pre-test setup, if applicable.
+	Setup() error
+
+	// Runs post-test teardown, if applicable.
+	Teardown() error
+
 	// Returns the default (root) Group.
 	GetDefaultGroup() *Group
 
@@ -79,6 +85,14 @@ func (fn RunnerFunc) MakeArchive() *Archive {
 
 func (fn RunnerFunc) NewVU() (VU, error) {
 	return fn.VU(), nil
+}
+
+func (fn RunnerFunc) Setup() error {
+	return nil
+}
+
+func (fn RunnerFunc) Teardown() error {
+	return nil
 }
 
 func (fn RunnerFunc) GetDefaultGroup() *Group {

--- a/lib/runner.go
+++ b/lib/runner.go
@@ -77,6 +77,9 @@ type MiniRunner struct {
 	Fn         func(ctx context.Context) ([]stats.Sample, error)
 	SetupFn    func(ctx context.Context) error
 	TeardownFn func(ctx context.Context) error
+
+	Group   *Group
+	Options Options
 }
 
 func (r MiniRunner) VU() *MiniRunnerVU {
@@ -106,14 +109,18 @@ func (r MiniRunner) Teardown(ctx context.Context) error {
 }
 
 func (r MiniRunner) GetDefaultGroup() *Group {
-	return &Group{}
+	if r.Group == nil {
+		r.Group = &Group{}
+	}
+	return r.Group
 }
 
 func (r MiniRunner) GetOptions() Options {
-	return Options{}
+	return r.Options
 }
 
 func (r MiniRunner) SetOptions(opts Options) {
+	r.Options = opts
 }
 
 // A VU spawned by a MiniRunner.

--- a/lib/runner.go
+++ b/lib/runner.go
@@ -27,7 +27,7 @@ import (
 )
 
 // Ensure MiniRunner conforms to Runner.
-var _ Runner = MiniRunner{}
+var _ Runner = &MiniRunner{}
 
 // A Runner is a factory for VUs. It should precompute as much as possible upon creation (parse
 // ASTs, load files into memory, etc.), so that spawning VUs becomes as fast as possible.

--- a/lib/runner.go
+++ b/lib/runner.go
@@ -46,10 +46,10 @@ type Runner interface {
 	NewVU() (VU, error)
 
 	// Runs pre-test setup, if applicable.
-	Setup() error
+	Setup(ctx context.Context) error
 
 	// Runs post-test teardown, if applicable.
-	Teardown() error
+	Teardown(ctx context.Context) error
 
 	// Returns the default (root) Group.
 	GetDefaultGroup() *Group

--- a/lib/runner.go
+++ b/lib/runner.go
@@ -119,7 +119,7 @@ func (r MiniRunner) GetOptions() Options {
 	return r.Options
 }
 
-func (r MiniRunner) SetOptions(opts Options) {
+func (r *MiniRunner) SetOptions(opts Options) {
 	r.Options = opts
 }
 

--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -54,6 +54,29 @@ Thanks to @cstyan for their work on this!
 
 **Docs**: [Request information](https://docs.k6.io/docs/TODO)
 
+### Lifecycle: setup/teardown functions (#457)
+Finally k6 has the same basic test lifecycle hooks as many "normal" testing tools, setup and teardown, and you have the full JS API of k6 available within these functions which means you can make HTTP calls etc. that you can’t do in the global/init scope.
+
+To use the lifecycle hooks you simply define an exported setup() and/or teardown() function in your script:
+
+```js
+export function setup() {
+	return { “data”: “passed to main and teardown function” };
+}
+
+export function teardown(data)  {
+	console.log(JSON.stringify(data));
+}
+
+export default function(data) {
+if (data.v != 1) {
+		throw new Error("incorrect data: " + JSON.stringify(data));
+	}
+}
+```
+
+**Docs**: [Test life cycle](https://docs.k6.io/v1.0/docs/test-life-cycle)
+
 ### CLI: HTTP debug flag (#447)
 If you specify `--http-debug` when running a test k6 will now continuously print request and response information.
 


### PR DESCRIPTION
```js
export function setup() {
    return {v: 1};
}

export default function(data) {
    console.log(JSON.stringify(data));
}

export function teardown(data) {
    if (data.v != 1) {
        throw new Error("incorrect data: " + JSON.stringify(data));
    }
}
```

Both `setup()` and `teardown()` are ran in full VU contexts, and can thus do things like network requests just like you can in `default()`.

Pass `k6 run --no-setup --no-teardown ...` to skip running them; for clustered execution, etc.

Closes #194 