### PR TITLE
Cloud: decrease payload when pushing metrics

### DIFF
--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -368,12 +368,12 @@ func TestVUIntegrationMetrics(t *testing.T) {
 					assert.Equal(t, stats.Trend, s.Metric.Type)
 				case 1:
 					assert.Equal(t, 0.0, s.Value)
-					assert.Equal(t, metrics.DataSent, s.Metric)
+					assert.Equal(t, metrics.DataSent, s.Metric, "`data_sent` sample is before `data_received` and `iteration_duration`")
 				case 2:
 					assert.Equal(t, 0.0, s.Value)
-					assert.Equal(t, metrics.DataReceived, s.Metric)
+					assert.Equal(t, metrics.DataReceived, s.Metric, "`data_received` sample is after `data_received`")
 				case 3:
-					assert.Equal(t, metrics.IterationDuration, s.Metric)
+					assert.Equal(t, metrics.IterationDuration, s.Metric, "`iteration-duration` sample is after `data_received`")
 				}
 			}
 		})

--- a/lib/netext/tracer_test.go
+++ b/lib/netext/tracer_test.go
@@ -60,7 +60,7 @@ func TestTracer(t *testing.T) {
 
 			assert.Len(t, samples, 8)
 			seenMetrics := map[*stats.Metric]bool{}
-			for _, s := range samples {
+			for i, s := range samples {
 				assert.NotContains(t, seenMetrics, s.Metric)
 				seenMetrics[s.Metric] = true
 
@@ -70,6 +70,7 @@ func TestTracer(t *testing.T) {
 				switch s.Metric {
 				case metrics.HTTPReqs:
 					assert.Equal(t, 1.0, s.Value)
+					assert.Equal(t, 0, i, "`HTTPReqs` is reported before the other HTTP metrics")
 				case metrics.HTTPReqConnecting:
 					if isReuse {
 						assert.Equal(t, 0.0, s.Value)

--- a/stats/cloud/api.go
+++ b/stats/cloud/api.go
@@ -42,10 +42,11 @@ type Sample struct {
 }
 
 type SampleData struct {
-	Type  stats.MetricType  `json:"type"`
-	Time  time.Time         `json:"time"`
-	Value float64           `json:"value"`
-	Tags  map[string]string `json:"tags,omitempty"`
+	Type   stats.MetricType   `json:"type"`
+	Time   time.Time          `json:"time"`
+	Value  float64            `json:"value"`
+	Values map[string]float64 `json:"values,omitempty"`
+	Tags   map[string]string  `json:"tags,omitempty"`
 }
 
 type ThresholdResult map[string]map[string]bool


### PR DESCRIPTION
Decrease `pushMetrics` payload by grouping http metrics and iteration metrics like:

```
{"type":"Points", 
"data": {
  "time":"2017-12-05T11:58:30.906235601+01:00", 
  "value": null, 
  "tags":{"group":"", "method":"GET","name":"http://test.loadimpact.com","status":"200","url":"http://test.loadimpact.com"}},  
  "values":{   "http_req_duration": 4.865751,
                 "http_req_blocked": 4.865751,
                 "http_req_connecting": 4.865751,
                 "http_req_sending": 4.865751,
                 "http_req_waiting": 4.865751,
                 "http_req_receiving": 4.865751,
                 "http_reqs": 1
  } 
},
,"metric":"http_req_li_all"
}
```

```

{"type":"Points", 
"data": {
  "time":"2017-12-05T11:58:30.906235601+01:00", 
  "value": null, 
  "tags":{"group":"",   "method":"GET","name":"http://test.loadimpact.com","status":"200","url":"http://test.loadimpact.com"}  
  "values":{   "data_received": 48888,
                      "data_sent": 4.865751,
                      "iter_duration": 4.865751
  } 
},
,"metric":"iter_li_all"
}
```

The implementation requires than `http_reqs` and `data_sent` metrics are collected before the other related metrics.