### PR TITLE
[Bugfix] Several bugfixes related to redirects and cookies

### DIFF
--- a/js/modules/k6/http/http_request.go
+++ b/js/modules/k6/http/http_request.go
@@ -312,7 +312,7 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 	} else {
 		if activeJar != nil {
 			if rc := res.Cookies(); len(rc) > 0 {
-				activeJar.SetCookies(req.URL, rc)
+				activeJar.SetCookies(res.Request.URL, rc)
 			}
 		}
 

--- a/js/modules/k6/http/http_request.go
+++ b/js/modules/k6/http/http_request.go
@@ -250,6 +250,7 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 			if activeJar != nil {
 				if respCookies := req.Response.Cookies(); len(respCookies) > 0 {
 					activeJar.SetCookies(req.URL, respCookies)
+					req.Header.Del("Cookie")
 					h.setRequestCookies(req, activeJar, reqCookies)
 				}
 			}

--- a/js/modules/k6/http/http_request.go
+++ b/js/modules/k6/http/http_request.go
@@ -250,9 +250,9 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 			if activeJar != nil {
 				if respCookies := req.Response.Cookies(); len(respCookies) > 0 {
 					activeJar.SetCookies(req.URL, respCookies)
-					req.Header.Del("Cookie")
-					h.setRequestCookies(req, activeJar, reqCookies)
 				}
+				req.Header.Del("Cookie")
+				h.setRequestCookies(req, activeJar, reqCookies)
 			}
 
 			if l := len(via); int64(l) > redirects.Int64 {


### PR DESCRIPTION
**1. Set response cookies using the correct response URL.**
req.URL: the url of the initial request.
res.Request.URL: the url of the request that gave the response, after all redirects. In other words: the response url.

Example:
- Request `https://domain1.com` which redirects to `https://domain2.com`
- Response of `https://domain2.com` sets cookie `myCookie`.

Before this fix `myCookie` would be set using url `https://domain1.com` instead of `https://domain2.com`

**2. Clear cookies on request before setting them in CheckRedirect**
When a redirect response contains new cookies (Set-Cookie) these are put in the cookieJar.
After this is done the cookies are set on the request using the jar.
The problem is that the request already contains the original cookies (without the new ones). This results in cookies being set twice.
The solution is to clear the cookies on the request, before setting them again.

**3. Also set cookies based on cookieJar when redirect response does not set extra cookie**
In `CheckRedirect` it would only set the cookies on the request based on the cookieJar, when the response would contain new cookies (`Set-Cookie`). However this should always be done.


