### PR TITLE
Simplify the dummy collector

### DIFF
--- a/stats/dummy/collector.go
+++ b/stats/dummy/collector.go
@@ -22,46 +22,38 @@ package dummy
 
 import (
 	"context"
-	"sync"
 
 	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/stats"
 )
 
+// Collector implements the lib.Collector interface and should be used only for testing
 type Collector struct {
 	Samples []stats.Sample
-	running bool
-
-	lock sync.Mutex
 }
 
+// Init does nothing, it's only included to satisfy the lib.Collector interface
 func (c *Collector) Init() error { return nil }
 
+// MakeConfig does nothing, it's only included to satisfy the lib.Collector interface
 func (c *Collector) MakeConfig() interface{} { return nil }
 
+// Run just blocks until the context is done
 func (c *Collector) Run(ctx context.Context) {
-	c.lock.Lock()
-	c.running = true
-	c.lock.Unlock()
-
 	<-ctx.Done()
-
-	c.lock.Lock()
-	c.running = false
-	c.lock.Unlock()
 }
 
+// Collect just appends all of the samples passed to it to the internal sample slice.
+// According to the the lib.Collector interface, it should never be called concurrently,
+// so there's no locking on purpose - that way Go's race condition detector can actually
+// detect incorrect usage.
+// Also, theoretically the collector doesn't have to actually Run() before samples start
+// being collected, it only has to be initialized.
 func (c *Collector) Collect(samples []stats.Sample) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	//TODO: fix this check, was giving a hard time with testing
-	//if !c.running {
-	//	panic("attempted to collect while not running")
-	//}
 	c.Samples = append(c.Samples, samples...)
 }
 
+// Link returns a dummy string, it's only included to satisfy the lib.Collector interface
 func (c *Collector) Link() string {
 	return "http://example.com/"
 }

--- a/stats/dummy/collector_test.go
+++ b/stats/dummy/collector_test.go
@@ -44,11 +44,6 @@ func TestCollectorRun(t *testing.T) {
 
 func TestCollectorCollect(t *testing.T) {
 	c := &Collector{}
-	t.Run("context", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		go func() { c.Run(ctx) }()
-		c.Collect([]stats.Sample{{}})
-		assert.Len(t, c.Samples, 1)
-	})
+	c.Collect([]stats.Sample{{}})
+	assert.Len(t, c.Samples, 1)
 }


### PR DESCRIPTION
This should fix https://github.com/loadimpact/k6/issues/469 and simplify https://github.com/loadimpact/k6/pull/553

I investigated the `lib.Collector` interface and its various implementations and I think that the current assumption in the dummy stat collector that `Collect()` should only be called after `Run()` is wrong. The purpose of `Run()` is to periodically, in batches, send the collected samples to some upstream collector. It would be concurrently run with all of the calls to `Collect()` (which themselves should only be sequential), but I don't see a reason why it must be started before `Collect()` is ever called.

Also, the current synchronization in the dummy collector actually prevented something important from being tested. `Collect()` should never be called concurrently, and with the current locking, we probably wouldn't have known if that was actually the case. This pull request removes any locking from `Collect()` so that when [this](https://github.com/loadimpact/k6/issues/536) is fixed and we enable automatic testing with `-race`, Go's race condition detector can actually detect incorrect usage of the collector.

That's also one of the reasons that I gave up on the idea of using a channel instead a `[]stat.Sample` slice that I discussed with @antekresic in https://github.com/loadimpact/k6/pull/553. The other reason is that go doesn't have channels with infinite buffers and it would be inconvenient to specify exact buffer sizes in a lot of tests, for example [this one](https://github.com/loadimpact/k6/blob/fa5731484a9d8bbfe10a4af569dfe8978133ffd9/core/engine_test.go#L493). In the end it's also not really necessary and sample slices are simpler than channels.