### PR TITLE
Encode times as microsececond UNIX timestamps in cloud collector

### DIFF
--- a/stats/cloud/api.go
+++ b/stats/cloud/api.go
@@ -35,6 +35,28 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Timestamp is used for sending times encoded as microsecond UNIX timestamps to the cloud servers
+type Timestamp time.Time
+
+// MarshalJSON encodes the microsecond UNIX timestamps as strings because JavaScripts doesn't have actual integers and tends to round big numbers
+func (ct Timestamp) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + strconv.FormatInt(time.Time(ct).UnixNano()/1000, 10) + `"`), nil
+}
+
+// UnmarshalJSON decodes the string-enclosed microsecond timestamp back into the proper time.Time alias
+func (ct *Timestamp) UnmarshalJSON(p []byte) error {
+	var s string
+	if err := json.Unmarshal(p, &s); err != nil {
+		return err
+	}
+	microSecs, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return err
+	}
+	*ct = Timestamp(time.Unix(microSecs/1000000, (microSecs%1000000)*1000))
+	return nil
+}
+
 type Sample struct {
 	Type   string     `json:"type"`
 	Metric string     `json:"metric"`
@@ -43,7 +65,7 @@ type Sample struct {
 
 type SampleData struct {
 	Type   stats.MetricType   `json:"type"`
-	Time   time.Time          `json:"time"`
+	Time   Timestamp          `json:"time"`
 	Value  float64            `json:"value"`
 	Values map[string]float64 `json:"values,omitempty"`
 	Tags   map[string]string  `json:"tags,omitempty"`

--- a/stats/cloud/api_test.go
+++ b/stats/cloud/api_test.go
@@ -21,6 +21,7 @@
 package cloud
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -28,12 +29,56 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func init() {
 	_ = os.Setenv("K6CLOUD_HOST", "")
 	_ = os.Setenv("K6CLOUD_TOKEN", "")
+}
+
+func TestTimestampMarshaling(t *testing.T) {
+	oldTimeFormat, err := time.Parse(
+		time.RFC3339,
+		//1521806137415652223 as a unix nanosecond timestamp
+		"2018-03-23T13:55:37.415652223+02:00",
+	)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		t   time.Time
+		exp string
+	}{
+		{oldTimeFormat, `"1521806137415652"`},
+		{time.Unix(1521806137, 415652223), `"1521806137415652"`},
+		{time.Unix(1521806137, 0), `"1521806137000000"`},
+		{time.Unix(0, 0), `"0"`},
+		{time.Unix(0, 1), `"0"`},
+		{time.Unix(0, 1000), `"1"`},
+		{time.Unix(1, 0), `"1000000"`},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Test #%d", i), func(t *testing.T) {
+			res, err := json.Marshal(Timestamp(tc.t))
+			require.NoError(t, err)
+			assert.Equal(t, string(res), tc.exp)
+
+			var rev Timestamp
+			require.NoError(t, json.Unmarshal(res, &rev))
+			diff := tc.t.Sub(time.Time(rev))
+			if diff < -time.Microsecond || diff > time.Microsecond {
+				t.Errorf(
+					"Expected the difference to be under a microsecond, but is %s (%d and %d)",
+					diff,
+					tc.t.UnixNano(),
+					time.Time(rev).UnixNano(),
+				)
+			}
+		})
+	}
 }
 
 func TestCreateTestRun(t *testing.T) {
@@ -67,7 +112,7 @@ func TestPublishMetric(t *testing.T) {
 			Metric: "metric",
 			Data: SampleData{
 				Type:  1,
-				Time:  time.Now(),
+				Time:  Timestamp(time.Now()),
 				Value: 1.2,
 			},
 		},

--- a/stats/cloud/collector.go
+++ b/stats/cloud/collector.go
@@ -167,7 +167,7 @@ func (c *Collector) Collect(samples []stats.Sample) {
 				Metric: "http_req_li_all",
 				Data: SampleData{
 					Type:   samp.Metric.Type,
-					Time:   samp.Time,
+					Time:   Timestamp(samp.Time),
 					Tags:   samp.Tags,
 					Values: make(map[string]float64),
 				},
@@ -180,7 +180,7 @@ func (c *Collector) Collect(samples []stats.Sample) {
 				Metric: "iter_li_all",
 				Data: SampleData{
 					Type:   samp.Metric.Type,
-					Time:   samp.Time,
+					Time:   Timestamp(samp.Time),
 					Tags:   samp.Tags,
 					Values: make(map[string]float64),
 				},
@@ -197,7 +197,7 @@ func (c *Collector) Collect(samples []stats.Sample) {
 				Metric: name,
 				Data: SampleData{
 					Type:  samp.Metric.Type,
-					Time:  samp.Time,
+					Time:  Timestamp(samp.Time),
 					Value: samp.Value,
 					Tags:  samp.Tags,
 				},


### PR DESCRIPTION
This fixes https://github.com/loadimpact/k6/issues/513

@ppcano, @Griatch: please review and merge whenever you want. This is a relatively self-contained change, so I think it can wait as an open pull request until you want it and are ready for it in the backend.