### PR TITLE
Add --no-batch option to HAR convert

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -33,6 +33,7 @@ var output = ""
 var (
 	enableChecks bool
 	threshold    uint
+	nobatch      bool
 	only         []string
 	skip         []string
 )
@@ -72,7 +73,7 @@ var convertCmd = &cobra.Command{
 			return err
 		}
 
-		script, err := har.Convert(h, enableChecks, threshold, only, skip)
+		script, err := har.Convert(h, enableChecks, threshold, nobatch, only, skip)
 		if err != nil {
 			return err
 		}
@@ -108,5 +109,6 @@ func init() {
 	convertCmd.Flags().StringSliceVarP(&only, "only", "", []string{}, "include only requests from the given domains")
 	convertCmd.Flags().StringSliceVarP(&skip, "skip", "", []string{}, "skip requests from the given domains")
 	convertCmd.Flags().UintVarP(&threshold, "batch-threshold", "", 500, "batch request idle time threshold (see example)")
+	convertCmd.Flags().BoolVarP(&nobatch, "no-batch", "", false, "don't generate batch calls")
 	convertCmd.Flags().BoolVarP(&enableChecks, "enable-status-code-checks", "", false, "add a check for each http status response")
 }

--- a/converter/har/converter.go
+++ b/converter/har/converter.go
@@ -89,6 +89,8 @@ func Convert(h HAR, includeCodeCheck bool, batchTime uint, nobatch bool, only, s
 		sort.Sort(EntryByStarted(entries))
 
 		if nobatch {
+			fmt.Fprint(w, "\t\tlet res;\n")
+
 			for _, e := range entries {
 
 				var params []string


### PR DESCRIPTION
Produces simpler code using `http.<method>` calls instead of batch (concurrent calls). This will in turn make two converted recordings easier to diff.

We have more changes coming to this so the code is not very pretty at the moment. But we would like to keep it like this until we have merged in our other stuff and then do a code cleanup.
