### PR TITLE
Add CLI flags to set environment variables

### DIFF
--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -94,7 +94,8 @@ An archive is a fully self-contained test run, and can be executed identically e
 
 func init() {
 	RootCmd.AddCommand(archiveCmd)
+	archiveCmd.Flags().SortFlags = false
 	archiveCmd.Flags().AddFlagSet(optionFlagSet())
-	archiveCmd.Flags().AddFlagSet(runtimeOptionFlagSet())
+	archiveCmd.Flags().AddFlagSet(runtimeOptionFlagSet(false))
 	archiveCmd.Flags().StringVarP(&archiveOut, "archive-out", "O", archiveOut, "archive output filename")
 }

--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -34,12 +34,12 @@ var archiveCmd = &cobra.Command{
 	Use:   "archive",
 	Short: "Create an archive",
 	Long: `Create an archive.
-	 
+
 An archive is a fully self-contained test run, and can be executed identically elsewhere.`,
 	Example: `
   # Archive a test run.
   k6 archive -u 10 -d 10s -O myarchive.tar script.js
-  
+
   # Run the resulting archive.
   k6 run myarchive.tar`[1:],
 	Args: cobra.ExactArgs(1),
@@ -55,7 +55,13 @@ An archive is a fully self-contained test run, and can be executed identically e
 		if err != nil {
 			return err
 		}
-		r, err := newRunner(src, runType, afero.NewOsFs())
+
+		runtimeOptions, err := getRuntimeOptions(cmd.Flags())
+		if err != nil {
+			return err
+		}
+
+		r, err := newRunner(src, runType, afero.NewOsFs(), runtimeOptions)
 		if err != nil {
 			return err
 		}
@@ -89,5 +95,6 @@ An archive is a fully self-contained test run, and can be executed identically e
 func init() {
 	RootCmd.AddCommand(archiveCmd)
 	archiveCmd.Flags().AddFlagSet(optionFlagSet())
+	archiveCmd.Flags().AddFlagSet(runtimeOptionFlagSet())
 	archiveCmd.Flags().StringVarP(&archiveOut, "archive-out", "O", archiveOut, "archive output filename")
 }

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -141,6 +141,7 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 
 func init() {
 	RootCmd.AddCommand(cloudCmd)
+	cloudCmd.Flags().SortFlags = false
 	cloudCmd.Flags().AddFlagSet(optionFlagSet())
-	cloudCmd.Flags().AddFlagSet(runtimeOptionFlagSet())
+	cloudCmd.Flags().AddFlagSet(runtimeOptionFlagSet(false))
 }

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -60,7 +60,12 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 			return err
 		}
 
-		r, err := newRunner(src, runType, afero.NewOsFs())
+		runtimeOptions, err := getRuntimeOptions(cmd.Flags())
+		if err != nil {
+			return err
+		}
+
+		r, err := newRunner(src, runType, afero.NewOsFs(), runtimeOptions)
 		if err != nil {
 			return err
 		}
@@ -137,4 +142,5 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 func init() {
 	RootCmd.AddCommand(cloudCmd)
 	cloudCmd.Flags().AddFlagSet(optionFlagSet())
+	cloudCmd.Flags().AddFlagSet(runtimeOptionFlagSet())
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -54,6 +54,11 @@ var inspectCmd = &cobra.Command{
 			typ = detectType(src.Data)
 		}
 
+		runtimeOptions, err := getRuntimeOptions(cmd.Flags())
+		if err != nil {
+			return err
+		}
+
 		var opts lib.Options
 		switch typ {
 		case typeArchive:
@@ -61,10 +66,13 @@ var inspectCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			opts = arc.Options
+			b, err := js.NewBundleFromArchive(arc, runtimeOptions)
+			if err != nil {
+				return err
+			}
+			opts = b.Options
 		case typeJS:
-			//TODO: also accept CLI env vars? they can influence the JS init and options
-			b, err := js.NewBundle(src, fs, lib.RuntimeOptions{})
+			b, err := js.NewBundle(src, fs, runtimeOptions)
 			if err != nil {
 				return err
 			}
@@ -82,5 +90,7 @@ var inspectCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(inspectCmd)
+	inspectCmd.Flags().SortFlags = false
+	inspectCmd.Flags().AddFlagSet(runtimeOptionFlagSet(false))
 	inspectCmd.Flags().StringVarP(&runType, "type", "t", runType, "override file `type`, \"js\" or \"archive\"")
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -63,7 +63,8 @@ var inspectCmd = &cobra.Command{
 			}
 			opts = arc.Options
 		case typeJS:
-			b, err := js.NewBundle(src, fs)
+			//TODO: also accept CLI env vars? they can influence the JS init and options
+			b, err := js.NewBundle(src, fs, lib.RuntimeOptions{})
 			if err != nil {
 				return err
 			}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -414,7 +414,7 @@ func init() {
 
 	runCmd.Flags().SortFlags = false
 	runCmd.Flags().AddFlagSet(optionFlagSet())
-	runCmd.Flags().AddFlagSet(runtimeOptionFlagSet())
+	runCmd.Flags().AddFlagSet(runtimeOptionFlagSet(true))
 	runCmd.Flags().AddFlagSet(configFlagSet())
 	runCmd.Flags().StringVarP(&runType, "type", "t", runType, "override file `type`, \"js\" or \"archive\"")
 }

--- a/cmd/runtime_options.go
+++ b/cmd/runtime_options.go
@@ -59,6 +59,7 @@ func runtimeOptionFlagSet() *pflag.FlagSet {
 func getRuntimeOptions(flags *pflag.FlagSet) (lib.RuntimeOptions, error) {
 	opts := lib.RuntimeOptions{
 		NoSystemEnvVars: getNullBool(flags, "no-system-env-vars"),
+		Env:             make(map[string]string),
 	}
 
 	// If not disabled, gather the actual system environment variables
@@ -72,11 +73,6 @@ func getRuntimeOptions(flags *pflag.FlagSet) (lib.RuntimeOptions, error) {
 		return opts, err
 	}
 	if len(envVars) > 0 {
-		// Initialize opts.Env if NoSystemEnvVars was enabled
-		if opts.Env == nil {
-			opts.Env = make(map[string]string)
-		}
-
 		for _, kv := range envVars {
 			k, v := parseEnvKeyValue(kv)
 			// Allow only alphanumeric ASCII variable names for now

--- a/cmd/runtime_options.go
+++ b/cmd/runtime_options.go
@@ -48,26 +48,26 @@ func collectEnv() map[string]string {
 	return env
 }
 
-func runtimeOptionFlagSet() *pflag.FlagSet {
+func runtimeOptionFlagSet(includeSysEnv bool) *pflag.FlagSet {
 	flags := pflag.NewFlagSet("", 0)
 	flags.SortFlags = false
-	flags.Bool("no-system-env-vars", false, "don't pass actual system environment variables to the runtime")
+	flags.Bool("include-system-env-vars", includeSysEnv, "pass the real system environment variables to the runtime")
 	flags.StringSliceP("env", "e", nil, "add/override environment variable with `VAR=value`")
 	return flags
 }
 
 func getRuntimeOptions(flags *pflag.FlagSet) (lib.RuntimeOptions, error) {
 	opts := lib.RuntimeOptions{
-		NoSystemEnvVars: getNullBool(flags, "no-system-env-vars"),
-		Env:             make(map[string]string),
+		IncludeSystemEnvVars: getNullBool(flags, "include-system-env-vars"),
+		Env:                  make(map[string]string),
 	}
 
-	// If not disabled, gather the actual system environment variables
-	if !opts.NoSystemEnvVars.Bool {
+	// If enabled, gather the actual system environment variables
+	if opts.IncludeSystemEnvVars.Bool {
 		opts.Env = collectEnv()
 	}
 
-	// Set/overwrite environment varialbes with custom user-supplied values
+	// Set/overwrite environment variables with custom user-supplied values
 	envVars, err := flags.GetStringSlice("env")
 	if err != nil {
 		return opts, err

--- a/cmd/runtime_options.go
+++ b/cmd/runtime_options.go
@@ -1,0 +1,91 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2018 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package cmd
+
+import (
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/loadimpact/k6/lib"
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+)
+
+var userEnvVarName = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+func parseEnvKeyValue(kv string) (string, string) {
+	if idx := strings.IndexRune(kv, '='); idx != -1 {
+		return kv[:idx], kv[idx+1:]
+	}
+	return kv, ""
+}
+
+func collectEnv() map[string]string {
+	env := make(map[string]string)
+	for _, kv := range os.Environ() {
+		k, v := parseEnvKeyValue(kv)
+		env[k] = v
+	}
+	return env
+}
+
+func runtimeOptionFlagSet() *pflag.FlagSet {
+	flags := pflag.NewFlagSet("", 0)
+	flags.SortFlags = false
+	flags.Bool("no-system-env-vars", false, "don't pass actual system environment variables to the runtime")
+	flags.StringSliceP("env", "e", nil, "add/override environment variable with `VAR=value`")
+	return flags
+}
+
+func getRuntimeOptions(flags *pflag.FlagSet) (lib.RuntimeOptions, error) {
+	opts := lib.RuntimeOptions{
+		NoSystemEnvVars: getNullBool(flags, "no-system-env-vars"),
+	}
+
+	// If not disabled, gather the actual system environment variables
+	if !opts.NoSystemEnvVars.Bool {
+		opts.Env = collectEnv()
+	}
+
+	// Set/overwrite environment varialbes with custom user-supplied values
+	envVars, err := flags.GetStringSlice("env")
+	if err != nil {
+		return opts, err
+	}
+	if len(envVars) > 0 {
+		// Initialize opts.Env if NoSystemEnvVars was enabled
+		if opts.Env == nil {
+			opts.Env = make(map[string]string)
+		}
+
+		for _, kv := range envVars {
+			k, v := parseEnvKeyValue(kv)
+			// Allow only alphanumeric ASCII variable names for now
+			if !userEnvVarName.MatchString(k) {
+				return opts, errors.Errorf("Invalid environment variable name '%s'", k)
+			}
+			opts.Env[k] = v
+		}
+	}
+
+	return opts, nil
+}

--- a/cmd/runtime_options_test.go
+++ b/cmd/runtime_options_test.go
@@ -1,0 +1,29 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2018 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package cmd
+
+//TODO: write an end-to-end test that sets real environment variables and does
+// something like TestBundleEnv in js/bundle_test.go
+
+//TODO: write tests for passing environment variables with wrong names
+
+//TODO: wirte tests to check for correct option and env var overriding
+

--- a/cmd/runtime_options_test.go
+++ b/cmd/runtime_options_test.go
@@ -130,7 +130,7 @@ func TestEnvVars(t *testing.T) {
 			require.NoError(t, err)
 			require.EqualValues(t, tc.expEnv, rtOpts.Env)
 
-			// Clear the env again so real system values don't accidentally polute the end-to-end test
+			// Clear the env again so real system values don't accidentally pollute the end-to-end test
 			os.Clearenv()
 
 			jsCode := "export default function() {\n"

--- a/cmd/runtime_options_test.go
+++ b/cmd/runtime_options_test.go
@@ -20,10 +20,155 @@
 
 package cmd
 
-//TODO: write an end-to-end test that sets real environment variables and does
-// something like TestBundleEnv in js/bundle_test.go
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
 
-//TODO: write tests for passing environment variables with wrong names
+	"github.com/loadimpact/k6/lib"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
 
-//TODO: wirte tests to check for correct option and env var overriding
+type EnvVarTest struct {
+	name      string
+	systemEnv map[string]string
+	cliOpts   []string
+	expErr    bool
+	expEnv    map[string]string
+}
 
+var envVarTestCases = []EnvVarTest{
+	{
+		"empty env",
+		map[string]string{},
+		[]string{},
+		false,
+		map[string]string{},
+	},
+	{
+		"disabled sys env",
+		map[string]string{"test1": "val1"},
+		[]string{"--no-system-env-vars"},
+		false,
+		map[string]string{},
+	},
+	{
+		"only system env",
+		map[string]string{"test1": "val1"},
+		[]string{},
+		false,
+		map[string]string{"test1": "val1"},
+	},
+	{
+		"mixed system and cli env",
+		map[string]string{"test1": "val1", "test2": ""},
+		[]string{"--env", "test3=val3", "-e", "test4", "-e", "test5="},
+		false,
+		map[string]string{"test1": "val1", "test2": "", "test3": "val3", "test4": "", "test5": ""},
+	},
+	{
+		"disabled system env with cli params",
+		map[string]string{"test1": "val1"},
+		[]string{"-e", "test2=overwriten", "-e", "test2=val2", "--no-system-env-vars"},
+		false,
+		map[string]string{"test2": "val2"},
+	},
+	{
+		"overwriting system env with cli param",
+		map[string]string{"test1": "val1sys"},
+		[]string{"--env", "test1=val1cli"},
+		false,
+		map[string]string{"test1": "val1cli"},
+	},
+	{
+		"error invalid cli var name 1",
+		map[string]string{},
+		[]string{"--env", "test a=error"},
+		true,
+		map[string]string{},
+	},
+	{
+		"error invalid cli var name 2",
+		map[string]string{},
+		[]string{"--env", "1var=error"},
+		true,
+		map[string]string{},
+	},
+	{
+		"error invalid cli var name 3",
+		map[string]string{},
+		[]string{"--env", "уникод=unicode-disabled"},
+		true,
+		map[string]string{},
+	},
+	{
+		"valid env vars with spaces",
+		map[string]string{"test1": "value 1"},
+		[]string{"--env", "test2=value 2"},
+		false,
+		map[string]string{"test1": "value 1", "test2": "value 2"},
+	},
+}
+
+func TestEnvVars(t *testing.T) {
+	for _, tc := range envVarTestCases {
+		t.Run(fmt.Sprintf("EnvVar test '%s'", tc.name), func(t *testing.T) {
+			os.Clearenv()
+			for key, val := range tc.systemEnv {
+				require.NoError(t, os.Setenv(key, val))
+			}
+			flags := runtimeOptionFlagSet()
+			require.NoError(t, flags.Parse(tc.cliOpts))
+
+			rtOpts, err := getRuntimeOptions(flags)
+			if tc.expErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.EqualValues(t, tc.expEnv, rtOpts.Env)
+
+			// Clear the env again so real system values don't accidentally polute the end-to-end test
+			os.Clearenv()
+
+			jsCode := "export default function() {\n"
+			for key, val := range tc.expEnv {
+				jsCode += fmt.Sprintf(
+					"if (__ENV.%s !== '%s') { throw new Error('Invalid %s: ' + __ENV.%s); }\n",
+					key, val, key, key,
+				)
+			}
+			jsCode += "}"
+
+			runner, err := newRunner(
+				&lib.SourceData{
+					Data:     []byte(jsCode),
+					Filename: "/script.js",
+				},
+				typeJS,
+				afero.NewOsFs(),
+				rtOpts,
+			)
+			require.NoError(t, err)
+
+			archive := runner.MakeArchive()
+			archiveBuf := &bytes.Buffer{}
+			archive.Write(archiveBuf)
+
+			_, err = newRunner(
+				&lib.SourceData{
+					Data:     []byte(archiveBuf.Bytes()),
+					Filename: "/script.tar",
+				},
+				typeArchive,
+				afero.NewOsFs(),
+				lib.RuntimeOptions{}, // Empty runtime options!
+			)
+			require.NoError(t, err)
+
+			//TODO: write test when the runner overwrites some env vars in the archive?
+		})
+	}
+}

--- a/converter/har/converter_test.go
+++ b/converter/har/converter_test.go
@@ -59,7 +59,7 @@ func TestBuildK6RequestObject(t *testing.T) {
 	_, err = js.New(&lib.SourceData{
 		Filename: "/script.js",
 		Data:     []byte(fmt.Sprintf("export default function() { res = http.batch([%v]); }", v)),
-	}, afero.NewMemMapFs())
+	}, afero.NewMemMapFs(), lib.RuntimeOptions{})
 	assert.NoError(t, err)
 }
 

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -6,5 +6,6 @@
 		"ineffassign", "interfacer", "unconvert",
 		"goconst", "gosimple", "staticcheck",
 		"misspell"
-	]
+	],
+	"Exclude": ["/usr/local/go/src", "/go/src"]
 }

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -23,8 +23,6 @@ package js
 import (
 	"context"
 	"encoding/json"
-	"os"
-	"strings"
 
 	"github.com/dop251/goja"
 	"github.com/loadimpact/k6/js/common"
@@ -56,20 +54,8 @@ type BundleInstance struct {
 	Default goja.Callable
 }
 
-func collectEnv() map[string]string {
-	env := make(map[string]string)
-	for _, kv := range os.Environ() {
-		if idx := strings.IndexRune(kv, '='); idx != -1 {
-			env[kv[:idx]] = kv[idx+1:]
-		} else {
-			env[kv] = ""
-		}
-	}
-	return env
-}
-
 // Creates a new bundle from a source file and a filesystem.
-func NewBundle(src *lib.SourceData, fs afero.Fs) (*Bundle, error) {
+func NewBundle(src *lib.SourceData, fs afero.Fs, rtOpts lib.RuntimeOptions) (*Bundle, error) {
 	// Compile sources, both ES5 and ES6 are supported.
 	code := string(src.Data)
 	pgm, _, err := compiler.Compile(code, src.Filename, "", "", true)
@@ -91,7 +77,7 @@ func NewBundle(src *lib.SourceData, fs afero.Fs) (*Bundle, error) {
 		Source:          code,
 		Program:         pgm,
 		BaseInitContext: NewInitContext(rt, new(context.Context), fs, loader.Dir(src.Filename)),
-		Env:             collectEnv(),
+		Env:             rtOpts.Env,
 	}
 	if err := bundle.instantiate(rt, bundle.BaseInitContext); err != nil {
 		return nil, err
@@ -131,7 +117,7 @@ func NewBundle(src *lib.SourceData, fs afero.Fs) (*Bundle, error) {
 	return &bundle, nil
 }
 
-func NewBundleFromArchive(arc *lib.Archive) (*Bundle, error) {
+func NewBundleFromArchive(arc *lib.Archive, rtOpts lib.RuntimeOptions) (*Bundle, error) {
 	if arc.Type != "js" {
 		return nil, errors.Errorf("expected bundle type 'js', got '%s'", arc.Type)
 	}
@@ -158,7 +144,7 @@ func NewBundleFromArchive(arc *lib.Archive) (*Bundle, error) {
 		Program:         pgm,
 		Options:         arc.Options,
 		BaseInitContext: initctx,
-		Env:             collectEnv(),
+		Env:             rtOpts.Env, //TODO: use Env from archive (and apply the rtOpts.Env?)
 	}, nil
 }
 

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -144,7 +144,7 @@ func NewBundleFromArchive(arc *lib.Archive, rtOpts lib.RuntimeOptions) (*Bundle,
 		Program:         pgm,
 		Options:         arc.Options,
 		BaseInitContext: initctx,
-		Env:             rtOpts.Env, //TODO: use Env from archive (and apply the rtOpts.Env?)
+		Env:             arc.Env, //TODO: if set, overwrite some options via rtOpts.Env?
 	}, nil
 }
 
@@ -155,6 +155,7 @@ func (b *Bundle) MakeArchive() *lib.Archive {
 		Filename: b.Filename,
 		Data:     []byte(b.Source),
 		Pwd:      b.BaseInitContext.pwd,
+		Env:      b.Env,
 	}
 
 	arc.Scripts = make(map[string][]byte, len(b.BaseInitContext.programs))

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -138,13 +138,18 @@ func NewBundleFromArchive(arc *lib.Archive, rtOpts lib.RuntimeOptions) (*Bundle,
 	}
 	initctx.files = arc.Files
 
+	env := arc.Env
+	for k, v := range rtOpts.Env {
+		env[k] = v
+	}
+
 	return &Bundle{
 		Filename:        arc.Filename,
 		Source:          string(arc.Data),
 		Program:         pgm,
 		Options:         arc.Options,
 		BaseInitContext: initctx,
-		Env:             arc.Env, //TODO: if set, overwrite some options via rtOpts.Env?
+		Env:             env,
 	}, nil
 }
 

--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -34,74 +34,52 @@ import (
 	"gopkg.in/guregu/null.v3"
 )
 
+func getSimpleBundle(filename, data string) (*Bundle, error) {
+	return NewBundle(
+		&lib.SourceData{
+			Filename: filename,
+			Data:     []byte(data),
+		},
+		afero.NewMemMapFs(),
+		lib.RuntimeOptions{},
+	)
+}
+
 func TestNewBundle(t *testing.T) {
 	t.Run("Blank", func(t *testing.T) {
-		_, err := NewBundle(&lib.SourceData{
-			Filename: "/script.js",
-			Data:     []byte(``),
-		}, afero.NewMemMapFs())
+		_, err := getSimpleBundle("/script.js", "")
 		assert.EqualError(t, err, "script must export a default function")
 	})
 	t.Run("Invalid", func(t *testing.T) {
-		_, err := NewBundle(&lib.SourceData{
-			Filename: "/script.js",
-			Data:     []byte{0x00},
-		}, afero.NewMemMapFs())
+		_, err := getSimpleBundle("/script.js", "\x00")
 		assert.EqualError(t, err, "SyntaxError: /script.js: Unexpected character '\x00' (1:0)\n> 1 | \x00\n    | ^ at <eval>:2:26853(114)")
 	})
 	t.Run("Error", func(t *testing.T) {
-		_, err := NewBundle(&lib.SourceData{
-			Filename: "/script.js",
-			Data:     []byte(`throw new Error("aaaa");`),
-		}, afero.NewMemMapFs())
+		_, err := getSimpleBundle("/script.js", `throw new Error("aaaa");`)
 		assert.EqualError(t, err, "Error: aaaa at /script.js:1:7(3)")
 	})
 	t.Run("InvalidExports", func(t *testing.T) {
-		_, err := NewBundle(&lib.SourceData{
-			Filename: "/script.js",
-			Data:     []byte(`exports = null`),
-		}, afero.NewMemMapFs())
+		_, err := getSimpleBundle("/script.js", `exports = null`)
 		assert.EqualError(t, err, "exports must be an object")
 	})
 	t.Run("DefaultUndefined", func(t *testing.T) {
-		_, err := NewBundle(&lib.SourceData{
-			Filename: "/script.js",
-			Data: []byte(`
-				export default undefined;
-			`),
-		}, afero.NewMemMapFs())
+		_, err := getSimpleBundle("/script.js", `export default undefined;`)
 		assert.EqualError(t, err, "script must export a default function")
 	})
 	t.Run("DefaultNull", func(t *testing.T) {
-		_, err := NewBundle(&lib.SourceData{
-			Filename: "/script.js",
-			Data: []byte(`
-				export default null;
-			`),
-		}, afero.NewMemMapFs())
+		_, err := getSimpleBundle("/script.js", `export default null;`)
 		assert.EqualError(t, err, "script must export a default function")
 	})
 	t.Run("DefaultWrongType", func(t *testing.T) {
-		_, err := NewBundle(&lib.SourceData{
-			Filename: "/script.js",
-			Data: []byte(`
-				export default 12345;
-			`),
-		}, afero.NewMemMapFs())
+		_, err := getSimpleBundle("/script.js", `export default 12345;`)
 		assert.EqualError(t, err, "default export must be a function")
 	})
 	t.Run("Minimal", func(t *testing.T) {
-		_, err := NewBundle(&lib.SourceData{
-			Filename: "/script.js",
-			Data:     []byte(`export default function() {};`),
-		}, afero.NewMemMapFs())
+		_, err := getSimpleBundle("/script.js", `export default function() {};`)
 		assert.NoError(t, err)
 	})
 	t.Run("stdin", func(t *testing.T) {
-		b, err := NewBundle(&lib.SourceData{
-			Filename: "-",
-			Data:     []byte(`export default function() {};`),
-		}, afero.NewMemMapFs())
+		b, err := getSimpleBundle("-", `export default function() {};`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "-", b.Filename)
 			assert.Equal(t, "/", b.BaseInitContext.pwd)
@@ -109,13 +87,10 @@ func TestNewBundle(t *testing.T) {
 	})
 	t.Run("Options", func(t *testing.T) {
 		t.Run("Empty", func(t *testing.T) {
-			_, err := NewBundle(&lib.SourceData{
-				Filename: "/script.js",
-				Data: []byte(`
-					export let options = {};
-					export default function() {};
-				`),
-			}, afero.NewMemMapFs())
+			_, err := getSimpleBundle("/script.js", `
+				export let options = {};
+				export default function() {};
+			`)
 			assert.NoError(t, err)
 		})
 		t.Run("Invalid", func(t *testing.T) {
@@ -127,114 +102,90 @@ func TestNewBundle(t *testing.T) {
 			}
 			for name, data := range invalidOptions {
 				t.Run(name, func(t *testing.T) {
-					_, err := NewBundle(&lib.SourceData{
-						Filename: "/script.js",
-						Data: []byte(fmt.Sprintf(`
-							export let options = %s;
-							export default function() {};
-						`, data.Expr)),
-					}, afero.NewMemMapFs())
+					_, err := getSimpleBundle("/script.js", fmt.Sprintf(`
+						export let options = %s;
+						export default function() {};
+					`, data.Expr))
 					assert.EqualError(t, err, data.Error)
 				})
 			}
 		})
 
 		t.Run("Paused", func(t *testing.T) {
-			b, err := NewBundle(&lib.SourceData{
-				Filename: "/script.js",
-				Data: []byte(`
-					export let options = {
-						paused: true,
-					};
-					export default function() {};
-				`),
-			}, afero.NewMemMapFs())
+			b, err := getSimpleBundle("/script.js", `
+				export let options = {
+					paused: true,
+				};
+				export default function() {};
+			`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, null.BoolFrom(true), b.Options.Paused)
 			}
 		})
 		t.Run("VUs", func(t *testing.T) {
-			b, err := NewBundle(&lib.SourceData{
-				Filename: "/script.js",
-				Data: []byte(`
-					export let options = {
-						vus: 100,
-					};
-					export default function() {};
-				`),
-			}, afero.NewMemMapFs())
+			b, err := getSimpleBundle("/script.js", `
+				export let options = {
+					vus: 100,
+				};
+				export default function() {};
+			`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, null.IntFrom(100), b.Options.VUs)
 			}
 		})
 		t.Run("VUsMax", func(t *testing.T) {
-			b, err := NewBundle(&lib.SourceData{
-				Filename: "/script.js",
-				Data: []byte(`
-					export let options = {
-						vusMax: 100,
-					};
-					export default function() {};
-				`),
-			}, afero.NewMemMapFs())
+			b, err := getSimpleBundle("/script.js", `
+				export let options = {
+					vusMax: 100,
+				};
+				export default function() {};
+			`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, null.IntFrom(100), b.Options.VUsMax)
 			}
 		})
 		t.Run("Duration", func(t *testing.T) {
-			b, err := NewBundle(&lib.SourceData{
-				Filename: "/script.js",
-				Data: []byte(`
-					export let options = {
-						duration: "10s",
-					};
-					export default function() {};
-				`),
-			}, afero.NewMemMapFs())
+			b, err := getSimpleBundle("/script.js", `
+				export let options = {
+					duration: "10s",
+				};
+				export default function() {};
+			`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, lib.NullDurationFrom(10*time.Second), b.Options.Duration)
 			}
 		})
 		t.Run("Iterations", func(t *testing.T) {
-			b, err := NewBundle(&lib.SourceData{
-				Filename: "/script.js",
-				Data: []byte(`
-					export let options = {
-						iterations: 100,
-					};
-					export default function() {};
-				`),
-			}, afero.NewMemMapFs())
+			b, err := getSimpleBundle("/script.js", `
+				export let options = {
+					iterations: 100,
+				};
+				export default function() {};
+			`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, null.IntFrom(100), b.Options.Iterations)
 			}
 		})
 		t.Run("Stages", func(t *testing.T) {
-			b, err := NewBundle(&lib.SourceData{
-				Filename: "/script.js",
-				Data: []byte(`
-					export let options = {
-						stages: [],
-					};
-					export default function() {};
-				`),
-			}, afero.NewMemMapFs())
+			b, err := getSimpleBundle("/script.js", `
+				export let options = {
+					stages: [],
+				};
+				export default function() {};
+			`)
 			if assert.NoError(t, err) {
 				assert.Len(t, b.Options.Stages, 0)
 			}
 
 			t.Run("Empty", func(t *testing.T) {
-				b, err := NewBundle(&lib.SourceData{
-					Filename: "/script.js",
-					Data: []byte(`
-						export let options = {
-							stages: [
-								{},
-							],
-						};
-						export default function() {};
-					`),
-				}, afero.NewMemMapFs())
+				b, err := getSimpleBundle("/script.js", `
+					export let options = {
+						stages: [
+							{},
+						],
+					};
+					export default function() {};
+				`)
 				if assert.NoError(t, err) {
 					if assert.Len(t, b.Options.Stages, 1) {
 						assert.Equal(t, lib.Stage{}, b.Options.Stages[0])
@@ -242,17 +193,14 @@ func TestNewBundle(t *testing.T) {
 				}
 			})
 			t.Run("Target", func(t *testing.T) {
-				b, err := NewBundle(&lib.SourceData{
-					Filename: "/script.js",
-					Data: []byte(`
-						export let options = {
-							stages: [
-								{target: 10},
-							],
-						};
-						export default function() {};
-					`),
-				}, afero.NewMemMapFs())
+				b, err := getSimpleBundle("/script.js", `
+					export let options = {
+						stages: [
+							{target: 10},
+						],
+					};
+					export default function() {};
+				`)
 				if assert.NoError(t, err) {
 					if assert.Len(t, b.Options.Stages, 1) {
 						assert.Equal(t, lib.Stage{Target: null.IntFrom(10)}, b.Options.Stages[0])
@@ -260,17 +208,14 @@ func TestNewBundle(t *testing.T) {
 				}
 			})
 			t.Run("Duration", func(t *testing.T) {
-				b, err := NewBundle(&lib.SourceData{
-					Filename: "/script.js",
-					Data: []byte(`
-						export let options = {
-							stages: [
-								{duration: "10s"},
-							],
-						};
-						export default function() {};
-					`),
-				}, afero.NewMemMapFs())
+				b, err := getSimpleBundle("/script.js", `
+					export let options = {
+						stages: [
+							{duration: "10s"},
+						],
+					};
+					export default function() {};
+				`)
 				if assert.NoError(t, err) {
 					if assert.Len(t, b.Options.Stages, 1) {
 						assert.Equal(t, lib.Stage{Duration: lib.NullDurationFrom(10 * time.Second)}, b.Options.Stages[0])
@@ -278,17 +223,14 @@ func TestNewBundle(t *testing.T) {
 				}
 			})
 			t.Run("DurationAndTarget", func(t *testing.T) {
-				b, err := NewBundle(&lib.SourceData{
-					Filename: "/script.js",
-					Data: []byte(`
-						export let options = {
-							stages: [
-								{duration: "10s", target: 10},
-							],
-						};
-						export default function() {};
-					`),
-				}, afero.NewMemMapFs())
+				b, err := getSimpleBundle("/script.js", `
+					export let options = {
+						stages: [
+							{duration: "10s", target: 10},
+						],
+					};
+					export default function() {};
+				`)
 				if assert.NoError(t, err) {
 					if assert.Len(t, b.Options.Stages, 1) {
 						assert.Equal(t, lib.Stage{Duration: lib.NullDurationFrom(10 * time.Second), Target: null.IntFrom(10)}, b.Options.Stages[0])
@@ -296,18 +238,15 @@ func TestNewBundle(t *testing.T) {
 				}
 			})
 			t.Run("RampUpAndPlateau", func(t *testing.T) {
-				b, err := NewBundle(&lib.SourceData{
-					Filename: "/script.js",
-					Data: []byte(`
-						export let options = {
-							stages: [
-								{duration: "10s", target: 10},
-								{duration: "5s"},
-							],
-						};
-						export default function() {};
-					`),
-				}, afero.NewMemMapFs())
+				b, err := getSimpleBundle("/script.js", `
+					export let options = {
+						stages: [
+							{duration: "10s", target: 10},
+							{duration: "5s"},
+						],
+					};
+					export default function() {};
+				`)
 				if assert.NoError(t, err) {
 					if assert.Len(t, b.Options.Stages, 2) {
 						assert.Equal(t, lib.Stage{Duration: lib.NullDurationFrom(10 * time.Second), Target: null.IntFrom(10)}, b.Options.Stages[0])
@@ -317,29 +256,23 @@ func TestNewBundle(t *testing.T) {
 			})
 		})
 		t.Run("MaxRedirects", func(t *testing.T) {
-			b, err := NewBundle(&lib.SourceData{
-				Filename: "/script.js",
-				Data: []byte(`
-					export let options = {
-						maxRedirects: 10,
-					};
-					export default function() {};
-				`),
-			}, afero.NewMemMapFs())
+			b, err := getSimpleBundle("/script.js", `
+				export let options = {
+					maxRedirects: 10,
+				};
+				export default function() {};
+			`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, null.IntFrom(10), b.Options.MaxRedirects)
 			}
 		})
 		t.Run("InsecureSkipTLSVerify", func(t *testing.T) {
-			b, err := NewBundle(&lib.SourceData{
-				Filename: "/script.js",
-				Data: []byte(`
-					export let options = {
-						insecureSkipTLSVerify: true,
-					};
-					export default function() {};
-				`),
-			}, afero.NewMemMapFs())
+			b, err := getSimpleBundle("/script.js", `
+				export let options = {
+					insecureSkipTLSVerify: true,
+				};
+				export default function() {};
+			`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, null.BoolFrom(true), b.Options.InsecureSkipTLSVerify)
 			}
@@ -355,10 +288,7 @@ func TestNewBundle(t *testing.T) {
 					`
 					script = fmt.Sprintf(script, suiteName)
 
-					b, err := NewBundle(&lib.SourceData{
-						Filename: "/script.js",
-						Data:     []byte(script),
-					}, afero.NewMemMapFs())
+					b, err := getSimpleBundle("/script.js", script)
 					if assert.NoError(t, err) {
 						if assert.Len(t, *b.Options.TLSCipherSuites, 1) {
 							assert.Equal(t, (*b.Options.TLSCipherSuites)[0], suiteID)
@@ -369,33 +299,27 @@ func TestNewBundle(t *testing.T) {
 		})
 		t.Run("TLSVersion", func(t *testing.T) {
 			t.Run("Object", func(t *testing.T) {
-				b, err := NewBundle(&lib.SourceData{
-					Filename: "/script.js",
-					Data: []byte(`
-						export let options = {
-							tlsVersion: {
-								min: "ssl3.0",
-								max: "tls1.2"
-							}
-						};
-						export default function() {};
-					`),
-				}, afero.NewMemMapFs())
+				b, err := getSimpleBundle("/script.js", `
+					export let options = {
+						tlsVersion: {
+							min: "ssl3.0",
+							max: "tls1.2"
+						}
+					};
+					export default function() {};
+				`)
 				if assert.NoError(t, err) {
 					assert.Equal(t, b.Options.TLSVersion.Min, lib.TLSVersion(tls.VersionSSL30))
 					assert.Equal(t, b.Options.TLSVersion.Max, lib.TLSVersion(tls.VersionTLS12))
 				}
 			})
 			t.Run("String", func(t *testing.T) {
-				b, err := NewBundle(&lib.SourceData{
-					Filename: "/script.js",
-					Data: []byte(`
+				b, err := getSimpleBundle("/script.js", `
 					export let options = {
 						tlsVersion: "ssl3.0"
 					};
 					export default function() {};
-				`),
-				}, afero.NewMemMapFs())
+				`)
 				if assert.NoError(t, err) {
 					assert.Equal(t, b.Options.TLSVersion.Min, lib.TLSVersion(tls.VersionSSL30))
 					assert.Equal(t, b.Options.TLSVersion.Max, lib.TLSVersion(tls.VersionSSL30))
@@ -404,17 +328,14 @@ func TestNewBundle(t *testing.T) {
 			})
 		})
 		t.Run("Thresholds", func(t *testing.T) {
-			b, err := NewBundle(&lib.SourceData{
-				Filename: "/script.js",
-				Data: []byte(`
-					export let options = {
-						thresholds: {
-							http_req_duration: ["avg<100"],
-						},
-					};
-					export default function() {};
-				`),
-			}, afero.NewMemMapFs())
+			b, err := getSimpleBundle("/script.js", `
+				export let options = {
+					thresholds: {
+						http_req_duration: ["avg<100"],
+					},
+				};
+				export default function() {};
+			`)
 			if assert.NoError(t, err) {
 				if assert.Len(t, b.Options.Thresholds["http_req_duration"].Thresholds, 1) {
 					assert.Equal(t, "avg<100", b.Options.Thresholds["http_req_duration"].Thresholds[0].Source)
@@ -439,7 +360,7 @@ func TestNewBundleFromArchive(t *testing.T) {
 			export default function() { return exclaim(file); };
 		`),
 	}
-	b, err := NewBundle(src, fs)
+	b, err := NewBundle(src, fs, lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -466,7 +387,7 @@ func TestNewBundleFromArchive(t *testing.T) {
 	assert.Len(t, arc.Files, 1)
 	assert.Equal(t, `hi`, string(arc.Files["/path/to/file.txt"]))
 
-	b2, err := NewBundleFromArchive(arc)
+	b2, err := NewBundleFromArchive(arc, lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -484,13 +405,10 @@ func TestNewBundleFromArchive(t *testing.T) {
 }
 
 func TestBundleInstantiate(t *testing.T) {
-	b, err := NewBundle(&lib.SourceData{
-		Filename: "/script.js",
-		Data: []byte(`
+	b, err := getSimpleBundle("/script.js", `
 		let val = true;
 		export default function() { return val; }
-		`),
-	}, afero.NewMemMapFs())
+	`)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -520,20 +438,17 @@ func TestBundleEnv(t *testing.T) {
 	assert.NoError(t, os.Setenv("TEST_A", "1"))
 	assert.NoError(t, os.Setenv("TEST_B", ""))
 
-	b1, err := NewBundle(&lib.SourceData{
-		Filename: "/script.js",
-		Data: []byte(`
-			export default function() {
-				if (__ENV.TEST_A !== "1") { throw new Error("Invalid TEST_A: " + __ENV.TEST_A); }
-				if (__ENV.TEST_B !== "") { throw new Error("Invalid TEST_B: " + __ENV.TEST_B); }
-			}
-		`),
-	}, afero.NewMemMapFs())
+	b1, err := getSimpleBundle("/script.js", `
+		export default function() {
+			if (__ENV.TEST_A !== "1") { throw new Error("Invalid TEST_A: " + __ENV.TEST_A); }
+			if (__ENV.TEST_B !== "") { throw new Error("Invalid TEST_B: " + __ENV.TEST_B); }
+		}
+	`)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	b2, err := NewBundleFromArchive(b1.MakeArchive())
+	b2, err := NewBundleFromArchive(b1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -23,7 +23,6 @@ package js
 import (
 	"crypto/tls"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -435,15 +434,23 @@ func TestBundleInstantiate(t *testing.T) {
 }
 
 func TestBundleEnv(t *testing.T) {
-	assert.NoError(t, os.Setenv("TEST_A", "1"))
-	assert.NoError(t, os.Setenv("TEST_B", ""))
+	rtOpts := lib.RuntimeOptions{Env: map[string]string{
+		"TEST_A": "1",
+		"TEST_B": "",
+	}}
 
-	b1, err := getSimpleBundle("/script.js", `
-		export default function() {
-			if (__ENV.TEST_A !== "1") { throw new Error("Invalid TEST_A: " + __ENV.TEST_A); }
-			if (__ENV.TEST_B !== "") { throw new Error("Invalid TEST_B: " + __ENV.TEST_B); }
-		}
-	`)
+	b1, err := NewBundle(
+		&lib.SourceData{
+			Filename: "/script.js",
+			Data: []byte(`
+				export default function() {
+					if (__ENV.TEST_A !== "1") { throw new Error("Invalid TEST_A: " + __ENV.TEST_A); }
+					if (__ENV.TEST_B !== "") { throw new Error("Invalid TEST_B: " + __ENV.TEST_B); }
+				}
+			`),
+		},
+		afero.NewMemMapFs(), rtOpts,
+	)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/js/console_test.go
+++ b/js/console_test.go
@@ -91,7 +91,7 @@ func TestConsole(t *testing.T) {
 							`export default function() { console.%s(%s); }`,
 							name, args,
 						)),
-					}, afero.NewMemMapFs())
+					}, afero.NewMemMapFs(), lib.RuntimeOptions{})
 					assert.NoError(t, err)
 
 					vu, err := r.newVU()

--- a/js/initcontext_test.go
+++ b/js/initcontext_test.go
@@ -34,23 +34,17 @@ import (
 func TestInitContextRequire(t *testing.T) {
 	t.Run("Modules", func(t *testing.T) {
 		t.Run("Nonexistent", func(t *testing.T) {
-			_, err := NewBundle(&lib.SourceData{
-				Filename: "/script.js",
-				Data:     []byte(`import "k6/NONEXISTENT";`),
-			}, afero.NewMemMapFs())
+			_, err := getSimpleBundle("/script.js", `import "k6/NONEXISTENT";`)
 			assert.EqualError(t, err, "GoError: unknown builtin module: k6/NONEXISTENT")
 		})
 
 		t.Run("k6", func(t *testing.T) {
-			b, err := NewBundle(&lib.SourceData{
-				Filename: "/script.js",
-				Data: []byte(`
+			b, err := getSimpleBundle("/script.js", `
 					import k6 from "k6";
 					export let _k6 = k6;
 					export let dummy = "abc123";
 					export default function() {}
-				`),
-			}, afero.NewMemMapFs())
+			`)
 			if !assert.NoError(t, err, "bundle error") {
 				return
 			}
@@ -74,15 +68,12 @@ func TestInitContextRequire(t *testing.T) {
 			}
 
 			t.Run("group", func(t *testing.T) {
-				b, err := NewBundle(&lib.SourceData{
-					Filename: "/script.js",
-					Data: []byte(`
+				b, err := getSimpleBundle("/script.js", `
 						import { group } from "k6";
 						export let _group = group;
 						export let dummy = "abc123";
 						export default function() {}
-					`),
-				}, afero.NewMemMapFs())
+				`)
 				if !assert.NoError(t, err) {
 					return
 				}
@@ -107,10 +98,7 @@ func TestInitContextRequire(t *testing.T) {
 
 	t.Run("Files", func(t *testing.T) {
 		t.Run("Nonexistent", func(t *testing.T) {
-			_, err := NewBundle(&lib.SourceData{
-				Filename: "/script.js",
-				Data:     []byte(`import "/nonexistent.js"; export default function() {}`),
-			}, afero.NewMemMapFs())
+			_, err := getSimpleBundle("/script.js", `import "/nonexistent.js"; export default function() {}`)
 			assert.EqualError(t, err, "GoError: open /nonexistent.js: file does not exist")
 		})
 		t.Run("Invalid", func(t *testing.T) {
@@ -119,7 +107,7 @@ func TestInitContextRequire(t *testing.T) {
 			_, err := NewBundle(&lib.SourceData{
 				Filename: "/script.js",
 				Data:     []byte(`import "/file.js"; export default function() {}`),
-			}, fs)
+			}, fs, lib.RuntimeOptions{})
 			assert.EqualError(t, err, "SyntaxError: /file.js: Unexpected character '\x00' (1:0)\n> 1 | \x00\n    | ^ at <eval>:2:26853(114)")
 		})
 		t.Run("Error", func(t *testing.T) {
@@ -128,7 +116,7 @@ func TestInitContextRequire(t *testing.T) {
 			_, err := NewBundle(&lib.SourceData{
 				Filename: "/script.js",
 				Data:     []byte(`import "/file.js"; export default function() {}`),
-			}, fs)
+			}, fs, lib.RuntimeOptions{})
 			assert.EqualError(t, err, "Error: aaaa at /file.js:1:19(4)")
 		})
 
@@ -180,9 +168,9 @@ func TestInitContextRequire(t *testing.T) {
 							`, libName)),
 						}
 
-						lib := `export default function() { return 12345; }`
+						jsLib := `export default function() { return 12345; }`
 						if constName != "" {
-							lib = fmt.Sprintf(
+							jsLib = fmt.Sprintf(
 								`import { c } from "%s"; export default function() { return c; }`,
 								constName,
 							)
@@ -193,9 +181,9 @@ func TestInitContextRequire(t *testing.T) {
 						}
 
 						assert.NoError(t, fs.MkdirAll(filepath.Dir(data.LibPath), 0755))
-						assert.NoError(t, afero.WriteFile(fs, data.LibPath, []byte(lib), 0644))
+						assert.NoError(t, afero.WriteFile(fs, data.LibPath, []byte(jsLib), 0644))
 
-						b, err := NewBundle(src, fs)
+						b, err := NewBundle(src, fs, lib.RuntimeOptions{})
 						if !assert.NoError(t, err) {
 							return
 						}
@@ -227,7 +215,7 @@ func TestInitContextRequire(t *testing.T) {
 					}
 				};
 				`),
-			}, fs)
+			}, fs, lib.RuntimeOptions{})
 			if !assert.NoError(t, err) {
 				return
 			}
@@ -259,7 +247,7 @@ func TestInitContextOpen(t *testing.T) {
 				export let data = open("%s");
 				export default function() {}
 				`, loadPath)),
-			}, fs)
+			}, fs, lib.RuntimeOptions{})
 			if !assert.NoError(t, err) {
 				return
 			}
@@ -277,7 +265,7 @@ func TestInitContextOpen(t *testing.T) {
 		_, err := NewBundle(&lib.SourceData{
 			Filename: "/script.js",
 			Data:     []byte(`open("/nonexistent.txt"); export default function() {}`),
-		}, fs)
+		}, fs, lib.RuntimeOptions{})
 		assert.EqualError(t, err, "GoError: open /nonexistent.txt: file does not exist")
 	})
 }

--- a/js/runner.go
+++ b/js/runner.go
@@ -56,16 +56,16 @@ type Runner struct {
 	RPSLimit   *rate.Limiter
 }
 
-func New(src *lib.SourceData, fs afero.Fs) (*Runner, error) {
-	bundle, err := NewBundle(src, fs)
+func New(src *lib.SourceData, fs afero.Fs, rtOpts lib.RuntimeOptions) (*Runner, error) {
+	bundle, err := NewBundle(src, fs, rtOpts)
 	if err != nil {
 		return nil, err
 	}
 	return NewFromBundle(bundle)
 }
 
-func NewFromArchive(arc *lib.Archive) (*Runner, error) {
-	bundle, err := NewBundleFromArchive(arc)
+func NewFromArchive(arc *lib.Archive, rtOpts lib.RuntimeOptions) (*Runner, error) {
+	bundle, err := NewBundleFromArchive(arc, rtOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -50,7 +50,7 @@ func TestRunnerNew(t *testing.T) {
 			let counter = 0;
 			export default function() { counter++; }
 		`),
-		}, afero.NewMemMapFs())
+		}, afero.NewMemMapFs(), lib.RuntimeOptions{})
 		assert.NoError(t, err)
 
 		t.Run("NewVU", func(t *testing.T) {
@@ -71,7 +71,7 @@ func TestRunnerNew(t *testing.T) {
 		_, err := New(&lib.SourceData{
 			Filename: "/script.js",
 			Data:     []byte(`blarg`),
-		}, afero.NewMemMapFs())
+		}, afero.NewMemMapFs(), lib.RuntimeOptions{})
 		assert.EqualError(t, err, "ReferenceError: blarg is not defined at /script.js:1:1(0)")
 	})
 }
@@ -80,12 +80,12 @@ func TestRunnerGetDefaultGroup(t *testing.T) {
 	r1, err := New(&lib.SourceData{
 		Filename: "/script.js",
 		Data:     []byte(`export default function() {};`),
-	}, afero.NewMemMapFs())
+	}, afero.NewMemMapFs(), lib.RuntimeOptions{})
 	if assert.NoError(t, err) {
 		assert.NotNil(t, r1.GetDefaultGroup())
 	}
 
-	r2, err := NewFromArchive(r1.MakeArchive())
+	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
 	if assert.NoError(t, err) {
 		assert.NotNil(t, r2.GetDefaultGroup())
 	}
@@ -95,12 +95,12 @@ func TestRunnerOptions(t *testing.T) {
 	r1, err := New(&lib.SourceData{
 		Filename: "/script.js",
 		Data:     []byte(`export default function() {};`),
-	}, afero.NewMemMapFs())
+	}, afero.NewMemMapFs(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	r2, err := NewFromArchive(r1.MakeArchive())
+	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -134,7 +134,7 @@ func TestRunnerIntegrationImports(t *testing.T) {
 					_, err := New(&lib.SourceData{
 						Filename: "/script.js",
 						Data:     []byte(fmt.Sprintf(`import "%s"; export default function() {}`, mod)),
-					}, afero.NewMemMapFs())
+					}, afero.NewMemMapFs(), lib.RuntimeOptions{})
 					assert.NoError(t, err)
 				})
 			})
@@ -162,12 +162,12 @@ func TestRunnerIntegrationImports(t *testing.T) {
 					export default function() {
 						if (hi != "hi!") { throw new Error("incorrect value"); }
 					}`, data.path)),
-				}, fs)
+				}, fs, lib.RuntimeOptions{})
 				if !assert.NoError(t, err) {
 					return
 				}
 
-				r2, err := NewFromArchive(r1.MakeArchive())
+				r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
 				if !assert.NoError(t, err) {
 					return
 				}
@@ -195,13 +195,13 @@ func TestVURunContext(t *testing.T) {
 		export let options = { vus: 10 };
 		export default function() { fn(); }
 		`),
-	}, afero.NewMemMapFs())
+	}, afero.NewMemMapFs(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
 	r1.SetOptions(r1.GetOptions().Apply(lib.Options{Throw: null.BoolFrom(true)}))
 
-	r2, err := NewFromArchive(r1.MakeArchive())
+	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -242,13 +242,13 @@ func TestVURunInterrupt(t *testing.T) {
 		Data: []byte(`
 		export default function() { while(true) {} }
 		`),
-	}, afero.NewMemMapFs())
+	}, afero.NewMemMapFs(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
 	r1.SetOptions(lib.Options{Throw: null.BoolFrom(true)})
 
-	r2, err := NewFromArchive(r1.MakeArchive())
+	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -283,12 +283,12 @@ func TestVUIntegrationGroups(t *testing.T) {
 			});
 		}
 		`),
-	}, afero.NewMemMapFs())
+	}, afero.NewMemMapFs(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	r2, err := NewFromArchive(r1.MakeArchive())
+	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -339,12 +339,12 @@ func TestVUIntegrationMetrics(t *testing.T) {
 		let myMetric = new Trend("my_metric");
 		export default function() { myMetric.add(5); }
 		`),
-	}, afero.NewMemMapFs())
+	}, afero.NewMemMapFs(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	r2, err := NewFromArchive(r1.MakeArchive())
+	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -406,13 +406,13 @@ func TestVUIntegrationInsecureRequests(t *testing.T) {
 					import http from "k6/http";
 					export default function() { http.get("https://expired.badssl.com/"); }
 				`),
-			}, afero.NewMemMapFs())
+			}, afero.NewMemMapFs(), lib.RuntimeOptions{})
 			if !assert.NoError(t, err) {
 				return
 			}
 			r1.SetOptions(lib.Options{Throw: null.BoolFrom(true)}.Apply(data.opts))
 
-			r2, err := NewFromArchive(r1.MakeArchive())
+			r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
 			if !assert.NoError(t, err) {
 				return
 			}
@@ -445,7 +445,7 @@ func TestVUIntegrationBlacklist(t *testing.T) {
 					import http from "k6/http";
 					export default function() { http.get("http://10.1.2.3/"); }
 				`),
-	}, afero.NewMemMapFs())
+	}, afero.NewMemMapFs(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -459,7 +459,7 @@ func TestVUIntegrationBlacklist(t *testing.T) {
 		BlacklistIPs: []*net.IPNet{cidr},
 	})
 
-	r2, err := NewFromArchive(r1.MakeArchive())
+	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -515,13 +515,13 @@ func TestVUIntegrationTLSConfig(t *testing.T) {
 					import http from "k6/http";
 					export default function() { http.get("https://sha256.badssl.com/"); }
 				`),
-			}, afero.NewMemMapFs())
+			}, afero.NewMemMapFs(), lib.RuntimeOptions{})
 			if !assert.NoError(t, err) {
 				return
 			}
 			r1.SetOptions(lib.Options{Throw: null.BoolFrom(true)}.Apply(data.opts))
 
-			r2, err := NewFromArchive(r1.MakeArchive())
+			r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
 			if !assert.NoError(t, err) {
 				return
 			}
@@ -558,13 +558,13 @@ func TestVUIntegrationHTTP2(t *testing.T) {
 				if (res.proto != "HTTP/2.0") { throw new Error("wrong proto: " + res.proto) }
 			}
 		`),
-	}, afero.NewMemMapFs())
+	}, afero.NewMemMapFs(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
 	r1.SetOptions(lib.Options{Throw: null.BoolFrom(true)})
 
-	r2, err := NewFromArchive(r1.MakeArchive())
+	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -610,7 +610,7 @@ func TestVUIntegrationCookies(t *testing.T) {
 				}
 			}
 		`),
-	}, afero.NewMemMapFs())
+	}, afero.NewMemMapFs(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -619,7 +619,7 @@ func TestVUIntegrationCookies(t *testing.T) {
 		MaxRedirects: null.IntFrom(10),
 	})
 
-	r2, err := NewFromArchive(r1.MakeArchive())
+	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -647,13 +647,13 @@ func TestVUIntegrationVUID(t *testing.T) {
 				if (__VU != 1234) { throw new Error("wrong __VU: " + __VU); }
 			}`,
 		),
-	}, afero.NewMemMapFs())
+	}, afero.NewMemMapFs(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
 	r1.SetOptions(lib.Options{Throw: null.BoolFrom(true)})
 
-	r2, err := NewFromArchive(r1.MakeArchive())
+	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -742,7 +742,7 @@ func TestVUIntegrationClientCerts(t *testing.T) {
 			import http from "k6/http";
 			export default function() { http.get("https://%s")}
 		`, listener.Addr().String())),
-	}, afero.NewMemMapFs())
+	}, afero.NewMemMapFs(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -752,7 +752,7 @@ func TestVUIntegrationClientCerts(t *testing.T) {
 	})
 
 	t.Run("Unauthenticated", func(t *testing.T) {
-		r2, err := NewFromArchive(r1.MakeArchive())
+		r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -797,7 +797,7 @@ func TestVUIntegrationClientCerts(t *testing.T) {
 	})
 
 	t.Run("Authenticated", func(t *testing.T) {
-		r2, err := NewFromArchive(r1.MakeArchive())
+		r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
 		if !assert.NoError(t, err) {
 			return
 		}

--- a/lib/archive.go
+++ b/lib/archive.go
@@ -59,6 +59,9 @@ type Archive struct {
 	// Archived filesystem.
 	Scripts map[string][]byte `json:"-"` // included scripts
 	Files   map[string][]byte `json:"-"` // non-script resources
+
+	// Environment variables
+	Env map[string]string `json:"env"`
 }
 
 // Reads an archive created by Archive.Write from a reader.

--- a/lib/archive_test.go
+++ b/lib/archive_test.go
@@ -128,5 +128,3 @@ func TestArchiveJSONEscape(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, string(b), "test<.js")
 }
-
-//TODO: write test for environment variables

--- a/lib/archive_test.go
+++ b/lib/archive_test.go
@@ -128,3 +128,5 @@ func TestArchiveJSONEscape(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, string(b), "test<.js")
 }
+
+//TODO: write test for environment variables

--- a/lib/runtime_options.go
+++ b/lib/runtime_options.go
@@ -1,0 +1,44 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2018 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package lib
+
+import null "gopkg.in/guregu/null.v3"
+
+// RuntimeOptions are settings passed onto the goja JS runtime
+type RuntimeOptions struct {
+	// Whether to disable the passing of actual system environment variables to the JS runtime
+	NoSystemEnvVars null.Bool `json:"noSystemEnvVars" envconfig:"no_system_env_vars"`
+
+	// Environment variables passed onto the runner
+	Env map[string]string `json:"env" envconfig:"env"`
+}
+
+// Apply overwrites the receiver RuntimeOptions' fields with any that are set
+// on the argument struct and returns the receiver
+func (o RuntimeOptions) Apply(opts RuntimeOptions) RuntimeOptions {
+	if opts.NoSystemEnvVars.Valid {
+		o.NoSystemEnvVars = opts.NoSystemEnvVars
+	}
+	if opts.Env != nil {
+		o.Env = opts.Env
+	}
+	return o
+}

--- a/lib/runtime_options.go
+++ b/lib/runtime_options.go
@@ -24,8 +24,8 @@ import null "gopkg.in/guregu/null.v3"
 
 // RuntimeOptions are settings passed onto the goja JS runtime
 type RuntimeOptions struct {
-	// Whether to disable the passing of actual system environment variables to the JS runtime
-	NoSystemEnvVars null.Bool `json:"noSystemEnvVars" envconfig:"no_system_env_vars"`
+	// Whether to pass the actual system environment variables to the JS runtime
+	IncludeSystemEnvVars null.Bool `json:"includeSystemEnvVars" envconfig:"include_system_env_vars"`
 
 	// Environment variables passed onto the runner
 	Env map[string]string `json:"env" envconfig:"env"`
@@ -34,8 +34,8 @@ type RuntimeOptions struct {
 // Apply overwrites the receiver RuntimeOptions' fields with any that are set
 // on the argument struct and returns the receiver
 func (o RuntimeOptions) Apply(opts RuntimeOptions) RuntimeOptions {
-	if opts.NoSystemEnvVars.Valid {
-		o.NoSystemEnvVars = opts.NoSystemEnvVars
+	if opts.IncludeSystemEnvVars.Valid {
+		o.IncludeSystemEnvVars = opts.IncludeSystemEnvVars
 	}
 	if opts.Env != nil {
 		o.Env = opts.Env


### PR DESCRIPTION
This closes #467. I wrote a comment in the issue with some information from a discussion with @robingustafsson about the implementation details, since my initial attempts at writing this hit a bit of a snag.

This should be mostly finished now, it should be mostly ready for code review. The [documentation](https://docs.k6.io/docs/environment-variables) is not yet done, though I think that's outside of the git repo. There are also a few remaining things that I'm not sure how to address:
- Should the `inspect` command [also accept](https://github.com/na--/k6/blob/31d0055857ad4524a017e1d9515f3966571137d6/cmd/inspect.go#L66) CLI environment variables? I'm leaning towards "yes", since with the old code system environment variables could [affect](https://github.com/loadimpact/k6/blob/b843d0a560e4f9a9405da775ddf98ed47bd0dd78/js/bundle.go#L94) the result of `inspect` 
- When we're running a test from an archive with some saved env vars in it, should we also be able to overwrite them via the new CLI env vars flags? I think the answer should also should be "yes", for similar reasons to before. This [affects](https://github.com/na--/k6/blob/31d0055857ad4524a017e1d9515f3966571137d6/cmd/runtime_options_test.go#L171) the end-to-end tests as well.
- I'm a bit concerned with capturing all of the system environment variables in `metadata.json` by default when running `k6 archive`/`k6 cloud`. This may lead to users inadvertently exposing private data. At the same time, disabling the capture of environment variables by default could lead to backwards incomparability with `k6 run` (I think) or to inconsistent behaviour between the `run` and `archive`/`cloud` commands... 

Please tell me if there's anything I'm missing or haven't considered, I'd be happy to fix it.