### PR TITLE
Adding SetRunStatus to kafka collector

### DIFF
--- a/stats/kafka/collector.go
+++ b/stats/kafka/collector.go
@@ -103,6 +103,8 @@ func (c *Collector) GetRequiredSystemTags() lib.TagSet {
 	return lib.TagSet{} // There are no required tags for this collector
 }
 
+func (c *Collector) SetRunStatus(status int) {}
+
 func (c *Collector) formatSamples(samples stats.Samples) ([]string, error) {
 	var metrics []string
 


### PR DESCRIPTION
Fixing broken master by adding the missing method of the `lib.Collector`