### PR TITLE
Remote IP address as a new optional system metric tag 

### DIFF
--- a/js/modules/k6/http/http_request.go
+++ b/js/modules/k6/http/http_request.go
@@ -397,7 +397,14 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 			req.Header.Set(digest.KEY_AUTHORIZATION, authorization)
 		}
 		trail := tracer.Done()
+
+		if state.Options.SystemTags["ip"] && trail.ConnRemoteAddr != nil {
+			if ip, _, err := net.SplitHostPort(trail.ConnRemoteAddr.String()); err == nil {
+				tags["ip"] = ip
+			}
+		}
 		trail.SaveSamples(stats.NewSampleTags(tags))
+		delete(tags, "ip")
 		statsSamples = append(statsSamples, trail)
 	}
 
@@ -521,6 +528,11 @@ func (h *HTTP) request(ctx context.Context, rt *goja.Runtime, state *common.Stat
 		}
 	}
 
+	if state.Options.SystemTags["ip"] && trail.ConnRemoteAddr != nil {
+		if ip, _, err := net.SplitHostPort(trail.ConnRemoteAddr.String()); err == nil {
+			tags["ip"] = ip
+		}
+	}
 	trail.SaveSamples(stats.IntoSampleTags(&tags))
 	statsSamples = append(statsSamples, trail)
 	return resp, statsSamples, nil

--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -178,6 +178,12 @@ func (*WS) Connect(ctx context.Context, url string, args ...goja.Value) (*WSHTTP
 		done:               make(chan struct{}),
 	}
 
+	if state.Options.SystemTags["ip"] && conn.RemoteAddr() != nil {
+		if ip, _, err := net.SplitHostPort(conn.RemoteAddr().String()); err == nil {
+			tags["ip"] = ip
+		}
+	}
+
 	// Run the user-provided set up function
 	if _, err := setupFn(goja.Undefined(), rt.ToValue(&socket)); err != nil {
 		return nil, err

--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -355,7 +355,9 @@ func TestSystemTags(t *testing.T) {
 		DualStack: true,
 	})
 
-	testedSystemTags := []string{"group", "status", "subproto", "url"}
+	//TODO: test for actual tag values after removing the dependency on the
+	// external service demos.kaazing.com (https://github.com/loadimpact/k6/issues/537)
+	testedSystemTags := []string{"group", "status", "subproto", "url", "ip"}
 	state := &common.State{
 		Group:   root,
 		Dialer:  dialer,
@@ -415,7 +417,7 @@ func TestTLSConfig(t *testing.T) {
 		Group:  root,
 		Dialer: dialer,
 		Options: lib.Options{
-			SystemTags: lib.GetTagSet("url", "proto", "status", "subproto"),
+			SystemTags: lib.GetTagSet("url", "proto", "status", "subproto", "ip"),
 		},
 	}
 

--- a/lib/netext/tracer_test.go
+++ b/lib/netext/tracer_test.go
@@ -30,6 +30,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -89,6 +90,8 @@ func TestTracer(t *testing.T) {
 			assertLaterOrZero(t, tracer.wroteRequest, false)
 			assertLaterOrZero(t, tracer.gotFirstResponseByte, false)
 			assertLaterOrZero(t, now(), false)
+
+			assert.Equal(t, strings.TrimPrefix(srv.URL, "https://"), trail.ConnRemoteAddr.String())
 
 			assert.Len(t, samples, 8)
 			seenMetrics := map[*stats.Metric]bool{}

--- a/lib/options.go
+++ b/lib/options.go
@@ -32,7 +32,7 @@ import (
 )
 
 // DefaultSystemTagList includes all of the system tags emitted with metrics by default.
-// Other tags that are not enabled by default include: iter, vu, ocsp_status
+// Other tags that are not enabled by default include: iter, vu, ocsp_status, ip
 var DefaultSystemTagList = []string{
 	"proto", "subproto", "status", "method", "url", "name", "group", "check", "error", "tls_version",
 }

--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -53,6 +53,10 @@ Metrics streamed to the LoadImpact cloud can be partially aggregated to reduce b
 
 **Docs**: [LoadImpact Insights Aggregation](https://docs.k6.io/docs/load-impact-insights#section-aggregation)
 
+### Remote IP address as an optional system metric tag (#616)
+
+It's now possible to add the remote server's IP address to the tags for HTTP and WebSocket metrics. The `ip` [system tag](https://docs.k6.io/docs/tags-and-groups#section-system-tags) is not included by default, but it could easily be enabled by modifying the `systemTags` [option](https://docs.k6.io/docs/options).
+
 ## UX
 
 * Clearer error message when using `open` function outside init context (#563)


### PR DESCRIPTION
This fixes #509

I decided to create this PR branch from the `cloud-aggregation` one instead of `master because this way I wouldn't have to resolve the many merge conflicts between those two. Only the [last commit](https://github.com/loadimpact/k6/pull/616/commits/a8a01e5d1b6640660323cf7a0d4599081317ae73) here is important, the rest are from the aggregation changes and should hopefully be hidden by github's diff when we merge https://github.com/loadimpact/k6/pull/600 