### PR TITLE
Add vu and iter tags to metrics

### DIFF
--- a/js/common/state.go
+++ b/js/common/state.go
@@ -59,4 +59,6 @@ type State struct {
 
 	// Buffer pool; use instead of allocating fresh buffers when possible.
 	BPool *bpool.BufferPool
+
+	Vu, Iteration int64
 }

--- a/js/modules/k6/http/http_request.go
+++ b/js/modules/k6/http/http_request.go
@@ -127,6 +127,8 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 		"url":    url.URLString,
 		"name":   url.Name,
 		"group":  state.Group.Path,
+		"vu":     strconv.FormatInt(state.Vu, 10),
+		"iter":   strconv.FormatInt(state.Iteration, 10),
 	}
 	redirects := state.Options.MaxRedirects
 	timeout := 60 * time.Second

--- a/js/modules/k6/k6.go
+++ b/js/modules/k6/k6.go
@@ -22,6 +22,7 @@ package k6
 
 import (
 	"context"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -70,8 +71,11 @@ func (*K6) Group(ctx context.Context, name string, fn goja.Callable) (goja.Value
 		stats.Sample{
 			Time:   t,
 			Metric: metrics.GroupDuration,
-			Tags:   map[string]string{"group": g.Path},
-			Value:  stats.D(t.Sub(startTime)),
+			Tags: map[string]string{
+				"group": g.Path,
+				"vu":    strconv.FormatInt(state.Vu, 10),
+				"iter":  strconv.FormatInt(state.Iteration, 10)},
+			Value: stats.D(t.Sub(startTime)),
 		},
 	)
 	return ret, err
@@ -108,6 +112,8 @@ func (*K6) Check(ctx context.Context, arg0, checks goja.Value, extras ...goja.Va
 			return false, err
 		}
 		tags["check"] = check.Name
+		tags["vu"] = strconv.FormatInt(state.Vu, 10)
+		tags["iter"] = strconv.FormatInt(state.Iteration, 10)
 
 		// Resolve callables into values.
 		fn, ok := goja.AssertFunction(val)

--- a/js/modules/k6/k6_test.go
+++ b/js/modules/k6/k6_test.go
@@ -136,6 +136,8 @@ func TestCheck(t *testing.T) {
 			assert.Equal(t, map[string]string{
 				"group": "",
 				"check": "check",
+				"vu":    "0",
+				"iter":  "0",
 			}, state.Samples[0].Tags)
 		}
 
@@ -184,6 +186,8 @@ func TestCheck(t *testing.T) {
 			assert.Equal(t, map[string]string{
 				"group": "",
 				"check": "0",
+				"vu":    "0",
+				"iter":  "0",
 			}, state.Samples[0].Tags)
 		}
 	})
@@ -247,6 +251,8 @@ func TestCheck(t *testing.T) {
 							assert.Equal(t, map[string]string{
 								"group": "",
 								"check": "check",
+								"vu":    "0",
+								"iter":  "0",
 							}, state.Samples[0].Tags)
 						}
 					})
@@ -301,6 +307,8 @@ func TestCheck(t *testing.T) {
 				"check": "check",
 				"a":     "1",
 				"b":     "2",
+				"vu":    "0",
+				"iter":  "0",
 			}, state.Samples[0].Tags)
 		}
 	})

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -359,7 +359,7 @@ func TestVUIntegrationMetrics(t *testing.T) {
 
 			samples, err := vu.RunOnce(context.Background())
 			assert.NoError(t, err)
-			assert.Len(t, samples, 3)
+			assert.Len(t, samples, 4)
 			for i, s := range samples {
 				switch i {
 				case 0:
@@ -372,6 +372,8 @@ func TestVUIntegrationMetrics(t *testing.T) {
 				case 2:
 					assert.Equal(t, 0.0, s.Value)
 					assert.Equal(t, metrics.DataReceived, s.Metric)
+				case 3:
+					assert.Equal(t, metrics.IterationDuration, s.Metric)
 				}
 			}
 		})

--- a/lib/metrics/metrics.go
+++ b/lib/metrics/metrics.go
@@ -6,10 +6,11 @@ import (
 
 var (
 	// Engine-emitted.
-	VUs        = stats.New("vus", stats.Gauge)
-	VUsMax     = stats.New("vus_max", stats.Gauge)
-	Iterations = stats.New("iterations", stats.Counter)
-	Errors     = stats.New("errors", stats.Counter)
+	VUs               = stats.New("vus", stats.Gauge)
+	VUsMax            = stats.New("vus_max", stats.Gauge)
+	Iterations        = stats.New("iterations", stats.Counter)
+	IterationDuration = stats.New("iteration_duration", stats.Trend, stats.Time)
+	Errors            = stats.New("errors", stats.Counter)
 
 	// Runner-emitted.
 	Checks        = stats.New("checks", stats.Rate)


### PR DESCRIPTION
Changes: 
- introduce new iteration_duration metric
- add "vu" and "iter" tags to the following metrics:
   - http_reqs
   - http_req_*
   - checks
   - data_send
   - data_received
   - group_duration
   - iteration_duration
