### PR TITLE
Fixes digest authentication bug

### DIFF
--- a/js/modules/k6/http/http_request.go
+++ b/js/modules/k6/http/http_request.go
@@ -380,6 +380,9 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 			if throw {
 				return nil, nil, err
 			}
+
+			resp.Error = err.Error()
+			return resp, statsSamples, nil
 		}
 
 		if res.StatusCode == http.StatusUnauthorized {

--- a/js/modules/k6/http/http_request_test.go
+++ b/js/modules/k6/http/http_request_test.go
@@ -624,15 +624,30 @@ func TestRequestAndBatch(t *testing.T) {
 				assertRequestMetricsEmitted(t, state.Samples, "GET", url, "", 200, "")
 			})
 			t.Run("digest", func(t *testing.T) {
-				state.Samples = nil
-				url := sr("http://bob:pass@HTTPBIN_IP:HTTPBIN_PORT/digest-auth/auth/bob/pass")
+				t.Run("success", func(t *testing.T) {
+					state.Samples = nil
+					url := sr("http://bob:pass@HTTPBIN_IP:HTTPBIN_PORT/digest-auth/auth/bob/pass")
 
-				_, err := common.RunString(rt, fmt.Sprintf(`
-				let res = http.request("GET", "%s", null, { auth: "digest" });
-				if (res.status != 200) { throw new Error("wrong status: " + res.status); }
-				`, url))
-				assert.NoError(t, err)
-				assertRequestMetricsEmitted(t, state.Samples, "GET", sr("HTTPBIN_IP_URL/digest-auth/auth/bob/pass"), url, 200, "")
+					_, err := common.RunString(rt, fmt.Sprintf(`
+					let res = http.request("GET", "%s", null, { auth: "digest" });
+					if (res.status != 200) { throw new Error("wrong status: " + res.status); }
+					`, url))
+					assert.NoError(t, err)
+					assertRequestMetricsEmitted(t, state.Samples, "GET", sr("HTTPBIN_IP_URL/digest-auth/auth/bob/pass"), url, 200, "")
+				})
+				t.Run("failure", func(t *testing.T) {
+					tb.Mux.HandleFunc("/digest-auth/failure", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						time.Sleep(2 * time.Second)
+					}))
+
+					state.Samples = nil
+					url := sr("http://bob:pass@HTTPBIN_IP:HTTPBIN_PORT/digest-auth/failure")
+
+					_, err := common.RunString(rt, fmt.Sprintf(`
+					let res = http.request("GET", "%s", null, { auth: "digest", timeout: 1, throw: false });
+					`, url))
+					assert.NoError(t, err)
+				})
 			})
 			t.Run("ntlm", func(t *testing.T) {
 				tb.Mux.HandleFunc("/ntlm", http.HandlerFunc(ntlmHandler("bob", "pass")))


### PR DESCRIPTION
k6 was crashing when using digest authentication and some requests failed.

We forgot to return when getting an error on the authentication call