### PR TITLE
Better error message when script/module can't be found

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -22,7 +22,9 @@ package loader
 
 import (
 	"io/ioutil"
+	"net"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -119,15 +121,15 @@ func Load(fs afero.Fs, pwd, name string) (*lib.SourceData, error) {
 	// If its not a file, check is it a remote location. HTTPS is enforced, because it's 2017, HTTPS is easy,
 	// running arbitrary, trivially MitM'd code (even sandboxed) is very, very bad.
 	origURL := "https://" + name
-	//parsedURL, err := url.Parse(origURL)
+	parsedURL, err := url.Parse(origURL)
 
-	//if err != nil {
-	//	return nil, errors.Errorf(invalidScriptErrMsg, name)
-	//}
+	if err != nil {
+		return nil, errors.Errorf(invalidScriptErrMsg, name)
+	}
 
-	//if _, err = net.LookupHost(parsedURL.Hostname()); err != nil {
-	//	return nil, errors.Errorf(invalidScriptErrMsg, name)
-	//}
+	if _, err = net.LookupHost(parsedURL.Hostname()); err != nil {
+		return nil, errors.Errorf(invalidScriptErrMsg, name)
+	}
 
 	// Load it and have a look.
 	url := origURL

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -118,7 +118,7 @@ func Load(fs afero.Fs, pwd, name string) (*lib.SourceData, error) {
 		return &lib.SourceData{Filename: name, Data: data}, nil
 	}
 
-	// If its not a file, check is it a remote location. HTTPS is enforced, because it's 2017, HTTPS is easy,
+	// If it's not a file, check is it a remote location. HTTPS is enforced, because it's 2017, HTTPS is easy,
 	// running arbitrary, trivially MitM'd code (even sandboxed) is very, very bad.
 	origURL := "https://" + name
 	parsedURL, err := url.Parse(origURL)

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -131,4 +131,17 @@ func TestLoad(t *testing.T) {
 			assert.Equal(t, responseStr, string(src.Data))
 		}
 	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		t.Run("Host", func(t *testing.T) {
+			src, err := Load(nil, "/", "some-path-that-doesnt-exist.js")
+			assert.Nil(t, src)
+			assert.Error(t, err)
+		})
+		t.Run("URL", func(t *testing.T) {
+			src, err := Load(nil, "/", "192.168.0.%31")
+			assert.Nil(t, src)
+			assert.Error(t, err)
+		})
+	})
 }


### PR DESCRIPTION
Closes #528 

I added some checks for URL parsing and valid hostnames but I guess this would work without those. Let me know if we want to remove them.