### PR TITLE
Cloud: support progress bar & aborting cloud test

### DIFF
--- a/stats/cloud/api.go
+++ b/stats/cloud/api.go
@@ -61,6 +61,13 @@ type CreateTestRunResponse struct {
 	ReferenceID string `json:"reference_id"`
 }
 
+type TestProgressResponse struct {
+	RunStatusText string  `json:"run_status_text"`
+	RunStatus     int     `json:"run_status"`
+	ResultStatus  int     `json:"result_status"`
+	Progress      float64 `json:"progress"`
+}
+
 type LoginResponse struct {
 	Token string `json:"token"`
 }
@@ -173,6 +180,33 @@ func (c *Client) TestFinished(referenceID string, thresholds ThresholdResult, ta
 	}
 
 	req, err := c.NewRequest("POST", url, data)
+	if err != nil {
+		return err
+	}
+
+	return c.Do(req, nil)
+}
+
+func (c *Client) GetTestProgress(referenceID string) (*TestProgressResponse, error) {
+	url := fmt.Sprintf("%s/test-progress/%s", c.baseURL, referenceID)
+	req, err := c.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ctrr := TestProgressResponse{}
+	err = c.Do(req, &ctrr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ctrr, nil
+}
+
+func (c *Client) StopCloudTestRun(referenceID string) error {
+	url := fmt.Sprintf("%s/tests/%s/stop", c.baseURL, referenceID)
+
+	req, err := c.NewRequest("POST", url, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Implements:

- a progress bar
- aborting cloud test (via CTRL+C)
- return a CLI error if the test result has failed

![screen shot 2018-01-26 at 15 52 47](https://user-images.githubusercontent.com/825430/35445027-9f8fc686-02b0-11e8-8f2d-7bd229c60859.png)
![screen shot 2018-01-26 at 15 52 39](https://user-images.githubusercontent.com/825430/35445029-9fac7da8-02b0-11e8-9f69-74df006e2173.png)

WIP - The PR is pending for the backend to be ready.