### PR TITLE
Fixing stages validation

### DIFF
--- a/lib/options.go
+++ b/lib/options.go
@@ -277,7 +277,7 @@ func (o Options) Apply(opts Options) Options {
 	}
 	if len(opts.Stages) > 0 {
 		for _, s := range opts.Stages {
-			if s.Duration.Valid && s.Target.Valid {
+			if s.Duration.Valid {
 				o.Stages = append(o.Stages, s)
 			}
 		}

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -63,7 +63,7 @@ func TestOptions(t *testing.T) {
 		assert.Equal(t, int64(1234), opts.Iterations.Int64)
 	})
 	t.Run("Stages", func(t *testing.T) {
-		opts := Options{}.Apply(Options{Stages: []Stage{{Duration: types.NullDurationFrom(1 * time.Second), Target: null.IntFrom(10)}}})
+		opts := Options{}.Apply(Options{Stages: []Stage{{Duration: types.NullDurationFrom(1 * time.Second)}}})
 		assert.NotNil(t, opts.Stages)
 		assert.Len(t, opts.Stages, 1)
 		assert.Equal(t, 1*time.Second, time.Duration(opts.Stages[0].Duration.Duration))


### PR DESCRIPTION
Stages don’t require a target value, only duration

While documenting all the options, I realize that target is not a required value for a stage. If not set it will just keep running with the current value