### PR TITLE
Validating stages option

### DIFF
--- a/lib/options.go
+++ b/lib/options.go
@@ -275,8 +275,12 @@ func (o Options) Apply(opts Options) Options {
 	if opts.Iterations.Valid {
 		o.Iterations = opts.Iterations
 	}
-	if opts.Stages != nil {
-		o.Stages = opts.Stages
+	if len(opts.Stages) > 0 {
+		for _, s := range opts.Stages {
+			if s.Duration.Valid && s.Target.Valid {
+				o.Stages = append(o.Stages, s)
+			}
+		}
 	}
 	if opts.SetupTimeout.Valid {
 		o.SetupTimeout = opts.SetupTimeout

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -63,10 +63,12 @@ func TestOptions(t *testing.T) {
 		assert.Equal(t, int64(1234), opts.Iterations.Int64)
 	})
 	t.Run("Stages", func(t *testing.T) {
-		opts := Options{}.Apply(Options{Stages: []Stage{{Duration: types.NullDurationFrom(1 * time.Second)}}})
+		opts := Options{}.Apply(Options{Stages: []Stage{{Duration: types.NullDurationFrom(1 * time.Second), Target: null.IntFrom(10)}}})
 		assert.NotNil(t, opts.Stages)
 		assert.Len(t, opts.Stages, 1)
 		assert.Equal(t, 1*time.Second, time.Duration(opts.Stages[0].Duration.Duration))
+
+		assert.Nil(t, Options{}.Apply(Options{Stages: []Stage{{}}}).Stages)
 	})
 	t.Run("RPS", func(t *testing.T) {
 		opts := Options{}.Apply(Options{RPS: null.IntFrom(12345)})

--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -62,3 +62,4 @@ Previously the `setup()` and `teardown()` functions timed out after 10 seconds. 
 * Archive: archives generated on Windows can now run on *nix and vice versa. (#566)
 * Submetrics are being tagged properly know. (#609)
 * Htlm: fixed `Selection.each(fn)` function, which was return only the first element. (#610)
+* Invalid Stages option won't keep k6 running indefinitely. (#615)


### PR DESCRIPTION
this PR validates the stages option, making sure only valid stages are being passed down to the test.

fixes #547 