### PR TITLE
Refactor sample tags and per-run tags

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -25,6 +25,8 @@ import (
 	"net"
 	"strings"
 
+	"github.com/loadimpact/k6/stats"
+
 	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/ui"
 	"github.com/pkg/errors"
@@ -129,15 +131,17 @@ func getOptions(flags *pflag.FlagSet) (lib.Options, error) {
 	if err != nil {
 		return opts, err
 	}
+
 	if len(runTags) > 0 {
-		opts.RunTags = make(map[string]string)
-		var name, value string
+		parsedRunTags := make(map[string]string, len(runTags))
 		for i, s := range runTags {
-			if name, value, err = parseTagNameValue(s); err != nil {
+			name, value, err := parseTagNameValue(s)
+			if err != nil {
 				return opts, errors.Wrapf(err, "tag %d", i)
 			}
-			opts.RunTags[name] = value
+			parsedRunTags[name] = value
 		}
+		opts.RunTags = stats.IntoSampleTags(&parsedRunTags)
 	}
 
 	return opts, nil

--- a/core/local/local.go
+++ b/core/local/local.go
@@ -278,10 +278,15 @@ func (e *Executor) Run(parent context.Context, out chan<- []stats.Sample) (reter
 			// Every iteration ends with a write to vuOut. Check if we've hit the end point.
 			// If not, make sure to include an Iterations bump in the list!
 			if out != nil {
+				var tags *stats.SampleTags
+				if e.Runner != nil {
+					tags = e.Runner.GetOptions().RunTags
+				}
 				samples = append(samples, stats.Sample{
 					Time:   time.Now(),
 					Metric: metrics.Iterations,
 					Value:  1,
+					Tags:   tags,
 				})
 				out <- samples
 			}

--- a/js/modules/k6/http/http_request.go
+++ b/js/modules/k6/http/http_request.go
@@ -188,7 +188,7 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 		req.Header.Set("User-Agent", userAgent.String)
 	}
 
-	tags := map[string]string{}
+	tags := state.Options.RunTags.CloneTags()
 	if state.Options.SystemTags["method"] {
 		tags["method"] = method
 	}
@@ -394,7 +394,7 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 			req.Header.Set(digest.KEY_AUTHORIZATION, authorization)
 		}
 
-		statsSamples = append(statsSamples, tracer.Done().Samples(tags)...)
+		statsSamples = append(statsSamples, tracer.Done().Samples(stats.NewSampleTags(tags))...)
 	}
 
 	if auth == "ntlm" {
@@ -517,7 +517,7 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 		}
 	}
 
-	statsSamples = append(statsSamples, trail.Samples(tags)...)
+	statsSamples = append(statsSamples, trail.Samples(stats.IntoSampleTags(&tags))...)
 	return resp, statsSamples, nil
 }
 

--- a/js/modules/k6/http/http_request_test.go
+++ b/js/modules/k6/http/http_request_test.go
@@ -61,7 +61,8 @@ func assertRequestMetricsEmitted(t *testing.T, samples []stats.Sample, method, u
 	seenWaiting := false
 	seenReceiving := false
 	for _, sample := range samples {
-		if sample.Tags["url"] == url {
+		tags := sample.Tags.CloneTags()
+		if tags["url"] == url {
 			switch sample.Metric {
 			case metrics.HTTPReqDuration:
 				seenDuration = true
@@ -79,10 +80,10 @@ func assertRequestMetricsEmitted(t *testing.T, samples []stats.Sample, method, u
 				seenReceiving = true
 			}
 
-			assert.Equal(t, strconv.Itoa(status), sample.Tags["status"])
-			assert.Equal(t, method, sample.Tags["method"])
-			assert.Equal(t, group, sample.Tags["group"])
-			assert.Equal(t, name, sample.Tags["name"])
+			assert.Equal(t, strconv.Itoa(status), tags["status"])
+			assert.Equal(t, method, tags["method"])
+			assert.Equal(t, group, tags["group"])
+			assert.Equal(t, name, tags["name"])
 		}
 	}
 	assert.True(t, seenDuration, "url %s didn't emit Duration", url)
@@ -309,7 +310,9 @@ func TestRequestAndBatch(t *testing.T) {
 		assert.NoError(t, err)
 		assertRequestMetricsEmitted(t, state.Samples, "GET", "https://http2.akamai.com/demo", "", 200, "")
 		for _, sample := range state.Samples {
-			assert.Equal(t, "HTTP/2.0", sample.Tags["proto"])
+			proto, ok := sample.Tags.Get("proto")
+			assert.True(t, ok)
+			assert.Equal(t, "HTTP/2.0", proto)
 		}
 	})
 	t.Run("TLS", func(t *testing.T) {
@@ -719,7 +722,9 @@ func TestRequestAndBatch(t *testing.T) {
 				assert.NoError(t, err)
 				assertRequestMetricsEmitted(t, state.Samples, "GET", sr("HTTPBIN_URL/headers"), "", 200, "")
 				for _, sample := range state.Samples {
-					assert.Equal(t, "value", sample.Tags["tag"])
+					tagValue, ok := sample.Tags.Get("tag")
+					assert.True(t, ok)
+					assert.Equal(t, "value", tagValue)
 				}
 			})
 		})
@@ -1004,7 +1009,7 @@ func TestSystemTags(t *testing.T) {
 			assert.NotEmpty(t, state.Samples)
 			for _, sample := range state.Samples {
 				assert.NotEmpty(t, sample.Tags)
-				for emittedTag := range sample.Tags {
+				for emittedTag := range sample.Tags.CloneTags() {
 					assert.Equal(t, expectedTag, emittedTag)
 				}
 			}

--- a/js/modules/k6/k6_test.go
+++ b/js/modules/k6/k6_test.go
@@ -144,7 +144,7 @@ func TestCheck(t *testing.T) {
 			assert.Equal(t, map[string]string{
 				"group": "",
 				"check": "check",
-			}, state.Samples[0].Tags)
+			}, state.Samples[0].Tags.CloneTags())
 		}
 
 		t.Run("Multiple", func(t *testing.T) {
@@ -157,7 +157,8 @@ func TestCheck(t *testing.T) {
 			assert.Len(t, state.Samples, 2)
 			var foundA, foundB bool
 			for _, sample := range state.Samples {
-				name := sample.Tags["check"]
+				name, ok := sample.Tags.Get("check")
+				assert.True(t, ok)
 				switch name {
 				case "a":
 					assert.False(t, foundA, "duplicate 'a'")
@@ -193,7 +194,7 @@ func TestCheck(t *testing.T) {
 			assert.Equal(t, map[string]string{
 				"group": "",
 				"check": "0",
-			}, state.Samples[0].Tags)
+			}, state.Samples[0].Tags.CloneTags())
 		}
 	})
 
@@ -257,7 +258,7 @@ func TestCheck(t *testing.T) {
 							assert.Equal(t, map[string]string{
 								"group": "",
 								"check": "check",
-							}, state.Samples[0].Tags)
+							}, state.Samples[0].Tags.CloneTags())
 						}
 					})
 				}
@@ -311,7 +312,7 @@ func TestCheck(t *testing.T) {
 				"check": "check",
 				"a":     "1",
 				"b":     "2",
-			}, state.Samples[0].Tags)
+			}, state.Samples[0].Tags.CloneTags())
 		}
 	})
 }

--- a/js/modules/k6/metrics/metrics.go
+++ b/js/modules/k6/metrics/metrics.go
@@ -51,9 +51,11 @@ func newMetric(ctxPtr *context.Context, name string, t stats.MetricType, isTime 
 func (m Metric) Add(ctx context.Context, v goja.Value, addTags ...map[string]string) {
 	state := common.GetState(ctx)
 
-	tags := map[string]string{
-		"group": state.Group.Path,
+	tags := state.Options.RunTags.CloneTags()
+	if state.Options.SystemTags["group"] {
+		tags["group"] = state.Group.Path
 	}
+
 	for _, ts := range addTags {
 		for k, v := range ts {
 			tags[k] = v
@@ -66,7 +68,7 @@ func (m Metric) Add(ctx context.Context, v goja.Value, addTags ...map[string]str
 	}
 
 	state.Samples = append(state.Samples,
-		stats.Sample{Time: time.Now(), Metric: m.metric, Value: vfloat, Tags: tags},
+		stats.Sample{Time: time.Now(), Metric: m.metric, Value: vfloat, Tags: stats.IntoSampleTags(&tags)},
 	)
 }
 

--- a/js/modules/k6/metrics/metrics_test.go
+++ b/js/modules/k6/metrics/metrics_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 func TestMetrics(t *testing.T) {
+	t.Parallel()
 	types := map[string]stats.MetricType{
 		"Counter": stats.Counter,
 		"Gauge":   stats.Gauge,
@@ -50,8 +51,10 @@ func TestMetrics(t *testing.T) {
 	}
 	for fn, mtyp := range types {
 		t.Run(fn, func(t *testing.T) {
+			t.Parallel()
 			for isTime, valueType := range map[bool]stats.ValueType{false: stats.Default, true: stats.Time} {
 				t.Run(fmt.Sprintf("isTime=%v", isTime), func(t *testing.T) {
+					t.Parallel()
 					rt := goja.New()
 					rt.SetFieldNameMapper(common.FieldNameMapper{})
 
@@ -61,7 +64,10 @@ func TestMetrics(t *testing.T) {
 
 					root, _ := lib.NewGroup("", nil)
 					child, _ := root.Group("child")
-					state := &common.State{Group: root}
+					state := &common.State{
+						Options: lib.Options{SystemTags: lib.GetTagSet("group")},
+						Group:   root,
+					}
 
 					isTimeString := ""
 					if isTime {
@@ -98,7 +104,7 @@ func TestMetrics(t *testing.T) {
 											assert.Equal(t, state.Samples[0].Value, val.Float)
 											assert.Equal(t, map[string]string{
 												"group": g.Path,
-											}, state.Samples[0].Tags)
+											}, state.Samples[0].Tags.CloneTags())
 											assert.Equal(t, "my_metric", state.Samples[0].Metric.Name)
 											assert.Equal(t, mtyp, state.Samples[0].Metric.Type)
 											assert.Equal(t, valueType, state.Samples[0].Metric.Contains)
@@ -114,7 +120,7 @@ func TestMetrics(t *testing.T) {
 											assert.Equal(t, map[string]string{
 												"group": g.Path,
 												"a":     "1",
-											}, state.Samples[0].Tags)
+											}, state.Samples[0].Tags.CloneTags())
 											assert.Equal(t, "my_metric", state.Samples[0].Metric.Name)
 											assert.Equal(t, mtyp, state.Samples[0].Metric.Type)
 											assert.Equal(t, valueType, state.Samples[0].Metric.Contains)

--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -102,7 +102,7 @@ func (*WS) Connect(ctx context.Context, url string, args ...goja.Value) (*WSHTTP
 	// Leave header to nil by default so we can pass it directly to the Dialer
 	var header http.Header
 
-	tags := map[string]string{}
+	tags := state.Options.RunTags.CloneTags()
 	if state.Options.SystemTags["url"] {
 		tags["url"] = url
 	}
@@ -266,17 +266,19 @@ func (*WS) Connect(ctx context.Context, url string, args ...goja.Value) (*WSHTTP
 			end := time.Now()
 			sessionDuration := stats.D(end.Sub(start))
 
+			sampleTags := stats.IntoSampleTags(&tags)
+
 			samples := []stats.Sample{
-				{Metric: metrics.WSSessions, Time: start, Tags: tags, Value: 1},
-				{Metric: metrics.WSConnecting, Time: start, Tags: tags, Value: connectionDuration},
-				{Metric: metrics.WSSessionDuration, Time: start, Tags: tags, Value: sessionDuration},
+				{Metric: metrics.WSSessions, Time: start, Tags: sampleTags, Value: 1},
+				{Metric: metrics.WSConnecting, Time: start, Tags: sampleTags, Value: connectionDuration},
+				{Metric: metrics.WSSessionDuration, Time: start, Tags: sampleTags, Value: sessionDuration},
 			}
 
 			for _, msgSentTimestamp := range socket.msgSentTimestamps {
 				samples = append(samples, stats.Sample{
 					Metric: metrics.WSMessagesSent,
 					Time:   msgSentTimestamp,
-					Tags:   tags,
+					Tags:   sampleTags,
 					Value:  1,
 				})
 			}
@@ -285,7 +287,7 @@ func (*WS) Connect(ctx context.Context, url string, args ...goja.Value) (*WSHTTP
 				samples = append(samples, stats.Sample{
 					Metric: metrics.WSMessagesReceived,
 					Time:   msgReceivedTimestamp,
-					Tags:   tags,
+					Tags:   sampleTags,
 					Value:  1,
 				})
 			}
@@ -294,7 +296,7 @@ func (*WS) Connect(ctx context.Context, url string, args ...goja.Value) (*WSHTTP
 				samples = append(samples, stats.Sample{
 					Metric: metrics.WSPing,
 					Time:   pingDelta.pong,
-					Tags:   tags,
+					Tags:   sampleTags,
 					Value:  stats.D(pingDelta.pong.Sub(pingDelta.ping)),
 				})
 			}

--- a/js/runner.go
+++ b/js/runner.go
@@ -348,7 +348,7 @@ func (u *VU) runFn(ctx context.Context, fn goja.Callable, args ...goja.Value) (g
 	v, err := fn(goja.Undefined(), args...) // Actually run the JS script
 	t := time.Now()
 
-	tags := map[string]string{}
+	tags := state.Options.RunTags.CloneTags()
 	if state.Options.SystemTags["vu"] {
 		tags["vu"] = strconv.FormatInt(u.ID, 10)
 	}
@@ -356,10 +356,12 @@ func (u *VU) runFn(ctx context.Context, fn goja.Callable, args ...goja.Value) (g
 		tags["iter"] = strconv.FormatInt(iter, 10)
 	}
 
+	sampleTags := stats.IntoSampleTags(&tags)
+
 	state.Samples = append(state.Samples,
-		stats.Sample{Time: t, Metric: metrics.DataSent, Value: float64(u.Dialer.BytesWritten), Tags: tags},
-		stats.Sample{Time: t, Metric: metrics.DataReceived, Value: float64(u.Dialer.BytesRead), Tags: tags},
-		stats.Sample{Time: t, Metric: metrics.IterationDuration, Value: stats.D(t.Sub(startTime)), Tags: tags},
+		stats.Sample{Time: t, Metric: metrics.DataSent, Value: float64(u.Dialer.BytesWritten), Tags: sampleTags},
+		stats.Sample{Time: t, Metric: metrics.DataReceived, Value: float64(u.Dialer.BytesRead), Tags: sampleTags},
+		stats.Sample{Time: t, Metric: metrics.IterationDuration, Value: stats.D(t.Sub(startTime)), Tags: sampleTags},
 	)
 
 	if u.Runner.Bundle.Options.NoConnectionReuse.Bool {

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -687,7 +687,7 @@ func TestVUIntegrationHTTP2(t *testing.T) {
 
 			protoFound := false
 			for _, sample := range samples {
-				if proto := sample.Tags["proto"]; proto != "" {
+				if proto, ok := sample.Tags.Get("proto"); ok {
 					protoFound = true
 					assert.Equal(t, "HTTP/2.0", proto)
 				}

--- a/lib/netext/tracer.go
+++ b/lib/netext/tracer.go
@@ -55,7 +55,7 @@ type Trail struct {
 }
 
 // Samples returns a slice with all of the pre-calculated sample values for the request
-func (tr Trail) Samples(tags map[string]string) []stats.Sample {
+func (tr Trail) Samples(tags *stats.SampleTags) []stats.Sample {
 	return []stats.Sample{
 		{Metric: metrics.HTTPReqs, Time: tr.EndTime, Tags: tags, Value: 1},
 		{Metric: metrics.HTTPReqDuration, Time: tr.EndTime, Tags: tags, Value: stats.D(tr.Duration)},

--- a/lib/netext/tracer_test.go
+++ b/lib/netext/tracer_test.go
@@ -75,7 +75,7 @@ func TestTracer(t *testing.T) {
 			_, err = io.Copy(ioutil.Discard, res.Body)
 			assert.NoError(t, err)
 			assert.NoError(t, res.Body.Close())
-			samples := tracer.Done().Samples(map[string]string{"tag": "value"})
+			samples := tracer.Done().Samples(stats.IntoSampleTags(&map[string]string{"tag": "value"}))
 
 			assert.Empty(t, tracer.protoErrors)
 			assertLaterOrZero(t, tracer.getConn, isReuse)
@@ -95,7 +95,7 @@ func TestTracer(t *testing.T) {
 				seenMetrics[s.Metric] = true
 
 				assert.False(t, s.Time.IsZero())
-				assert.Equal(t, map[string]string{"tag": "value"}, s.Tags)
+				assert.Equal(t, map[string]string{"tag": "value"}, s.Tags.CloneTags())
 
 				switch s.Metric {
 				case metrics.HTTPReqs:

--- a/lib/options.go
+++ b/lib/options.go
@@ -246,7 +246,7 @@ type Options struct {
 	SystemTags TagSet `json:"systemTags" envconfig:"system_tags"`
 
 	// Tags to be applied to all samples for this running
-	RunTags map[string]string `json:"tags" envconfig:"tags"`
+	RunTags *stats.SampleTags `json:"tags" envconfig:"tags"`
 }
 
 // Returns the result of overwriting any fields with any that are set on the argument.
@@ -327,7 +327,6 @@ func (o Options) Apply(opts Options) Options {
 	}
 	if opts.SystemTags != nil {
 		o.SystemTags = opts.SystemTags
-
 	}
 	if opts.RunTags != nil {
 		o.RunTags = opts.RunTags

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -351,7 +351,7 @@ func TestOptions(t *testing.T) {
 		assert.Equal(t, stats, opts.SummaryTrendStats)
 	})
 	t.Run("RunTags", func(t *testing.T) {
-		tags := map[string]string{"myTag": "hello"}
+		tags := stats.IntoSampleTags(&map[string]string{"myTag": "hello"})
 		opts := Options{}.Apply(Options{RunTags: tags})
 		assert.Equal(t, tags, opts.RunTags)
 	})

--- a/lib/testutils/httpmultibin.go
+++ b/lib/testutils/httpmultibin.go
@@ -33,8 +33,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/loadimpact/k6/lib/netext"
 	"github.com/mccutchen/go-httpbin/httpbin"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http2"
 )
@@ -77,10 +79,35 @@ type HTTPMultiBin struct {
 	Cleanup         func()
 }
 
+func getWebsocketEchoHandler(t *testing.T) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conn, err := (&websocket.Upgrader{}).Upgrade(w, req, w.Header())
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		mt, message, err := conn.ReadMessage()
+		assert.NoError(t, err)
+		assert.NoError(t, conn.WriteMessage(mt, message))
+		assert.NoError(t, conn.Close())
+	})
+}
+func getWebsocketCloserHandler(t *testing.T) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conn, err := (&websocket.Upgrader{}).Upgrade(w, req, w.Header())
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.NoError(t, conn.Close())
+	})
+}
+
 // NewHTTPMultiBin returns a fully configured and running HTTPMultiBin
 func NewHTTPMultiBin(t *testing.T) *HTTPMultiBin {
 	// Create a http.ServeMux and set the httpbin handler as the default
 	mux := http.NewServeMux()
+	mux.Handle("/ws-echo", getWebsocketEchoHandler(t))
+	mux.Handle("/ws-close", getWebsocketCloserHandler(t))
 	mux.Handle("/", httpbin.NewHTTPBin().Handler())
 
 	// Initialize the HTTP server and get its details

--- a/stats/cloud/api.go
+++ b/stats/cloud/api.go
@@ -46,7 +46,7 @@ type SampleData struct {
 	Time   time.Time          `json:"time"`
 	Value  float64            `json:"value"`
 	Values map[string]float64 `json:"values,omitempty"`
-	Tags   map[string]string  `json:"tags,omitempty"`
+	Tags   *stats.SampleTags  `json:"tags,omitempty"`
 }
 
 type ThresholdResult map[string]map[string]bool

--- a/stats/cloud/collector.go
+++ b/stats/cloud/collector.go
@@ -34,8 +34,8 @@ import (
 )
 
 const (
-	TestName          = "k6 test"
-	MetricPushinteral = 1 * time.Second
+	TestName           = "k6 test"
+	MetricPushInterval = 1 * time.Second
 )
 
 // Collector sends result data to the Load Impact cloud service.
@@ -132,7 +132,7 @@ func (c *Collector) Link() string {
 }
 
 func (c *Collector) Run(ctx context.Context) {
-	timer := time.NewTicker(MetricPushinteral)
+	timer := time.NewTicker(MetricPushInterval)
 
 	for {
 		select {
@@ -188,8 +188,10 @@ func (c *Collector) Collect(samples []stats.Sample) {
 			iterationJSON.Data.Values[name] = samp.Value
 			cloudSamples = append(cloudSamples, iterationJSON)
 		} else if name == "data_received" || name == "iteration_duration" {
+			//TODO: make sure that tags match
 			iterationJSON.Data.Values[name] = samp.Value
 		} else if strings.HasPrefix(name, "http_req_") {
+			//TODO: make sure that tags match
 			httpJSON.Data.Values[name] = samp.Value
 		} else {
 			sampleJSON := &Sample{

--- a/stats/influxdb/collector.go
+++ b/stats/influxdb/collector.go
@@ -110,7 +110,7 @@ func (c *Collector) commit() {
 	for _, sample := range samples {
 		p, err := client.NewPoint(
 			sample.Metric.Name,
-			sample.Tags,
+			sample.Tags.CloneTags(), //TODO: optimize when implementing https://github.com/loadimpact/k6/issues/569
 			map[string]interface{}{"value": sample.Value},
 			sample.Time,
 		)

--- a/stats/json/wrapper.go
+++ b/stats/json/wrapper.go
@@ -35,7 +35,7 @@ type Envelope struct {
 type JSONSample struct {
 	Time  time.Time         `json:"time"`
 	Value float64           `json:"value"`
-	Tags  map[string]string `json:"tags"`
+	Tags  *stats.SampleTags `json:"tags"`
 }
 
 func NewJSONSample(sample *stats.Sample) *JSONSample {

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -181,7 +181,7 @@ func (st *SampleTags) Get(key string) (string, bool) {
 	return val, ok
 }
 
-// IsEqual trues to compare two tag sets with maximum efficiency.
+// IsEqual tries to compare two tag sets with maximum efficiency.
 func (st *SampleTags) IsEqual(other *SampleTags) bool {
 	if st == other {
 		return true
@@ -224,8 +224,8 @@ func (st *SampleTags) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &st.tags)
 }
 
-// CloneTags copies and sample tags and underlying tag set returns
-// the result. If the receiver is nil, it returns an empty non-nil map.
+// CloneTags copies the underlying set of a sample tags and
+// returns it. If the receiver is nil, it returns an empty non-nil map.
 func (st *SampleTags) CloneTags() map[string]string {
 	res := map[string]string{}
 	if st != nil {

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -21,6 +21,7 @@
 package stats
 
 import (
+	"encoding/json"
 	"errors"
 	"strconv"
 	"strings"
@@ -160,11 +161,106 @@ func (t ValueType) String() string {
 	}
 }
 
+// SampleTags is an immutable string[string] map for tags. Once a tag
+// set is created, direct modification is prohibited. It has
+// copy-on-write semantics and uses pointers for faster comparison
+// between maps, since the same tag set is often used for multiple samples.
+// All methods should not panic, even if they are called on a nil pointer.
+type SampleTags struct {
+	tags map[string]string
+	json []byte
+}
+
+// Get returns an empty string and false if the the requested key is not
+// present or its value and true if it is.
+func (st *SampleTags) Get(key string) (string, bool) {
+	if st == nil {
+		return "", false
+	}
+	val, ok := st.tags[key]
+	return val, ok
+}
+
+// IsEqual trues to compare two tag sets with maximum efficiency.
+func (st *SampleTags) IsEqual(other *SampleTags) bool {
+	if st == other {
+		return true
+	}
+	if st == nil || other == nil || len(st.tags) != len(other.tags) {
+		return false
+	}
+	for k, v := range st.tags {
+		if otherv, ok := other.tags[k]; !ok || v != otherv {
+			return false
+		}
+	}
+	return true
+}
+
+// MarshalJSON serializes SampleTags to a JSON string and caches
+// the result. It is not thread safe in the sense that the Go race
+// detector will complain if it's used concurrently, but no data
+// should be corrupted.
+func (st *SampleTags) MarshalJSON() ([]byte, error) {
+	if st == nil {
+		return []byte("null"), nil
+	}
+	if st.json != nil {
+		return st.json, nil
+	}
+	res, err := json.Marshal(st.tags)
+	if err != nil {
+		return res, err
+	}
+	st.json = res
+	return res, nil
+}
+
+// UnmarshalJSON deserializes SampleTags from a JSON string.
+func (st *SampleTags) UnmarshalJSON(data []byte) error {
+	if st == nil {
+		*st = SampleTags{}
+	}
+	return json.Unmarshal(data, &st.tags)
+}
+
+// CloneTags copies and sample tags and underlying tag set returns
+// the result. If the receiver is nil, it returns an empty non-nil map.
+func (st *SampleTags) CloneTags() map[string]string {
+	res := map[string]string{}
+	if st != nil {
+		for k, v := range st.tags {
+			res[k] = v
+		}
+	}
+	return res
+}
+
+// NewSampleTags *copies* the supplied tag set and returns a new SampleTags
+// instance with the key-value pairs from it.
+func NewSampleTags(data map[string]string) *SampleTags {
+	tags := map[string]string{}
+	for k, v := range data {
+		tags[k] = v
+	}
+	return &SampleTags{tags: tags}
+}
+
+// IntoSampleTags "consumes" the passed map and creates a new SampleTags
+// struct with the data. The map is set to nil as a hint that it shouldn't
+// be changed after it has been transformed into an "immutable" tag set.
+// Oh, how I miss Rust and move semantics... :)
+func IntoSampleTags(data *map[string]string) *SampleTags {
+	res := SampleTags{tags: *data}
+	*data = nil
+	return &res
+}
+
 // A Sample is a single measurement.
 type Sample struct {
 	Metric *Metric
 	Time   time.Time
-	Tags   map[string]string
+	Tags   *SampleTags
 	Value  float64
 }
 
@@ -231,11 +327,11 @@ func (m *Metric) HumanizeValue(v float64) string {
 
 // A Submetric represents a filtered dataset based on a parent metric.
 type Submetric struct {
-	Name   string            `json:"name"`
-	Parent string            `json:"parent"`
-	Suffix string            `json:"suffix"`
-	Tags   map[string]string `json:"tags"`
-	Metric *Metric           `json:"-"`
+	Name   string      `json:"name"`
+	Parent string      `json:"parent"`
+	Suffix string      `json:"suffix"`
+	Tags   *SampleTags `json:"tags"`
+	Metric *Metric     `json:"-"`
 }
 
 // Creates a submetric from a name.
@@ -262,7 +358,7 @@ func NewSubmetric(name string) (parentName string, sm *Submetric) {
 		value := strings.TrimSpace(strings.Trim(parts[1], `"'`))
 		tags[key] = value
 	}
-	return parts[0], &Submetric{Name: name, Parent: parts[0], Suffix: parts[1], Tags: tags}
+	return parts[0], &Submetric{Name: name, Parent: parts[0], Suffix: parts[1], Tags: IntoSampleTags(&tags)}
 }
 
 func (m *Metric) Summary(t time.Duration) *Summary {


### PR DESCRIPTION
This optimizes how sample tags are created, stored and compared in preparation for the cloud output aggregation functionality. There also are some fixes to the per-run tags and system tags and a much more comprehensive test for per-run tags as well.