### PR TITLE
fix default test name from stdin

### DIFF
--- a/stats/cloud/collector.go
+++ b/stats/cloud/collector.go
@@ -64,7 +64,7 @@ func New(conf Config, src *lib.SourceData, opts lib.Options, version string) (*C
 	if conf.Name == "" {
 		conf.Name = filepath.Base(src.Filename)
 	}
-	if conf.Name == "" {
+	if conf.Name == "-" {
 		conf.Name = TestName
 	}
 


### PR DESCRIPTION
ref #375

This PR solves this issue:

```
docker run --rm -i loadimpact/k6:latest run -o cloud -<script.js
          /\      |‾‾|  /‾‾/  /‾/
     /\  /  \     |  |_/  /  / /
    /  \/    \    |      |  /  ‾‾\
   /          \   |  |‾\  \ | (_) |
  / __________ \  |__|  \__\ \___/ .io
time="2018-02-20T20:24:01Z" level=error msg="Unknown Error: {\n  \"error\": {\n    \"code\": 0, \n    \"details\": {\n      \"name\": [\n        \"Shorter than minimum length 2.\"\n      ]\n    }, \n    \"message\": \"Validation error\"\n  }\n}\n"
```

With STDIN mode the filename is "-", not "" (empty) (see https://github.com/loadimpact/k6/blob/master/cmd/run.go#L87)
and "-" length is shorter than 2, the minimum length for the test name.