### PR TITLE
Fixing tagging on submetrics

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -330,7 +330,7 @@ func (e *Engine) processSamples(samples ...stats.Sample) {
 		m.Sink.Add(sample)
 
 		for _, sm := range m.Submetrics {
-			if !sm.Tags.IsEqual(sample.Tags) {
+			if !sample.Tags.Contains(sm.Tags) {
 				continue
 			}
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -365,7 +365,7 @@ func TestEngine_processSamples(t *testing.T) {
 		assert.EqualValues(t, map[string]string{"a": "1"}, sms[0].Tags.CloneTags())
 
 		e.processSamples(
-			stats.Sample{Metric: metric, Value: 1.25, Tags: stats.IntoSampleTags(&map[string]string{"a": "1"})},
+			stats.Sample{Metric: metric, Value: 1.25, Tags: stats.IntoSampleTags(&map[string]string{"a": "1", "b": "2"})},
 		)
 
 		assert.IsType(t, &stats.GaugeSink{}, e.Metrics["my_metric"].Sink)

--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -60,3 +60,4 @@ Previously the `setup()` and `teardown()` functions timed out after 10 seconds. 
 
 ## Bugs
 * Archive: archives generated on Windows can now run on *nix and vice versa. (#566)
+* Submetrics are being tagged properly know. (#609)

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -197,6 +197,23 @@ func (st *SampleTags) IsEqual(other *SampleTags) bool {
 	return true
 }
 
+func (st *SampleTags) Contains(other *SampleTags) bool {
+	if st == other {
+		return true
+	}
+	if st == nil || other == nil || len(st.tags) < len(other.tags) {
+		return false
+	}
+
+	for k, v := range other.tags {
+		if st.tags[k] != v {
+			return false
+		}
+	}
+
+	return true
+}
+
 // MarshalJSON serializes SampleTags to a JSON string and caches
 // the result. It is not thread safe in the sense that the Go race
 // detector will complain if it's used concurrently, but no data

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -198,10 +198,10 @@ func (st *SampleTags) IsEqual(other *SampleTags) bool {
 }
 
 func (st *SampleTags) Contains(other *SampleTags) bool {
-	if st == other {
+	if st == other || other == nil {
 		return true
 	}
-	if st == nil || other == nil || len(st.tags) < len(other.tags) {
+	if st == nil || len(st.tags) < len(other.tags) {
 		return false
 	}
 

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -222,6 +222,8 @@ func TestSampleTags(t *testing.T) {
 	assert.False(t, tags.IsEqual(nilTags))
 	assert.False(t, tags.IsEqual(emptyTags))
 	assert.False(t, tags.IsEqual(IntoSampleTags(&map[string]string{"key1": "val1", "key2": "val3"})))
+	assert.True(t, tags.Contains(IntoSampleTags(&map[string]string{"key1": "val1"})))
+	assert.False(t, tags.Contains(IntoSampleTags(&map[string]string{"key3": "val1"})))
 	assert.Equal(t, tagMap, tags.CloneTags())
 
 	assert.Nil(t, tags.json) // No cache


### PR DESCRIPTION
Fixes #590 by validating that sub metric tags are included in the sample tags.