### PR TITLE
Add a simple CI check for non vendored dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,12 @@ jobs:
             gometalinter --install
             gometalinter --deadline 10m --config gometalinter.json --vendor ./...
       - run:
+          name: Check dependencies
+          command: |
+            export PATH=$GOPATH/bin:$PATH
+            go get -u github.com/golang/dep/cmd/dep
+            dep status
+      - run:
           name: Run tests and code coverage
           command: |
             export PATH=$GOPATH/bin:$PATH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
             export PATH=$GOPATH/bin:$PATH
             go get -u github.com/golang/dep/cmd/dep
             dep status
+            dep ensure -update -dry-run
       - run:
           name: Run tests and code coverage
           command: |


### PR DESCRIPTION
From my local tests, this should be able to catch if we've forgotten to vendor something, but I'll test again it for real when it's merged into master.