### PR TITLE
Changing tags flag format

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -159,7 +159,7 @@ func parseTagNameValue(nv string) (string, string, error) {
 		return "", "", ErrTagEmptyString
 	}
 
-	idx := strings.IndexRune(nv, '=')
+	idx := strings.IndexRune(nv, ':')
 
 	switch idx {
 	case 0:

--- a/cmd/options_test.go
+++ b/cmd/options_test.go
@@ -41,13 +41,13 @@ func TestParseTagKeyValue(t *testing.T) {
 			ErrTagEmptyString,
 		},
 		{
-			"=",
+			":",
 			"",
 			"",
 			ErrTagEmptyName,
 		},
 		{
-			"=test",
+			":test",
 			"",
 			"",
 			ErrTagEmptyName,
@@ -59,13 +59,13 @@ func TestParseTagKeyValue(t *testing.T) {
 			ErrTagEmptyValue,
 		},
 		{
-			"test=",
+			"test:",
 			"",
 			"",
 			ErrTagEmptyValue,
 		},
 		{
-			"myTag=foo",
+			"myTag:foo",
 			"myTag",
 			"foo",
 			nil,


### PR DESCRIPTION
Changing separator from `foo=bar` to `foo:bar` in order to keep consistence
between how we format in flags like `stages` and environment variables,
since we use the envconfig project which also uses `:` as separator for maps