### PR TITLE
Fix TrendSink stats and add tests for all sink types

### DIFF
--- a/stats/sink.go
+++ b/stats/sink.go
@@ -22,6 +22,7 @@ package stats
 
 import (
 	"errors"
+	"math"
 	"sort"
 	"time"
 )
@@ -109,20 +110,22 @@ func (t *TrendSink) Add(s Sample) {
 	}
 }
 
+// P calculates the given percentile from sink values.
 func (t *TrendSink) P(pct float64) float64 {
 	switch t.Count {
 	case 0:
 		return 0
 	case 1:
 		return t.Values[0]
-	case 2:
-		if pct < 0.5 {
-			return t.Values[0]
-		} else {
-			return t.Values[1]
-		}
 	default:
-		return t.Values[int(float64(t.Count)*pct)]
+		// If percentile falls on a value in Values slice, we return that value.
+		// If percentile does not fall on a value in Values slice, we calculate (linear interpolation)
+		// the value that would fall at percentile, given the values above and below that percentile.
+		i := pct * (float64(t.Count) - 1.0)
+		j := t.Values[int(math.Floor(i))]
+		k := t.Values[int(math.Ceil(i))]
+		f := i - math.Floor(i)
+		return j + (k-j)*f
 	}
 }
 

--- a/stats/sink.go
+++ b/stats/sink.go
@@ -121,6 +121,7 @@ func (t *TrendSink) P(pct float64) float64 {
 		// If percentile falls on a value in Values slice, we return that value.
 		// If percentile does not fall on a value in Values slice, we calculate (linear interpolation)
 		// the value that would fall at percentile, given the values above and below that percentile.
+		t.Calc()
 		i := pct * (float64(t.Count) - 1.0)
 		j := t.Values[int(math.Floor(i))]
 		k := t.Values[int(math.Ceil(i))]
@@ -146,6 +147,7 @@ func (t *TrendSink) Calc() {
 }
 
 func (t *TrendSink) Format(tt time.Duration) map[string]float64 {
+	t.Calc()
 	return map[string]float64{
 		"min":   t.Min,
 		"max":   t.Max,

--- a/stats/sink_test.go
+++ b/stats/sink_test.go
@@ -26,6 +26,46 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestGaugeSink(t *testing.T) {
+	samples6 := []float64{1.0, 2.0, 3.0, 4.0, 10.0, 5.0}
+
+	t.Run("add", func(t *testing.T) {
+		t.Run("one value", func(t *testing.T) {
+			sink := GaugeSink{}
+			sink.Add(Sample{Metric: &Metric{}, Value: 1.0})
+			assert.Equal(t, 1.0, sink.Value)
+			assert.Equal(t, 1.0, sink.Min)
+			assert.Equal(t, true, sink.minSet)
+			assert.Equal(t, 1.0, sink.Max)
+		})
+		t.Run("values", func(t *testing.T) {
+			sink := GaugeSink{}
+			for _, s := range samples6 {
+				sink.Add(Sample{Metric: &Metric{}, Value: s})
+			}
+			assert.Equal(t, 5.0, sink.Value)
+			assert.Equal(t, 1.0, sink.Min)
+			assert.Equal(t, true, sink.minSet)
+			assert.Equal(t, 10.0, sink.Max)
+		})
+	})
+	t.Run("calc", func(t *testing.T) {
+		sink := GaugeSink{}
+		sink.Calc()
+		assert.Equal(t, 0.0, sink.Value)
+		assert.Equal(t, 0.0, sink.Min)
+		assert.Equal(t, false, sink.minSet)
+		assert.Equal(t, 0.0, sink.Max)
+	})
+	t.Run("format", func(t *testing.T) {
+		sink := GaugeSink{}
+		for _, s := range samples6 {
+			sink.Add(Sample{Metric: &Metric{}, Value: s})
+		}
+		assert.Equal(t, map[string]float64{"value": 5.0}, sink.Format(0))
+	})
+}
+
 func TestTrendSink(t *testing.T) {
 	unsortedSamples10 := []float64{0.0, 100.0, 30.0, 80.0, 70.0, 60.0, 50.0, 40.0, 90.0, 20.0}
 

--- a/stats/sink_test.go
+++ b/stats/sink_test.go
@@ -249,6 +249,12 @@ func TestDummySinkAddPanics(t *testing.T) {
 	})
 }
 
+func TestDummySinkCalcDoesNothing(t *testing.T) {
+	sink := DummySink{"a": 1}
+	sink.Calc()
+	assert.Equal(t, 1.0, sink["a"])
+}
+
 func TestDummySinkFormatReturnsItself(t *testing.T) {
 	assert.Equal(t, map[string]float64{"a": 1}, DummySink{"a": 1}.Format(0))
 }

--- a/stats/sink_test.go
+++ b/stats/sink_test.go
@@ -22,9 +22,45 @@ package stats
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestCounterSink(t *testing.T) {
+	samples10 := []float64{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 100.0}
+	now := time.Now()
+
+	t.Run("add", func(t *testing.T) {
+		t.Run("one value", func(t *testing.T) {
+			sink := CounterSink{}
+			sink.Add(Sample{Metric: &Metric{}, Value: 1.0, Time: now})
+			assert.Equal(t, 1.0, sink.Value)
+			assert.Equal(t, now, sink.First)
+		})
+		t.Run("values", func(t *testing.T) {
+			sink := CounterSink{}
+			for _, s := range samples10 {
+				sink.Add(Sample{Metric: &Metric{}, Value: s, Time: now})
+			}
+			assert.Equal(t, 145.0, sink.Value)
+			assert.Equal(t, now, sink.First)
+		})
+	})
+	t.Run("calc", func(t *testing.T) {
+		sink := CounterSink{}
+		sink.Calc()
+		assert.Equal(t, 0.0, sink.Value)
+		assert.Equal(t, time.Time{}, sink.First)
+	})
+	t.Run("format", func(t *testing.T) {
+		sink := CounterSink{}
+		for _, s := range samples10 {
+			sink.Add(Sample{Metric: &Metric{}, Value: s, Time: now})
+		}
+		assert.Equal(t, map[string]float64{"count": 145, "rate": 145.0}, sink.Format(1*time.Second))
+	})
+}
 
 func TestGaugeSink(t *testing.T) {
 	samples6 := []float64{1.0, 2.0, 3.0, 4.0, 10.0, 5.0}

--- a/stats/sink_test.go
+++ b/stats/sink_test.go
@@ -127,6 +127,46 @@ func TestTrendSink(t *testing.T) {
 	})
 }
 
+func TestRateSink(t *testing.T) {
+	samples6 := []float64{1.0, 0.0, 1.0, 0.0, 0.0, 1.0}
+
+	t.Run("add", func(t *testing.T) {
+		t.Run("one true", func(t *testing.T) {
+			sink := RateSink{}
+			sink.Add(Sample{Metric: &Metric{}, Value: 1.0})
+			assert.Equal(t, int64(1), sink.Total)
+			assert.Equal(t, int64(1), sink.Trues)
+		})
+		t.Run("one false", func(t *testing.T) {
+			sink := RateSink{}
+			sink.Add(Sample{Metric: &Metric{}, Value: 0.0})
+			assert.Equal(t, int64(1), sink.Total)
+			assert.Equal(t, int64(0), sink.Trues)
+		})
+		t.Run("values", func(t *testing.T) {
+			sink := RateSink{}
+			for _, s := range samples6 {
+				sink.Add(Sample{Metric: &Metric{}, Value: s})
+			}
+			assert.Equal(t, int64(6), sink.Total)
+			assert.Equal(t, int64(3), sink.Trues)
+		})
+	})
+	t.Run("calc", func(t *testing.T) {
+		sink := RateSink{}
+		sink.Calc()
+		assert.Equal(t, int64(0), sink.Total)
+		assert.Equal(t, int64(0), sink.Trues)
+	})
+	t.Run("format", func(t *testing.T) {
+		sink := RateSink{}
+		for _, s := range samples6 {
+			sink.Add(Sample{Metric: &Metric{}, Value: s})
+		}
+		assert.Equal(t, map[string]float64{"rate": 0.5}, sink.Format(0))
+	})
+}
+
 func TestDummySinkAddPanics(t *testing.T) {
 	assert.Panics(t, func() {
 		DummySink{}.Add(Sample{})


### PR DESCRIPTION
Changes percentile calculation to use linear interpolation of two bounding values if percentile doesn't precisely fall on a value index. Also, fixes issue where calls to `TrendSink.P()` and `TrendSink.Format()` could return wrong results if `TrendSink.Calc()` hadn't been previously called.

Closes #465.