### PR TITLE
Adding no-vu-connection-reuse option

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -59,7 +59,8 @@ func optionFlagSet() *pflag.FlagSet {
 	flags.String("http-debug", "", "log all HTTP requests and responses. Excludes body by default. To include body use '---http-debug=full'")
 	flags.Lookup("http-debug").NoOptDefVal = "headers"
 	flags.Bool("insecure-skip-tls-verify", false, "skip verification of TLS certificates")
-	flags.Bool("no-connection-reuse", false, "don't reuse connections between iterations")
+	flags.Bool("no-connection-reuse", false, "disable keep-alive connections")
+	flags.Bool("no-vu-connection-reuse", false, "don't reuse connections between iterations")
 	flags.BoolP("throw", "w", false, "throw warnings (like failed http requests) as errors")
 	flags.StringSlice("blacklist-ip", nil, "blacklist an `ip range` from being called")
 	flags.StringSlice("summary-trend-stats", nil, "define `stats` for trend metrics (response times), one or more as 'avg,p(95),...'")
@@ -83,6 +84,7 @@ func getOptions(flags *pflag.FlagSet) (lib.Options, error) {
 		HttpDebug:             getNullString(flags, "http-debug"),
 		InsecureSkipTLSVerify: getNullBool(flags, "insecure-skip-tls-verify"),
 		NoConnectionReuse:     getNullBool(flags, "no-connection-reuse"),
+		NoVUConnectionReuse:   getNullBool(flags, "no-vu-connection-reuse"),
 		Throw:                 getNullBool(flags, "throw"),
 
 		// Default values for options without CLI flags:

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -557,7 +557,7 @@ func TestSentReceivedMetrics(t *testing.T) {
 			VUsMax:     null.IntFrom(tc.VUs),
 			Hosts:      tb.Dialer.Hosts,
 			InsecureSkipTLSVerify: null.BoolFrom(true),
-			NoConnectionReuse:     null.BoolFrom(noConnReuse),
+			NoVUConnectionReuse:   null.BoolFrom(noConnReuse),
 		}
 
 		r.SetOptions(options)

--- a/js/runner.go
+++ b/js/runner.go
@@ -161,6 +161,7 @@ func (r *Runner) newVU() (*VU, error) {
 		TLSClientConfig:    tlsConfig,
 		DialContext:        dialer.DialContext,
 		DisableCompression: true,
+		DisableKeepAlives:  r.Bundle.Options.NoConnectionReuse.Bool,
 	}
 	_ = http2.ConfigureTransport(transport)
 
@@ -381,7 +382,7 @@ func (u *VU) runFn(ctx context.Context, fn goja.Callable, args ...goja.Value) (g
 	}
 	sampleTags := stats.IntoSampleTags(&tags)
 
-	if u.Runner.Bundle.Options.NoConnectionReuse.Bool {
+	if u.Runner.Bundle.Options.NoVUConnectionReuse.Bool {
 		u.HTTPTransport.CloseIdleConnections()
 	}
 

--- a/lib/options.go
+++ b/lib/options.go
@@ -234,10 +234,13 @@ type Options struct {
 	// Hosts overrides dns entries for given hosts
 	Hosts map[string]net.IP `json:"hosts" envconfig:"hosts"`
 
+	// Disable keep-alive connections
+	NoConnectionReuse null.Bool `json:"noConnectionReuse" envconfig:"no_connection_reuse"`
+
 	// Do not reuse connections between VU iterations. This gives more realistic results (depending
 	// on what you're looking for), but you need to raise various kernel limits or you'll get
 	// errors about running out of file handles or sockets, or being unable to bind addresses.
-	NoConnectionReuse null.Bool `json:"noConnectionReuse" envconfig:"no_connection_reuse"`
+	NoVUConnectionReuse null.Bool `json:"noVUConnectionReuse" envconfig:"no_vu_connection_reuse"`
 
 	// These values are for third party collectors' benefit.
 	// Can't be set through env vars.
@@ -335,6 +338,9 @@ func (o Options) Apply(opts Options) Options {
 	}
 	if opts.NoConnectionReuse.Valid {
 		o.NoConnectionReuse = opts.NoConnectionReuse
+	}
+	if opts.NoVUConnectionReuse.Valid {
+		o.NoVUConnectionReuse = opts.NoVUConnectionReuse
 	}
 	if opts.External != nil {
 		o.External = opts.External

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -267,7 +267,11 @@ func TestOptions(t *testing.T) {
 		assert.True(t, opts.NoConnectionReuse.Valid)
 		assert.True(t, opts.NoConnectionReuse.Bool)
 	})
-
+	t.Run("NoVUConnectionReuse", func(t *testing.T) {
+		opts := Options{}.Apply(Options{NoVUConnectionReuse: null.BoolFrom(true)})
+		assert.True(t, opts.NoVUConnectionReuse.Valid)
+		assert.True(t, opts.NoVUConnectionReuse.Bool)
+	})
 	t.Run("BlacklistIPs", func(t *testing.T) {
 		opts := Options{}.Apply(Options{
 			BlacklistIPs: []*net.IPNet{{
@@ -409,6 +413,11 @@ func TestOptionsEnv(t *testing.T) {
 		// TLSVersion
 		// TLSAuth
 		{"NoConnectionReuse", "K6_NO_CONNECTION_REUSE"}: {
+			"":      null.Bool{},
+			"true":  null.BoolFrom(true),
+			"false": null.BoolFrom(false),
+		},
+		{"NoVUConnectionReuse", "K6_NO_VU_CONNECTION_REUSE"}: {
 			"":      null.Bool{},
 			"true":  null.BoolFrom(true),
 			"false": null.BoolFrom(false),

--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -12,8 +12,10 @@ Description of feature.
 
 ## UX
 * New option to reset cloud token (#672)
-* The option `--no-connection-reuse` now means that keep-alive connections will be disabled. (#676)
 
 ## Bugs fixed!
 
 * Category: description of bug. (#PR)
+
+## Breaking Changes
+* The `--no-connection-reuse` option has been re-purposed and now disables keep-alive connections globally. The newly added `--no-vu-connection-reuse` option does what was previously done by `--no-connection-reuse` - it closes any open connections between iterations of a VU, but allows for reusing them inside of a single iteration. (#676)

--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -2,6 +2,8 @@ TODO: Intro
 
 ## New Features!
 
+* New option `--no-vu-connection-reuse` that let's users close the connections between iterations of a VU. (#676)
+
 ### Category: Title (#533)
 
 Description of feature.
@@ -10,6 +12,7 @@ Description of feature.
 
 ## UX
 * New option to reset cloud token (#672)
+* The option `--no-connection-reuse` now means that keep-alive connections will be disabled. (#676)
 
 ## Bugs fixed!
 


### PR DESCRIPTION
This PR adds a new option `--no-vu-connection-reuse` that closes the idle connections between each iteration of a VU, and changes meaning of `--no-connection-reuse` to disabling keep-alive connections