### PR TITLE
har converter: Correlate variables in recordings (just redirects for now)

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -114,5 +114,5 @@ func init() {
 	convertCmd.Flags().BoolVarP(&nobatch, "no-batch", "", false, "don't generate batch calls")
 	convertCmd.Flags().BoolVarP(&enableChecks, "enable-status-code-checks", "", false, "add a status code check for each HTTP response")
 	convertCmd.Flags().BoolVarP(&returnOnFailedCheck, "return-on-failed-check", "", false, "return from iteration if we get an unexpected response status code")
-	convertCmd.Flags().BoolVarP(&correlate, "correlate", "", false, "detect values in responses being used in subsequent requests and try adapt the script accordingly (redirects, generated IDs, etc)")
+	convertCmd.Flags().BoolVarP(&correlate, "correlate", "", false, "detect values in responses being used in subsequent requests and try adapt the script accordingly (only redirects for now, but in the future we will try to track things like generated IDs etc)")
 }

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -33,6 +33,7 @@ var output = ""
 var (
 	enableChecks        bool
 	returnOnFailedCheck bool
+	correlate           bool
 	threshold           uint
 	nobatch             bool
 	only                []string
@@ -74,7 +75,7 @@ var convertCmd = &cobra.Command{
 			return err
 		}
 
-		script, err := har.Convert(h, enableChecks, returnOnFailedCheck, threshold, nobatch, only, skip)
+		script, err := har.Convert(h, enableChecks, returnOnFailedCheck, threshold, nobatch, correlate, only, skip)
 		if err != nil {
 			return err
 		}
@@ -113,5 +114,5 @@ func init() {
 	convertCmd.Flags().BoolVarP(&nobatch, "no-batch", "", false, "don't generate batch calls")
 	convertCmd.Flags().BoolVarP(&enableChecks, "enable-status-code-checks", "", false, "add a status code check for each HTTP response")
 	convertCmd.Flags().BoolVarP(&returnOnFailedCheck, "return-on-failed-check", "", false, "return from iteration if we get an unexpected response status code")
-
+	convertCmd.Flags().BoolVarP(&correlate, "correlate", "", false, "detect values in responses being used in subsequent requests and try adapt the script accordingly (redirects, generated IDs, etc)")
 }

--- a/cmd/convert_test.go
+++ b/cmd/convert_test.go
@@ -91,6 +91,8 @@ import http from 'k6/http';
 // Version: 1.2
 // Creator: WebInspector
 
+export let options = { maxRedirects: 0 };
+
 export default function() {
 
 	group("page_2 - https://golang.org/", function() {

--- a/converter/har/converter.go
+++ b/converter/har/converter.go
@@ -31,7 +31,7 @@ import (
 	"strings"
 )
 
-func Convert(h HAR, includeCodeCheck bool, returnOnFailedCheck bool, batchTime uint, nobatch bool, only, skip []string) (string, error) {
+func Convert(h HAR, includeCodeCheck bool, returnOnFailedCheck bool, batchTime uint, nobatch bool, correlate bool, only, skip []string) (string, error) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 
@@ -55,7 +55,9 @@ func Convert(h HAR, includeCodeCheck bool, returnOnFailedCheck bool, batchTime u
 		fmt.Fprintf(w, "// %v\n", h.Log.Comment)
 	}
 
-	fmt.Fprint(w, "\n")
+	// recordings include redirections as separate requests, and we dont want to trigger them twice
+	fmt.Fprint(w, "\nexport let options = { maxRedirects: 0 };\n\n")
+
 	fmt.Fprint(w, "export default function() {\n\n")
 
 	pages := h.Log.Pages
@@ -95,7 +97,9 @@ func Convert(h HAR, includeCodeCheck bool, returnOnFailedCheck bool, batchTime u
 		sort.Sort(EntryByStarted(entries))
 
 		if nobatch {
-			fmt.Fprint(w, "\t\tlet res;\n")
+			var recordedRedirectUrl string
+
+			fmt.Fprint(w, "\t\tlet res, redirectUrl;\n")
 
 			for _, e := range entries {
 
@@ -118,8 +122,21 @@ func Convert(h HAR, includeCodeCheck bool, returnOnFailedCheck bool, batchTime u
 					params = append(params, fmt.Sprintf("\"headers\": {\n\t\t\t\t\t%s\n\t\t\t\t}", strings.Join(headers, ",\n\t\t\t\t\t")))
 				}
 
-				fmt.Fprintf(w, "\t\tres = http.%s(%q,\n\t\t\t%q",
-					strings.ToLower(e.Request.Method), e.Request.URL, body)
+				fmt.Fprintf(w, "\t\tres = http.%s(", strings.ToLower(e.Request.Method))
+
+				if correlate && recordedRedirectUrl != "" {
+					if recordedRedirectUrl != e.Request.URL {
+						return "", errors.Errorf("The har file contained a redirect but the next request did not match that redirect. Possibly a misbehaving client or concurrent requests?")
+					}
+					fmt.Fprintf(w, "redirectUrl")
+					recordedRedirectUrl = ""
+				} else {
+					fmt.Fprintf(w, "%q", e.Request.URL)
+				}
+
+				if e.Request.Method != "GET" {
+					fmt.Fprintf(w, ", %q", body)
+				}
 
 				if len(params) > 0 {
 					fmt.Fprintf(w, ",\n\t\t\t{\n\t\t\t\t%s\n\t\t\t}", strings.Join(params, ",\n\t\t\t"))
@@ -133,6 +150,15 @@ func Convert(h HAR, includeCodeCheck bool, returnOnFailedCheck bool, batchTime u
 							fmt.Fprintf(w, "\t\tif (!check(res, {\"status is %v\": (r) => r.status === %v })) { return };\n", e.Response.Status, e.Response.Status)
 						} else {
 							fmt.Fprintf(w, "\t\tcheck(res, {\"status is %v\": (r) => r.status === %v });\n", e.Response.Status, e.Response.Status)
+						}
+					}
+				}
+
+				if e.Response.Headers != nil {
+					for _, header := range e.Response.Headers {
+						if header.Name == "Location" {
+							fmt.Fprintf(w, "\t\tredirectUrl = res.headers.Location;\n")
+							recordedRedirectUrl = header.Value
 						}
 					}
 				}

--- a/converter/har/converter.go
+++ b/converter/har/converter.go
@@ -159,6 +159,7 @@ func Convert(h HAR, includeCodeCheck bool, returnOnFailedCheck bool, batchTime u
 						if header.Name == "Location" {
 							fmt.Fprintf(w, "\t\tredirectUrl = res.headers.Location;\n")
 							recordedRedirectUrl = header.Value
+							break
 						}
 					}
 				}


### PR DESCRIPTION
Detect redirects in recordings and follow the redirects at runtime instead of following a hard-coded redirect. Also fix a bug with GET requests (http.get() does not take a body parameter)

