### PR TITLE
Overriding DNS

### DIFF
--- a/js/runner.go
+++ b/js/runner.go
@@ -21,7 +21,6 @@
 package js
 
 import (
-	"container/ring"
 	"context"
 	"crypto/tls"
 	"net"
@@ -137,21 +136,11 @@ func (r *Runner) newVU() (*VU, error) {
 		}
 	}
 
-	hosts := map[string]*ring.Ring{}
-	for host, ips := range r.Bundle.Options.Hosts {
-		hosts[host] = ring.New(len(ips))
-
-		for i := 0; i < len(ips); i++ {
-			hosts[host].Value = ips[i]
-			hosts[host] = hosts[host].Next()
-		}
-	}
-
 	dialer := &netext.Dialer{
 		Dialer:    r.BaseDialer,
 		Resolver:  r.Resolver,
 		Blacklist: r.Bundle.Options.BlacklistIPs,
-		Hosts:     hosts,
+		Hosts:     r.Bundle.Options.Hosts,
 	}
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -528,7 +528,7 @@ func TestVUIntegrationHosts(t *testing.T) {
 		NoConnectionReuse: null.BoolFrom(true),
 		Throw:             null.BoolFrom(true),
 		Hosts: map[string][]net.IP{
-			"test.loadimpact.com": []net.IP{ips[0], ips[1]},
+			"test.loadimpact.com": {ips[0], ips[1]},
 		},
 	})
 

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -477,6 +477,87 @@ func TestVUIntegrationBlacklist(t *testing.T) {
 	}
 }
 
+func TestVUIntegrationHosts(t *testing.T) {
+	srv := &http.Server{
+		Addr: ":8080",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			_, _ = fmt.Fprintf(w, "ok")
+		}),
+		ErrorLog: stdlog.New(ioutil.Discard, "", 0),
+	}
+	go srv.ListenAndServe()
+	defer srv.Shutdown(context.TODO())
+
+	// Getting local ip addresses to assert
+	addrs, err := net.InterfaceAddrs()
+	if !assert.NoError(t, err) {
+		return
+	}
+	ips := []net.IP{}
+	for _, address := range addrs {
+		if ipnet, ok := address.(*net.IPNet); ok {
+			if ipnet.IP.To4() != nil {
+				ips = append(ips, ipnet.IP)
+			}
+		}
+	}
+
+	r1, err := New(&lib.SourceData{
+		Filename: "/script.js",
+		Data: []byte(fmt.Sprintf(`
+					import { check, fail } from "k6";
+					import http from "k6/http";
+					let ips = [];
+					export default function() {
+						let res = http.get("http://test.loadimpact.com:8080/");
+						ips.push(res.remote_ip)
+
+						if (ips.length === 2) {
+							check(ips, {
+								"is correct IP": (ips) => ips.toString() == ["%s", "%s"].toString()
+							}) || fail("failed to override dns");
+						}
+					}
+				`, ips[1].String(), ips[0].String())),
+	}, afero.NewMemMapFs())
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	r1.SetOptions(lib.Options{
+		NoConnectionReuse: null.BoolFrom(true),
+		Throw:             null.BoolFrom(true),
+		Hosts: map[string][]net.IP{
+			"test.loadimpact.com": []net.IP{ips[0], ips[1]},
+		},
+	})
+
+	r2, err := NewFromArchive(r1.MakeArchive())
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	runners := map[string]*Runner{"Source": r1, "Archive": r2}
+	for name, r := range runners {
+		t.Run(name, func(t *testing.T) {
+			vu, err := r.NewVU()
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			//Running VU twice to assert each ip
+			_, err = vu.RunOnce(context.Background())
+			if !assert.NoError(t, err) {
+				return
+			}
+			_, err = vu.RunOnce(context.Background())
+			if !assert.NoError(t, err) {
+				return
+			}
+		})
+	}
+}
+
 func TestVUIntegrationTLSConfig(t *testing.T) {
 	testdata := map[string]struct {
 		opts   lib.Options

--- a/lib/netext/dialer.go
+++ b/lib/netext/dialer.go
@@ -21,7 +21,6 @@
 package netext
 
 import (
-	"container/ring"
 	"context"
 	"net"
 	"strings"
@@ -36,7 +35,7 @@ type Dialer struct {
 
 	Resolver  *dnscache.Resolver
 	Blacklist []*net.IPNet
-	Hosts     map[string]*ring.Ring
+	Hosts     map[string]net.IP
 
 	BytesRead    *int64
 	BytesWritten *int64
@@ -53,12 +52,9 @@ func (d *Dialer) DialContext(ctx context.Context, proto, addr string) (net.Conn,
 	delimiter := strings.LastIndex(addr, ":")
 	host := addr[:delimiter]
 
-	// lookup for domain defined in Hosts options before trying to solve DNS.
-	var ip net.IP
-	if _, ok := d.Hosts[host]; ok {
-		d.Hosts[host] = d.Hosts[host].Next()
-		ip = d.Hosts[host].Value.(net.IP)
-	} else {
+	// lookup for domain defined in Hosts option before trying to resolve DNS.
+	ip, ok := d.Hosts[host]
+	if !ok {
 		var err error
 		ip, err = d.Resolver.FetchOne(host)
 		if err != nil {

--- a/lib/options.go
+++ b/lib/options.go
@@ -184,7 +184,7 @@ type Options struct {
 	BlacklistIPs []*net.IPNet `json:"blacklistIPs" envconfig:"blacklist_ips"`
 
 	// Hosts overrides dns entries for given hosts
-	Hosts map[string][]net.IP `json:"hosts" envconfig:"hosts"`
+	Hosts map[string]net.IP `json:"hosts" envconfig:"hosts"`
 
 	// Do not reuse connections between VU iterations. This gives more realistic results (depending
 	// on what you're looking for), but you need to raise various kernel limits or you'll get

--- a/lib/options.go
+++ b/lib/options.go
@@ -183,6 +183,9 @@ type Options struct {
 	// Blacklist IP ranges that tests may not contact. Mainly useful in hosted setups.
 	BlacklistIPs []*net.IPNet `json:"blacklistIPs" envconfig:"blacklist_ips"`
 
+	// Hosts overrides dns entries for given hosts
+	Hosts map[string][]net.IP `json:"hosts" envconfig:"hosts"`
+
 	// Do not reuse connections between VU iterations. This gives more realistic results (depending
 	// on what you're looking for), but you need to raise various kernel limits or you'll get
 	// errors about running out of file handles or sockets, or being unable to bind addresses.
@@ -256,6 +259,9 @@ func (o Options) Apply(opts Options) Options {
 	}
 	if opts.BlacklistIPs != nil {
 		o.BlacklistIPs = opts.BlacklistIPs
+	}
+	if opts.Hosts != nil {
+		o.Hosts = opts.Hosts
 	}
 	if opts.NoConnectionReuse.Valid {
 		o.NoConnectionReuse = opts.NoConnectionReuse

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -200,7 +200,7 @@ func TestOptions(t *testing.T) {
 
 	t.Run("Hosts", func(t *testing.T) {
 		opts := Options{}.Apply(Options{Hosts: map[string][]net.IP{
-			"test.loadimpact.com": []net.IP{net.ParseIP("192.0.2.1")},
+			"test.loadimpact.com": {net.ParseIP("192.0.2.1")},
 		}})
 		assert.NotNil(t, opts.Hosts)
 		assert.NotEmpty(t, opts.Hosts)

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -199,12 +199,12 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("Hosts", func(t *testing.T) {
-		opts := Options{}.Apply(Options{Hosts: map[string][]net.IP{
-			"test.loadimpact.com": {net.ParseIP("192.0.2.1")},
+		opts := Options{}.Apply(Options{Hosts: map[string]net.IP{
+			"test.loadimpact.com": net.ParseIP("192.0.2.1"),
 		}})
 		assert.NotNil(t, opts.Hosts)
 		assert.NotEmpty(t, opts.Hosts)
-		assert.Equal(t, "192.0.2.1", opts.Hosts["test.loadimpact.com"][0].String())
+		assert.Equal(t, "192.0.2.1", opts.Hosts["test.loadimpact.com"].String())
 	})
 
 	t.Run("Thresholds", func(t *testing.T) {

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -23,6 +23,7 @@ package lib
 import (
 	"crypto/tls"
 	"encoding/json"
+	"net"
 	"os"
 	"reflect"
 	"testing"
@@ -196,6 +197,16 @@ func TestOptions(t *testing.T) {
 		assert.True(t, opts.NoConnectionReuse.Valid)
 		assert.True(t, opts.NoConnectionReuse.Bool)
 	})
+
+	t.Run("Hosts", func(t *testing.T) {
+		opts := Options{}.Apply(Options{Hosts: map[string][]net.IP{
+			"test.loadimpact.com": []net.IP{net.ParseIP("192.0.2.1")},
+		}})
+		assert.NotNil(t, opts.Hosts)
+		assert.NotEmpty(t, opts.Hosts)
+		assert.Equal(t, "192.0.2.1", opts.Hosts["test.loadimpact.com"][0].String())
+	})
+
 	t.Run("Thresholds", func(t *testing.T) {
 		opts := Options{}.Apply(Options{Thresholds: map[string]stats.Thresholds{
 			"metric": {


### PR DESCRIPTION
This PR closes #474. Adds the option to override DNS lookup with a specific array of IPs. 

Although I implemented the option of passing multiple IPs per domain, I'm not entirely sure if that is the best options for some reasons:

- If we consider @markingman needs, I think the option using environment variables that @robingustafsson gave it is a much better approach, once it makes easier to compare the results and there is no need to change the code to do that.
- Using multiples IPs per domain implies in required use of *noConnectionReuse*. Otherwise, the IP will be selected only in the first iteration of each VU.
- Using only one IP, we match the user experience of /etc/hosts.
- If one need to test multiple servers at once, it will probably put all those servers behind a load balancer instead of using various IPs per domain. 

So, I would like to ask if there is something important that I might be missing. Otherwise, I will advise for not letting the options of multiple IPs and follow with the simplest one, and set only one IP per domain.