### PR TITLE
Fix `cloud` collector when returning `iteration_duration` metric

### DIFF
--- a/stats/cloud/collector.go
+++ b/stats/cloud/collector.go
@@ -187,7 +187,7 @@ func (c *Collector) Collect(samples []stats.Sample) {
 			}
 			iterationJSON.Data.Values[name] = samp.Value
 			cloudSamples = append(cloudSamples, iterationJSON)
-		} else if name == "data_received" || name == "iter_duration" {
+		} else if name == "data_received" || name == "iteration_duration" {
 			iterationJSON.Data.Values[name] = samp.Value
 		} else if strings.HasPrefix(name, "http_req_") {
 			httpJSON.Data.Values[name] = samp.Value


### PR DESCRIPTION
Fix `cloud` collector when returning `iteration_duration` metric