### PR TITLE
Add configurable setup and teardown timeouts

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -24,7 +24,9 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
+	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/stats"
 
 	"github.com/loadimpact/k6/lib"
@@ -80,6 +82,10 @@ func getOptions(flags *pflag.FlagSet) (lib.Options, error) {
 		InsecureSkipTLSVerify: getNullBool(flags, "insecure-skip-tls-verify"),
 		NoConnectionReuse:     getNullBool(flags, "no-connection-reuse"),
 		Throw:                 getNullBool(flags, "throw"),
+
+		// Default values for options without CLI flags:
+		SetupTimeout:    types.NullDurationFrom(10 * time.Second),
+		TeardownTimeout: types.NullDurationFrom(10 * time.Second),
 	}
 
 	stageStrings, err := flags.GetStringSlice("stage")

--- a/core/local/local.go
+++ b/core/local/local.go
@@ -137,8 +137,10 @@ func (e *Executor) Run(parent context.Context, out chan<- []stats.Sample) (reter
 	defer e.runLock.Unlock()
 
 	if e.Runner != nil && e.runSetup {
-		// TODO: make this timeout configurable
-		setupCtx, setupCancel := context.WithTimeout(parent, 10*time.Second)
+		setupCtx, setupCancel := context.WithTimeout(
+			parent,
+			time.Duration(e.Runner.GetOptions().SetupTimeout.Duration),
+		)
 		if err := e.Runner.Setup(setupCtx); err != nil {
 			setupCancel()
 			return err
@@ -159,8 +161,10 @@ func (e *Executor) Run(parent context.Context, out chan<- []stats.Sample) (reter
 	var cutoff time.Time
 	defer func() {
 		if e.Runner != nil && e.runTeardown {
-			// TODO: make this timeout configurable
-			teardownCtx, teardownCancel := context.WithTimeout(parent, 10*time.Second)
+			teardownCtx, teardownCancel := context.WithTimeout(
+				parent,
+				time.Duration(e.Runner.GetOptions().TeardownTimeout.Duration),
+			)
 			reterr = e.Runner.Teardown(teardownCtx)
 			teardownCancel()
 		}

--- a/lib/options.go
+++ b/lib/options.go
@@ -192,6 +192,10 @@ type Options struct {
 	Iterations null.Int           `json:"iterations" envconfig:"iterations"`
 	Stages     []Stage            `json:"stages" envconfig:"stages"`
 
+	// Timeouts for the setup() and teardown() functions
+	SetupTimeout    types.NullDuration `json:"setupTimeout" envconfig:"setup_timeout"`
+	TeardownTimeout types.NullDuration `json:"teardownTimeout" envconfig:"teardown_timeout"`
+
 	// Limit HTTP requests per second.
 	RPS null.Int `json:"rps" envconfig:"rps"`
 

--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -43,6 +43,10 @@ Since InfluxDB indexes tags, highly variable information like `vu`, `iter` or ev
 
 Thanks to @danron for their work on this!
 
+### Configurable setup and teardown timeouts (#602)
+
+Previously the `setup()` and `teardown()` functions timed out after 10 seconds. Now that period is configurable via the `setupTimeout` and `teardownTimeout` script options or the `K6_SETUP_TIMEOUT` and `K6_TEARDOWN_TIMEOUT` environment variables. The default timeouts are still 10 seconds and at this time there are no CLI options for changing them to avoid clutter.
+
 
 ## UX
 


### PR DESCRIPTION
This fixes https://github.com/loadimpact/k6/issues/576, though we should add some upper limits when implementing https://github.com/loadimpact/k6/issues/539