### PR TITLE
Add missed updates to upcoming.md

### DIFF
--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -8,7 +8,7 @@ You can now specify any number of tags on the command line using the `--tag NAME
 
 The specified tags will be applied across all metrics. However if you have set a tag with the same name on a request, check or custom metric in the code that tag value will have precedence.
 
-Thanks @antekresic for their work on this!
+Thanks to @antekresic for their work on this!
 
 **Docs**: [Test wide tags](https://docs.k6.io/v1.0/docs/tags-and-groups#section-test-wide-tags) and [Options](https://docs.k6.io/v1.0/docs/options#section-available-options)
 
@@ -35,7 +35,9 @@ export default function() {
 ## UX
 
 * Clearer error message when using `open` function outside init context (#563)
+* Better error message when a script or module can't be found (#565). Thanks to @antekresic for their work on this!
 
 ## Internals
 
+* Removed all httpbin.org usage in tests, now a local transient HTTP server is used instead (#555). Thanks to @mccutchen for the great [go-httpbin](https://github.com/mccutchen/go-httpbin) library!
 * Fixed various data races and enabled automated testing with `-race` (#564)


### PR DESCRIPTION
The release notes were forgotten for https://github.com/loadimpact/k6/pull/565 by @antekresic and https://github.com/loadimpact/k6/pull/555