### PR TITLE
Fix the error message for unexpected server responses

### DIFF
--- a/stats/cloud/client.go
+++ b/stats/cloud/client.go
@@ -179,7 +179,12 @@ func checkResponse(r *http.Response) error {
 		Error ErrorResponse `json:"error"`
 	}
 	if err := json.Unmarshal(data, &payload); err != nil {
-		return errors.Errorf("Unknown Error: %s", string(data))
+		return errors.Errorf(
+			"Unexpected HTTP error from %s: %d %s",
+			r.Request.URL,
+			r.StatusCode,
+			http.StatusText(r.StatusCode),
+		)
 	}
 	return payload.Error
 }


### PR DESCRIPTION
The current error message depends on the raw unexpected server output and can contain all sorts of unprintable characters while giving no actual information on the HTTP error.