### PR TITLE
Fix a data race and expand tests

### DIFF
--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -626,26 +626,30 @@ func TestRunTags(t *testing.T) {
 			})
 
 			group("websockets", function() {
-				var response = ws.connect("wss://HTTPSBIN_IP:HTTPSBIN_PORT/ws-close", params, function (socket) {
-					socket.close()
-					/*
-					//TODO: enable these and use /ws-echo endpoint when data race is fixed
+				var response = ws.connect("wss://HTTPSBIN_IP:HTTPSBIN_PORT/ws-echo", params, function (socket) {
 					socket.on('open', function open() {
-						console.log('connected');
+						console.log('ws open and say hello');
 						socket.send("hello");
 					});
 
 					socket.on('message', function (message) {
+						console.log('ws got message ' + message);
 						if (message != "hello") {
 							fail("Expected to receive 'hello' but got '" + message + "' instead !");
 						}
+						console.log('ws closing socket...');
+						socket.close();
 					});
 
 					socket.on('close', function () {
-						console.log('disconnected');
+						console.log('ws close');
 					});
-					*/
+
+					socket.on('error', function (e) {
+						console.log('ws error: ' + e.error());
+					});
 				});
+				console.log('connect returned');
 				check(response, { "status is 101": (r) => r && r.status === 101 }, customTags);
 			})
 

--- a/lib/testutils/httpmultibin.go
+++ b/lib/testutils/httpmultibin.go
@@ -81,15 +81,19 @@ type HTTPMultiBin struct {
 
 func getWebsocketEchoHandler(t *testing.T) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		t.Logf("[%p %s] Upgrading to websocket connection...", req, req.URL)
 		conn, err := (&websocket.Upgrader{}).Upgrade(w, req, w.Header())
 		if !assert.NoError(t, err) {
 			return
 		}
+		t.Logf("[%p %s] Upgraded...", req, req.URL)
 
 		mt, message, err := conn.ReadMessage()
+		t.Logf("[%p %s] Read message '%s' of type %d (error '%v')", req, req.URL, message, mt, err)
 		assert.NoError(t, err)
 		assert.NoError(t, conn.WriteMessage(mt, message))
 		assert.NoError(t, conn.Close())
+		t.Logf("[%p %s] Wrote back message '%s' of type %d and closed the connection", req, req.URL, message, mt)
 	})
 }
 func getWebsocketCloserHandler(t *testing.T) http.Handler {


### PR DESCRIPTION
This is a continuation of https://github.com/loadimpact/k6/pull/564, fixing another data race with `ByteRead` and `BytesWritten` that I found while doing https://github.com/loadimpact/k6/pull/578, because it seems to be most easily revealed by websocket tests. Thus now the commented out test sections from https://github.com/loadimpact/k6/pull/578 are enabled again.