### PR TITLE
HTTP Debug Logging

### DIFF
--- a/cmd/convert_test.go
+++ b/cmd/convert_test.go
@@ -115,21 +115,24 @@ export default function() {
 func TestIntegrationConvertCmd(t *testing.T) {
 	t.Run("Stdout", func(t *testing.T) {
 		defaultFs = afero.NewMemMapFs()
-		afero.WriteFile(defaultFs, "/input.har", []byte(testHAR), 0644)
+		err := afero.WriteFile(defaultFs, "/input.har", []byte(testHAR), 0644)
+		assert.NoError(t, err)
 
 		buf := &bytes.Buffer{}
 		defaultWriter = buf
 
-		err := convertCmd.RunE(convertCmd, []string{"/input.har"})
+		err = convertCmd.RunE(convertCmd, []string{"/input.har"})
 		assert.NoError(t, err)
 		assert.Equal(t, testHARConvertResult, buf.String())
 	})
 	t.Run("Output file", func(t *testing.T) {
 		defaultFs = afero.NewMemMapFs()
-		afero.WriteFile(defaultFs, "/input.har", []byte(testHAR), 0644)
+		err := afero.WriteFile(defaultFs, "/input.har", []byte(testHAR), 0644)
+		assert.NoError(t, err)
 
-		convertCmd.Flags().Set("output", "/output.js")
-		err := convertCmd.RunE(convertCmd, []string{"/input.har"})
+		err = convertCmd.Flags().Set("output", "/output.js")
+		assert.NoError(t, err)
+		err = convertCmd.RunE(convertCmd, []string{"/input.har"})
 		assert.NoError(t, err)
 
 		output, err := afero.ReadFile(defaultFs, "/output.js")

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -44,7 +44,8 @@ func optionFlagSet() *pflag.FlagSet {
 	flags.Int64("batch-per-host", 0, "max parallel batch reqs per host")
 	flags.Int64("rps", 0, "limit requests per second")
 	flags.String("user-agent", fmt.Sprintf("k6/%s (https://k6.io/);", Version), "user agent for http requests")
-	flags.Bool("http-debug", false, "log all HTTP requests and responses")
+	flags.Bool("http-debug", false, "log all HTTP requests and responses, excluding body")
+	flags.Bool("http-debug-full", false, "log all HTTP requests and responses, including body")
 	flags.Bool("insecure-skip-tls-verify", false, "skip verification of TLS certificates")
 	flags.Bool("no-connection-reuse", false, "don't reuse connections between iterations")
 	flags.BoolP("throw", "w", false, "throw warnings (like failed http requests) as errors")
@@ -65,6 +66,7 @@ func getOptions(flags *pflag.FlagSet) (lib.Options, error) {
 		RPS:                   getNullInt64(flags, "rps"),
 		UserAgent:             getNullString(flags, "user-agent"),
 		HttpDebug:             getNullBool(flags, "http-debug"),
+		HttpDebugFull:         getNullBool(flags, "http-debug-full"),
 		InsecureSkipTLSVerify: getNullBool(flags, "insecure-skip-tls-verify"),
 		NoConnectionReuse:     getNullBool(flags, "no-connection-reuse"),
 		Throw:                 getNullBool(flags, "throw"),

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -44,8 +44,8 @@ func optionFlagSet() *pflag.FlagSet {
 	flags.Int64("batch-per-host", 0, "max parallel batch reqs per host")
 	flags.Int64("rps", 0, "limit requests per second")
 	flags.String("user-agent", fmt.Sprintf("k6/%s (https://k6.io/);", Version), "user agent for http requests")
-	flags.Bool("http-debug", false, "log all HTTP requests and responses, excluding body")
-	flags.Bool("http-debug-full", false, "log all HTTP requests and responses, including body")
+	flags.String("http-debug", "", "log all HTTP requests and responses. Excludes body by default. To include body use '---http-debug=full'")
+	flags.Lookup("http-debug").NoOptDefVal = "headers"
 	flags.Bool("insecure-skip-tls-verify", false, "skip verification of TLS certificates")
 	flags.Bool("no-connection-reuse", false, "don't reuse connections between iterations")
 	flags.BoolP("throw", "w", false, "throw warnings (like failed http requests) as errors")
@@ -65,8 +65,7 @@ func getOptions(flags *pflag.FlagSet) (lib.Options, error) {
 		Batch:                 getNullInt64(flags, "batch"),
 		RPS:                   getNullInt64(flags, "rps"),
 		UserAgent:             getNullString(flags, "user-agent"),
-		HttpDebug:             getNullBool(flags, "http-debug"),
-		HttpDebugFull:         getNullBool(flags, "http-debug-full"),
+		HttpDebug:             getNullString(flags, "http-debug"),
 		InsecureSkipTLSVerify: getNullBool(flags, "insecure-skip-tls-verify"),
 		NoConnectionReuse:     getNullBool(flags, "no-connection-reuse"),
 		Throw:                 getNullBool(flags, "throw"),

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -44,6 +44,7 @@ func optionFlagSet() *pflag.FlagSet {
 	flags.Int64("batch-per-host", 0, "max parallel batch reqs per host")
 	flags.Int64("rps", 0, "limit requests per second")
 	flags.String("user-agent", fmt.Sprintf("k6/%s (https://k6.io/);", Version), "user agent for http requests")
+	flags.Bool("http-debug", false, "log all HTTP requests and responses")
 	flags.Bool("insecure-skip-tls-verify", false, "skip verification of TLS certificates")
 	flags.Bool("no-connection-reuse", false, "don't reuse connections between iterations")
 	flags.BoolP("throw", "w", false, "throw warnings (like failed http requests) as errors")
@@ -63,6 +64,7 @@ func getOptions(flags *pflag.FlagSet) (lib.Options, error) {
 		Batch:                 getNullInt64(flags, "batch"),
 		RPS:                   getNullInt64(flags, "rps"),
 		UserAgent:             getNullString(flags, "user-agent"),
+		HttpDebug:             getNullBool(flags, "http-debug"),
 		InsecureSkipTLSVerify: getNullBool(flags, "insecure-skip-tls-verify"),
 		NoConnectionReuse:     getNullBool(flags, "no-connection-reuse"),
 		Throw:                 getNullBool(flags, "throw"),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Version = "0.18.2"
+var Version = "0.19.0"
 var Banner = `
           /\      |‾‾|  /‾‾/  /‾/   
      /\  /  \     |  |_/  /  / /   

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -307,7 +307,7 @@ a commandline interface for interacting with it.`,
 			updateFreq = 1 * time.Second
 		}
 		ticker := time.NewTicker(updateFreq)
-		if quiet {
+		if quiet || conf.HttpDebug.Bool || conf.HttpDebugFull.Bool {
 			ticker.Stop()
 		}
 	mainLoop:

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -307,7 +307,7 @@ a commandline interface for interacting with it.`,
 			updateFreq = 1 * time.Second
 		}
 		ticker := time.NewTicker(updateFreq)
-		if quiet || conf.HttpDebug.Bool || conf.HttpDebugFull.Bool {
+		if quiet || conf.HttpDebug.Valid && conf.HttpDebug.String != "" {
 			ticker.Stop()
 		}
 	mainLoop:

--- a/js/modules/k6/html/elements_gen_test.go
+++ b/js/modules/k6/html/elements_gen_test.go
@@ -411,14 +411,14 @@ func TestGenElements(t *testing.T) {
 			vT, errT := common.RunString(rt, `doc.find("#`+test.idTrue+`").get(0).`+test.property+`()`)
 			if errT != nil {
 				t.Errorf("Error for property name '%s' on element id '#%s':\n%+v", test.property, test.idTrue, errT)
-			} else if vT.Export() != true {
+			} else if vT.Export() != true { // nolint: gosimple
 				t.Errorf("Expected true for property name '%s' on element id '#%s'", test.property, test.idTrue)
 			}
 
 			vF, errF := common.RunString(rt, `doc.find("#`+test.idFalse+`").get(0).`+test.property+`()`)
 			if errF != nil {
 				t.Errorf("Error for property name '%s' on element id '#%s':\n%+v", test.property, test.idFalse, errF)
-			} else if vF.Export() != false {
+			} else if vF.Export() != false { // nolint: gosimple
 				t.Errorf("Expected false for property name '%s' on element id '#%s'", test.property, test.idFalse)
 			}
 		}

--- a/js/modules/k6/http/http.go
+++ b/js/modules/k6/http/http.go
@@ -151,8 +151,8 @@ func (*HTTP) setRequestCookies(req *http.Request, jar *cookiejar.Jar, reqCookies
 }
 
 func (*HTTP) debugRequest(state *common.State, req *http.Request, description string) {
-	if state.Options.HttpDebug.Bool {
-		dump, err := httputil.DumpRequestOut(req, false)
+	if state.Options.HttpDebug.Bool || state.Options.HttpDebugFull.Bool {
+		dump, err := httputil.DumpRequestOut(req, state.Options.HttpDebugFull.Bool)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -161,8 +161,8 @@ func (*HTTP) debugRequest(state *common.State, req *http.Request, description st
 }
 
 func (*HTTP) debugResponse(state *common.State, res *http.Response, description string) {
-	if state.Options.HttpDebug.Bool {
-		dump, err := httputil.DumpResponse(res, true)
+	if state.Options.HttpDebug.Bool || state.Options.HttpDebugFull.Bool {
+		dump, err := httputil.DumpResponse(res, state.Options.HttpDebugFull.Bool)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/js/modules/k6/http/http.go
+++ b/js/modules/k6/http/http.go
@@ -161,7 +161,7 @@ func (*HTTP) debugRequest(state *common.State, req *http.Request, description st
 }
 
 func (*HTTP) debugResponse(state *common.State, res *http.Response, description string) {
-	if state.Options.HttpDebug.String != "" {
+	if state.Options.HttpDebug.String != "" && res != nil {
 		dump, err := httputil.DumpResponse(res, state.Options.HttpDebug.String == "full")
 		if err != nil {
 			log.Fatal(err)

--- a/js/modules/k6/http/http.go
+++ b/js/modules/k6/http/http.go
@@ -26,7 +26,10 @@ import (
 	"net/http/cookiejar"
 	"reflect"
 
+	"fmt"
 	"github.com/loadimpact/k6/js/common"
+	log "github.com/sirupsen/logrus"
+	"net/http/httputil"
 )
 
 var (
@@ -145,4 +148,28 @@ func (*HTTP) setRequestCookies(req *http.Request, jar *cookiejar.Jar, reqCookies
 			req.AddCookie(c)
 		}
 	}
+}
+
+func (*HTTP) debugRequest(state *common.State, req *http.Request, description string) {
+	if state.Options.HttpDebug.Bool {
+		dump, err := httputil.DumpRequestOut(req, false)
+		if err != nil {
+			log.Fatal(err)
+		}
+		logDump(description, dump)
+	}
+}
+
+func (*HTTP) debugResponse(state *common.State, res *http.Response, description string) {
+	if state.Options.HttpDebug.Bool {
+		dump, err := httputil.DumpResponse(res, true)
+		if err != nil {
+			log.Fatal(err)
+		}
+		logDump(description, dump)
+	}
+}
+
+func logDump(description string, dump []byte) {
+	fmt.Printf("%s:\n%s\n", description, dump)
 }

--- a/js/modules/k6/http/http.go
+++ b/js/modules/k6/http/http.go
@@ -151,8 +151,8 @@ func (*HTTP) setRequestCookies(req *http.Request, jar *cookiejar.Jar, reqCookies
 }
 
 func (*HTTP) debugRequest(state *common.State, req *http.Request, description string) {
-	if state.Options.HttpDebug.Bool || state.Options.HttpDebugFull.Bool {
-		dump, err := httputil.DumpRequestOut(req, state.Options.HttpDebugFull.Bool)
+	if state.Options.HttpDebug.String != "" {
+		dump, err := httputil.DumpRequestOut(req, state.Options.HttpDebug.String == "full")
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -161,8 +161,8 @@ func (*HTTP) debugRequest(state *common.State, req *http.Request, description st
 }
 
 func (*HTTP) debugResponse(state *common.State, res *http.Response, description string) {
-	if state.Options.HttpDebug.Bool || state.Options.HttpDebugFull.Bool {
-		dump, err := httputil.DumpResponse(res, state.Options.HttpDebugFull.Bool)
+	if state.Options.HttpDebug.String != "" {
+		dump, err := httputil.DumpResponse(res, state.Options.HttpDebug.String == "full")
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/js/modules/k6/http/http_request.go
+++ b/js/modules/k6/http/http_request.go
@@ -246,6 +246,8 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 		Transport: state.HTTPTransport,
 		Timeout:   timeout,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			h.debugResponse(state, req.Response, "RedirectResponse")
+
 			// Update active jar with cookies found in "Set-Cookie" header(s) of redirect response
 			if activeJar != nil {
 				if respCookies := req.Response.Cookies(); len(respCookies) > 0 {
@@ -264,13 +266,17 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 					state.Logger.WithFields(log.Fields{"url": url.String()}).Warnf("Stopped after %d redirects and returned the redirection; pass { redirects: n } in request params or set global maxRedirects to silence this", l)
 				}
 				return http.ErrUseLastResponse
+			} else {
+				h.debugRequest(state, req, "RedirectRequest")
 			}
 			return nil
 		},
 	}
 
 	tracer := netext.Tracer{}
+	h.debugRequest(state, req, "Request")
 	res, resErr := client.Do(req.WithContext(netext.WithTracer(ctx, &tracer)))
+	h.debugResponse(state, res, "Response")
 	if resErr == nil && res != nil {
 		switch res.Header.Get("Content-Encoding") {
 		case "deflate":

--- a/js/modules/k6/http/response_test.go
+++ b/js/modules/k6/http/response_test.go
@@ -86,7 +86,7 @@ func (h *TestGetFormHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	}
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
 	w.WriteHeader(200)
-	w.Write(body)
+	_, _ = w.Write(body)
 }
 
 func TestResponse(t *testing.T) {

--- a/lib/options.go
+++ b/lib/options.go
@@ -164,6 +164,9 @@ type Options struct {
 	Batch        null.Int `json:"batch" envconfig:"batch"`
 	BatchPerHost null.Int `json:"batchPerHost" envconfig:"batch_per_host"`
 
+	// Should all HTTP requests and responses be logged?
+	HttpDebug null.Bool `json:"httpDebug" envconfig:"http_debug"`
+
 	// Accept invalid or untrusted TLS certificates.
 	InsecureSkipTLSVerify null.Bool `json:"insecureSkipTLSVerify" envconfig:"insecure_skip_tls_verify"`
 
@@ -235,6 +238,9 @@ func (o Options) Apply(opts Options) Options {
 	}
 	if opts.BatchPerHost.Valid {
 		o.BatchPerHost = opts.BatchPerHost
+	}
+	if opts.HttpDebug.Valid {
+		o.HttpDebug = opts.HttpDebug
 	}
 	if opts.InsecureSkipTLSVerify.Valid {
 		o.InsecureSkipTLSVerify = opts.InsecureSkipTLSVerify

--- a/lib/options.go
+++ b/lib/options.go
@@ -164,8 +164,11 @@ type Options struct {
 	Batch        null.Int `json:"batch" envconfig:"batch"`
 	BatchPerHost null.Int `json:"batchPerHost" envconfig:"batch_per_host"`
 
-	// Should all HTTP requests and responses be logged?
+	// Should all HTTP requests and responses be logged (excluding body)?
 	HttpDebug null.Bool `json:"httpDebug" envconfig:"http_debug"`
+
+	// Should all HTTP requests and responses be logged (including body)?
+	HttpDebugFull null.Bool `json:"httpDebugFull" envconfig:"http_debug_full"`
 
 	// Accept invalid or untrusted TLS certificates.
 	InsecureSkipTLSVerify null.Bool `json:"insecureSkipTLSVerify" envconfig:"insecure_skip_tls_verify"`
@@ -241,6 +244,9 @@ func (o Options) Apply(opts Options) Options {
 	}
 	if opts.HttpDebug.Valid {
 		o.HttpDebug = opts.HttpDebug
+	}
+	if opts.HttpDebugFull.Valid {
+		o.HttpDebugFull = opts.HttpDebugFull
 	}
 	if opts.InsecureSkipTLSVerify.Valid {
 		o.InsecureSkipTLSVerify = opts.InsecureSkipTLSVerify

--- a/lib/options.go
+++ b/lib/options.go
@@ -165,10 +165,7 @@ type Options struct {
 	BatchPerHost null.Int `json:"batchPerHost" envconfig:"batch_per_host"`
 
 	// Should all HTTP requests and responses be logged (excluding body)?
-	HttpDebug null.Bool `json:"httpDebug" envconfig:"http_debug"`
-
-	// Should all HTTP requests and responses be logged (including body)?
-	HttpDebugFull null.Bool `json:"httpDebugFull" envconfig:"http_debug_full"`
+	HttpDebug null.String `json:"httpDebug" envconfig:"http_debug"`
 
 	// Accept invalid or untrusted TLS certificates.
 	InsecureSkipTLSVerify null.Bool `json:"insecureSkipTLSVerify" envconfig:"insecure_skip_tls_verify"`
@@ -244,9 +241,6 @@ func (o Options) Apply(opts Options) Options {
 	}
 	if opts.HttpDebug.Valid {
 		o.HttpDebug = opts.HttpDebug
-	}
-	if opts.HttpDebugFull.Valid {
-		o.HttpDebugFull = opts.HttpDebugFull
 	}
 	if opts.InsecureSkipTLSVerify.Valid {
 		o.InsecureSkipTLSVerify = opts.InsecureSkipTLSVerify


### PR DESCRIPTION
Implements logging of HTTP requests and responses (#331).

- Initial requests are logged with `Request:`
- Redirect responses are loggged with `RedirectResponse:`
- Redirect requests (new requests based on a redirect response) are logged with `RedirectRequest:`
- Eventual responses are logged with `Response:`

Currently `fmt.Printf` is used, instead of `state.logger.Infof` because the logger escapes the message (especially newlines), which makes it unusable.

@robingustafsson do you agree with this approach?

ToDo:
- Write tests?