### PR TITLE
Cloud: Default `gzip` compression when pushing metrics.

### DIFF
--- a/stats/cloud/api.go
+++ b/stats/cloud/api.go
@@ -85,10 +85,16 @@ func (c *Client) CreateTestRun(testRun *TestRun) (*CreateTestRunResponse, error)
 	return &ctrr, nil
 }
 
-func (c *Client) PushMetric(referenceID string, compress bool, samples []*Sample) error {
+func (c *Client) PushMetric(referenceID string, noCompress bool, samples []*Sample) error {
 	url := fmt.Sprintf("%s/metrics/%s", c.baseURL, referenceID)
 
-	if compress {
+	if noCompress {
+		req, err := c.NewRequest("POST", url, samples)
+		if err != nil {
+			return err
+		}
+		return c.Do(req, nil)
+	} else {
 		var buf bytes.Buffer
 		if samples != nil {
 			b, err := json.Marshal(&samples)
@@ -108,12 +114,6 @@ func (c *Client) PushMetric(referenceID string, compress bool, samples []*Sample
 			return err
 		}
 		req.Header.Set("Content-Encoding", "gzip")
-		return c.Do(req, nil)
-	} else {
-		req, err := c.NewRequest("POST", url, samples)
-		if err != nil {
-			return err
-		}
 		return c.Do(req, nil)
 	}
 }

--- a/stats/cloud/collector.go
+++ b/stats/cloud/collector.go
@@ -190,7 +190,7 @@ func (c *Collector) pushMetrics() {
 		"samples": len(buffer),
 	}).Debug("Pushing metrics to cloud")
 
-	err := c.client.PushMetric(c.referenceID, c.config.Compress, buffer)
+	err := c.client.PushMetric(c.referenceID, c.config.NoCompress, buffer)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"error": err,

--- a/stats/cloud/config.go
+++ b/stats/cloud/config.go
@@ -28,7 +28,7 @@ type ConfigFields struct {
 	Token           string `json:"token" mapstructure:"token" envconfig:"CLOUD_TOKEN"`
 	Name            string `json:"name" mapstructure:"name" envconfig:"CLOUD_NAME"`
 	Host            string `json:"host" mapstructure:"host" envconfig:"CLOUD_HOST"`
-	Compress        bool   `json:"compress" mapstructure:"compress" envconfig:"CLOUD_COMPRESS"`
+	NoCompress      bool   `json:"no_compress" mapstructure:"no_compress" envconfig:"CLOUD_NO_COMPRESS"`
 	ProjectID       int    `json:"project_id" mapstructure:"project_id" envconfig:"CLOUD_PROJECT_ID"`
 	DeprecatedToken string `envconfig:"K6CLOUD_TOKEN"`
 }


### PR DESCRIPTION
Replace `K6_CLOUD_COMPRESS` with `K6_CLOUD_NO_COMPRESS` option.