### PR TITLE
cloud: support project selection 

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -119,7 +119,7 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 			name = filepath.Base(filename)
 		}
 
-		refID, err := client.StartCloudTestRun(name, arc)
+		refID, err := client.StartCloudTestRun(name, cloudConfig.ProjectID, arc)
 		if err != nil {
 			return err
 		}

--- a/stats/cloud/api.go
+++ b/stats/cloud/api.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"mime/multipart"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/loadimpact/k6/lib"
@@ -118,7 +119,7 @@ func (c *Client) PushMetric(referenceID string, noCompress bool, samples []*Samp
 	}
 }
 
-func (c *Client) StartCloudTestRun(name string, arc *lib.Archive) (string, error) {
+func (c *Client) StartCloudTestRun(name string, projectID int, arc *lib.Archive) (string, error) {
 	requestUrl := fmt.Sprintf("%s/archive-upload", c.baseURL)
 
 	var buf bytes.Buffer
@@ -126,6 +127,12 @@ func (c *Client) StartCloudTestRun(name string, arc *lib.Archive) (string, error
 
 	if err := mp.WriteField("name", name); err != nil {
 		return "", err
+	}
+
+	if projectID != 0 {
+		if err := mp.WriteField("project_id", strconv.Itoa(projectID)); err != nil {
+			return "", err
+		}
 	}
 
 	fw, err := mp.CreateFormFile("file", "archive.tar")

--- a/stats/cloud/config.go
+++ b/stats/cloud/config.go
@@ -29,7 +29,7 @@ type ConfigFields struct {
 	Name            string `json:"name" mapstructure:"name" envconfig:"CLOUD_NAME"`
 	Host            string `json:"host" mapstructure:"host" envconfig:"CLOUD_HOST"`
 	NoCompress      bool   `json:"no_compress" mapstructure:"no_compress" envconfig:"CLOUD_NO_COMPRESS"`
-	ProjectID       int    `json:"project_id" mapstructure:"project_id" envconfig:"CLOUD_PROJECT_ID"`
+	ProjectID       int    `json:"project_id" mapstructure:"projectID" envconfig:"CLOUD_PROJECT_ID"`
 	DeprecatedToken string `envconfig:"K6CLOUD_TOKEN"`
 }
 


### PR DESCRIPTION
Using in the script `projectID` or  environment variable `K6_CLOUD_PROJECT_ID`.

```
export let options = {
  vus: 40,
  duration: "10s",
  ext: {
    loadimpact: {
      name: 'Test name',
      projectID: 6
    }
  }
};
```