### PR TITLE
Influxdb tags as fields

### DIFF
--- a/cmd/collectors.go
+++ b/cmd/collectors.go
@@ -68,7 +68,7 @@ func newCollector(collectorName, arg string, src *lib.SourceData, conf Config) (
 		case collectorJSON:
 			return jsonc.New(afero.NewOsFs(), arg)
 		case collectorInfluxDB:
-			config := conf.Collectors.InfluxDB
+			config := influxdb.NewConfig().Apply(conf.Collectors.InfluxDB)
 			if err := loadConfig(&config); err != nil {
 				return nil, err
 			}

--- a/cmd/login_influxdb.go
+++ b/cmd/login_influxdb.go
@@ -46,7 +46,7 @@ This will set the default server used when just "-o influxdb" is passed.`,
 			return err
 		}
 
-		conf := config.Collectors.InfluxDB
+		conf := influxdb.NewConfig().Apply(config.Collectors.InfluxDB)
 		if len(args) > 0 {
 			if err := conf.UnmarshalText([]byte(args[0])); err != nil {
 				return err

--- a/samples/config.json
+++ b/samples/config.json
@@ -2,7 +2,7 @@
   "vus": 100,
   "collectors": {
     "influxdb": {
-      "tagsAsFields": ["vu","iter"]
+      "tagsAsFields": ["vu","iter", "url", "name"]
     }
   }
 }

--- a/samples/config.json
+++ b/samples/config.json
@@ -1,3 +1,8 @@
 {
-	"vus": 100
+  "vus": 100,
+  "collectors": {
+    "influxdb": {
+      "tagsAsFields": ["vu","iter"]
+    }
+  }
 }

--- a/stats/influxdb/config.go
+++ b/stats/influxdb/config.go
@@ -38,10 +38,11 @@ type ConfigFields struct {
 	PayloadSize int    `json:"payload_size,omitempty" envconfig:"INFLUXDB_PAYLOAD_SIZE"`
 
 	// Samples.
-	DB          string `json:"db" envconfig:"INFLUXDB_DB"`
-	Precision   string `json:"precision,omitempty" envconfig:"INFLUXDB_PRECISION"`
-	Retention   string `json:"retention,omitempty" envconfig:"INFLUXDB_RETENTION"`
-	Consistency string `json:"consistency,omitempty" envconfig:"INFLUXDB_CONSISTENCY"`
+	DB           string   `json:"db" envconfig:"INFLUXDB_DB"`
+	Precision    string   `json:"precision,omitempty" envconfig:"INFLUXDB_PRECISION"`
+	Retention    string   `json:"retention,omitempty" envconfig:"INFLUXDB_RETENTION"`
+	Consistency  string   `json:"consistency,omitempty" envconfig:"INFLUXDB_CONSISTENCY"`
+	TagsAsFields []string `json:"tagsAsFields,omitempty" envconfig:"INFLUXDB_TAGS_AS_FIELDS"`
 }
 
 type Config ConfigFields
@@ -73,6 +74,9 @@ func (c Config) Apply(cfg Config) Config {
 	}
 	if cfg.Consistency != "" {
 		c.Consistency = cfg.Consistency
+	}
+	if len(cfg.TagsAsFields) > 0 {
+		c.TagsAsFields = cfg.TagsAsFields
 	}
 	return c
 }
@@ -112,6 +116,8 @@ func (c *Config) UnmarshalText(text []byte) error {
 			c.Retention = vs[0]
 		case "consistency":
 			c.Consistency = vs[0]
+		case "tagsasfields":
+			c.TagsAsFields = vs
 		default:
 			return errors.Errorf("unknown query parameter: %s", k)
 		}

--- a/stats/influxdb/config.go
+++ b/stats/influxdb/config.go
@@ -82,6 +82,7 @@ func (c Config) Apply(cfg Config) Config {
 }
 
 func (c *Config) UnmarshalText(text []byte) error {
+	c.defaultValues()
 	u, err := url.Parse(string(text))
 	if err != nil {
 		return err
@@ -116,7 +117,7 @@ func (c *Config) UnmarshalText(text []byte) error {
 			c.Retention = vs[0]
 		case "consistency":
 			c.Consistency = vs[0]
-		case "tagsasfields":
+		case "tagsAsFields":
 			c.TagsAsFields = vs
 		default:
 			return errors.Errorf("unknown query parameter: %s", k)
@@ -126,6 +127,7 @@ func (c *Config) UnmarshalText(text []byte) error {
 }
 
 func (c *Config) UnmarshalJSON(data []byte) error {
+	c.defaultValues()
 	fields := ConfigFields(*c)
 	if err := json.Unmarshal(data, &fields); err != nil {
 		return err
@@ -136,4 +138,10 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 
 func (c Config) MarshalJSON() ([]byte, error) {
 	return json.Marshal(ConfigFields(c))
+}
+
+func (c *Config) defaultValues() {
+	if len(c.TagsAsFields) == 0 {
+		c.TagsAsFields = []string{"vu", "iter", "url"}
+	}
 }

--- a/stats/influxdb/config.go
+++ b/stats/influxdb/config.go
@@ -47,6 +47,11 @@ type ConfigFields struct {
 
 type Config ConfigFields
 
+func NewConfig() *Config {
+	c := &Config{TagsAsFields: []string{"vu", "iter", "url"}}
+	return c
+}
+
 func (c Config) Apply(cfg Config) Config {
 	if cfg.Addr != "" {
 		c.Addr = cfg.Addr
@@ -82,7 +87,6 @@ func (c Config) Apply(cfg Config) Config {
 }
 
 func (c *Config) UnmarshalText(text []byte) error {
-	c.defaultValues()
 	u, err := url.Parse(string(text))
 	if err != nil {
 		return err
@@ -127,7 +131,6 @@ func (c *Config) UnmarshalText(text []byte) error {
 }
 
 func (c *Config) UnmarshalJSON(data []byte) error {
-	c.defaultValues()
 	fields := ConfigFields(*c)
 	if err := json.Unmarshal(data, &fields); err != nil {
 		return err
@@ -138,10 +141,4 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 
 func (c Config) MarshalJSON() ([]byte, error) {
 	return json.Marshal(ConfigFields(c))
-}
-
-func (c *Config) defaultValues() {
-	if len(c.TagsAsFields) == 0 {
-		c.TagsAsFields = []string{"vu", "iter", "url"}
-	}
 }

--- a/stats/influxdb/config_test.go
+++ b/stats/influxdb/config_test.go
@@ -27,23 +27,24 @@ import (
 )
 
 func TestConfigText(t *testing.T) {
+	defaultTagsAsFields := []string{"vu", "iter", "url"}
 	testdata := map[string]Config{
-		"":                             {},
-		"dbname":                       {DB: "dbname"},
-		"/dbname":                      {DB: "dbname"},
-		"http://localhost:8086":        {Addr: "http://localhost:8086"},
-		"http://localhost:8086/dbname": {Addr: "http://localhost:8086", DB: "dbname"},
+		"":                             {TagsAsFields: defaultTagsAsFields},
+		"dbname":                       {DB: "dbname", TagsAsFields: defaultTagsAsFields},
+		"/dbname":                      {DB: "dbname", TagsAsFields: defaultTagsAsFields},
+		"http://localhost:8086":        {Addr: "http://localhost:8086", TagsAsFields: defaultTagsAsFields},
+		"http://localhost:8086/dbname": {Addr: "http://localhost:8086", DB: "dbname", TagsAsFields: defaultTagsAsFields},
 	}
 	queries := map[string]struct {
 		Config Config
 		Err    string
 	}{
-		"?":                {Config{}, ""},
-		"?insecure=false":  {Config{Insecure: false}, ""},
-		"?insecure=true":   {Config{Insecure: true}, ""},
-		"?insecure=ture":   {Config{}, "insecure must be true or false, not ture"},
-		"?payload_size=69": {Config{PayloadSize: 69}, ""},
-		"?payload_size=a":  {Config{}, "strconv.Atoi: parsing \"a\": invalid syntax"},
+		"?":                {Config{TagsAsFields: defaultTagsAsFields}, ""},
+		"?insecure=false":  {Config{Insecure: false, TagsAsFields: defaultTagsAsFields}, ""},
+		"?insecure=true":   {Config{Insecure: true, TagsAsFields: defaultTagsAsFields}, ""},
+		"?insecure=ture":   {Config{TagsAsFields: defaultTagsAsFields}, "insecure must be true or false, not ture"},
+		"?payload_size=69": {Config{PayloadSize: 69, TagsAsFields: defaultTagsAsFields}, ""},
+		"?payload_size=a":  {Config{TagsAsFields: defaultTagsAsFields}, "strconv.Atoi: parsing \"a\": invalid syntax"},
 	}
 	for str, data := range testdata {
 		t.Run(str, func(t *testing.T) {

--- a/stats/influxdb/config_test.go
+++ b/stats/influxdb/config_test.go
@@ -27,24 +27,23 @@ import (
 )
 
 func TestConfigText(t *testing.T) {
-	defaultTagsAsFields := []string{"vu", "iter", "url"}
 	testdata := map[string]Config{
-		"":                             {TagsAsFields: defaultTagsAsFields},
-		"dbname":                       {DB: "dbname", TagsAsFields: defaultTagsAsFields},
-		"/dbname":                      {DB: "dbname", TagsAsFields: defaultTagsAsFields},
-		"http://localhost:8086":        {Addr: "http://localhost:8086", TagsAsFields: defaultTagsAsFields},
-		"http://localhost:8086/dbname": {Addr: "http://localhost:8086", DB: "dbname", TagsAsFields: defaultTagsAsFields},
+		"":                             {},
+		"dbname":                       {DB: "dbname"},
+		"/dbname":                      {DB: "dbname"},
+		"http://localhost:8086":        {Addr: "http://localhost:8086"},
+		"http://localhost:8086/dbname": {Addr: "http://localhost:8086", DB: "dbname"},
 	}
 	queries := map[string]struct {
 		Config Config
 		Err    string
 	}{
-		"?":                {Config{TagsAsFields: defaultTagsAsFields}, ""},
-		"?insecure=false":  {Config{Insecure: false, TagsAsFields: defaultTagsAsFields}, ""},
-		"?insecure=true":   {Config{Insecure: true, TagsAsFields: defaultTagsAsFields}, ""},
-		"?insecure=ture":   {Config{TagsAsFields: defaultTagsAsFields}, "insecure must be true or false, not ture"},
-		"?payload_size=69": {Config{PayloadSize: 69, TagsAsFields: defaultTagsAsFields}, ""},
-		"?payload_size=a":  {Config{TagsAsFields: defaultTagsAsFields}, "strconv.Atoi: parsing \"a\": invalid syntax"},
+		"?":                {Config{}, ""},
+		"?insecure=false":  {Config{Insecure: false}, ""},
+		"?insecure=true":   {Config{Insecure: true}, ""},
+		"?insecure=ture":   {Config{}, "insecure must be true or false, not ture"},
+		"?payload_size=69": {Config{PayloadSize: 69}, ""},
+		"?payload_size=a":  {Config{}, "strconv.Atoi: parsing \"a\": invalid syntax"},
 	}
 	for str, data := range testdata {
 		t.Run(str, func(t *testing.T) {


### PR DESCRIPTION
This implements:
https://github.com/loadimpact/k6/issues/569

The code can be optimised so that we don't create a new map each time in `func extractFields` but I would like some input on  how to do that.

To configure this see samples/config.json or you can use the env var INFLUXDB_TAGS_AS_FIELDS. Default value is "iter,vu,url".
