### PR TITLE
Options will be passed as ENV_variables from command line

### DIFF
--- a/js/runner.go
+++ b/js/runner.go
@@ -176,6 +176,7 @@ func (r *Runner) newVU(samplesOut chan<- stats.SampleContainer) (*VU, error) {
 		Samples:        samplesOut,
 	}
 	vu.Runtime.Set("console", common.Bind(vu.Runtime, vu.Console, vu.Context))
+	vu.Runtime.Set("options", r.GetOptions())
 	common.BindToGlobal(vu.Runtime, map[string]interface{}{
 		"open": func() {
 			common.Throw(vu.Runtime, errors.New("\"open\" function is only available to the init code (aka global scope), see https://docs.k6.io/docs/test-life-cycle for more information"))

--- a/lib/options.go
+++ b/lib/options.go
@@ -187,80 +187,80 @@ type Options struct {
 
 	// Initial values for VUs, max VUs, duration cap, iteration cap, and stages.
 	// See the Runner or Executor interfaces for more information.
-	VUs        null.Int           `json:"vus" envconfig:"vus"`
-	VUsMax     null.Int           `json:"vusMax" envconfig:"vus_max"`
-	Duration   types.NullDuration `json:"duration" envconfig:"duration"`
-	Iterations null.Int           `json:"iterations" envconfig:"iterations"`
-	Stages     []Stage            `json:"stages" envconfig:"stages"`
+	VUs        null.Int           `json:"vus" envconfig:"vus" js:"vus"`
+	VUsMax     null.Int           `json:"vusMax" envconfig:"vus_max" js:"vusMax"`
+	Duration   types.NullDuration `json:"duration" envconfig:"duration" js:"duration"`
+	Iterations null.Int           `json:"iterations" envconfig:"iterations" js:"iterations"`
+	Stages     []Stage            `json:"stages" envconfig:"stages" js:"stages"`
 
 	// Timeouts for the setup() and teardown() functions
-	SetupTimeout    types.NullDuration `json:"setupTimeout" envconfig:"setup_timeout"`
-	TeardownTimeout types.NullDuration `json:"teardownTimeout" envconfig:"teardown_timeout"`
+	SetupTimeout    types.NullDuration `json:"setupTimeout" envconfig:"setup_timeout" js:"setupTimeout"`
+	TeardownTimeout types.NullDuration `json:"teardownTimeout" envconfig:"teardown_timeout" js:"teardownTimeout"`
 
 	// Limit HTTP requests per second.
-	RPS null.Int `json:"rps" envconfig:"rps"`
+	RPS null.Int `json:"rps" envconfig:"rps" js:"rps"`
 
 	// How many HTTP redirects do we follow?
-	MaxRedirects null.Int `json:"maxRedirects" envconfig:"max_redirects"`
+	MaxRedirects null.Int `json:"maxRedirects" envconfig:"max_redirects" js:"maxRedirects"`
 
 	// Default User Agent string for HTTP requests.
-	UserAgent null.String `json:"userAgent" envconfig:"user_agent"`
+	UserAgent null.String `json:"userAgent" envconfig:"user_agent" js:"userAgent"`
 
 	// How many batch requests are allowed in parallel, in total and per host?
-	Batch        null.Int `json:"batch" envconfig:"batch"`
-	BatchPerHost null.Int `json:"batchPerHost" envconfig:"batch_per_host"`
+	Batch        null.Int `json:"batch" envconfig:"batch" js:"batch"`
+	BatchPerHost null.Int `json:"batchPerHost" envconfig:"batch_per_host" js:"batchPerHost"`
 
 	// Should all HTTP requests and responses be logged (excluding body)?
-	HttpDebug null.String `json:"httpDebug" envconfig:"http_debug"`
+	HttpDebug null.String `json:"httpDebug" envconfig:"http_debug" js:"httpDebug"`
 
 	// Accept invalid or untrusted TLS certificates.
-	InsecureSkipTLSVerify null.Bool `json:"insecureSkipTLSVerify" envconfig:"insecure_skip_tls_verify"`
+	InsecureSkipTLSVerify null.Bool `json:"insecureSkipTLSVerify" envconfig:"insecure_skip_tls_verify" js:"insecureSkipTLSVerify"`
 
 	// Specify TLS versions and cipher suites, and present client certificates.
-	TLSCipherSuites *TLSCipherSuites `json:"tlsCipherSuites" envconfig:"tls_cipher_suites"`
-	TLSVersion      *TLSVersions     `json:"tlsVersion" envconfig:"tls_version"`
-	TLSAuth         []*TLSAuth       `json:"tlsAuth" envconfig:"tlsauth"`
+	TLSCipherSuites *TLSCipherSuites `json:"tlsCipherSuites" envconfig:"tls_cipher_suites" js:"tlsCipherSuites"`
+	TLSVersion      *TLSVersions     `json:"tlsVersion" envconfig:"tls_version" js:"tlsVersion"`
+	TLSAuth         []*TLSAuth       `json:"tlsAuth" envconfig:"tlsauth" js:"tlsAuth"`
 
 	// Throw warnings (eg. failed HTTP requests) as errors instead of simply logging them.
-	Throw null.Bool `json:"throw" envconfig:"throw"`
+	Throw null.Bool `json:"throw" envconfig:"throw" js:"throw"`
 
 	// Define thresholds; these take the form of 'metric=["snippet1", "snippet2"]'.
 	// To create a threshold on a derived metric based on tag queries ("submetrics"), create a
 	// metric on a nonexistent metric named 'real_metric{tagA:valueA,tagB:valueB}'.
-	Thresholds map[string]stats.Thresholds `json:"thresholds" envconfig:"thresholds"`
+	Thresholds map[string]stats.Thresholds `json:"thresholds" envconfig:"thresholds" js:"thresholds"`
 
 	// Blacklist IP ranges that tests may not contact. Mainly useful in hosted setups.
-	BlacklistIPs []*net.IPNet `json:"blacklistIPs" envconfig:"blacklist_ips"`
+	BlacklistIPs []*net.IPNet `json:"blacklistIPs" envconfig:"blacklist_ips" js:"blacklistIPs"`
 
 	// Hosts overrides dns entries for given hosts
-	Hosts map[string]net.IP `json:"hosts" envconfig:"hosts"`
+	Hosts map[string]net.IP `json:"hosts" envconfig:"hosts" js:"hosts"`
 
 	// Disable keep-alive connections
-	NoConnectionReuse null.Bool `json:"noConnectionReuse" envconfig:"no_connection_reuse"`
+	NoConnectionReuse null.Bool `json:"noConnectionReuse" envconfig:"no_connection_reuse" js:"noConnectionReuse"`
 
 	// Do not reuse connections between VU iterations. This gives more realistic results (depending
 	// on what you're looking for), but you need to raise various kernel limits or you'll get
 	// errors about running out of file handles or sockets, or being unable to bind addresses.
-	NoVUConnectionReuse null.Bool `json:"noVUConnectionReuse" envconfig:"no_vu_connection_reuse"`
+	NoVUConnectionReuse null.Bool `json:"noVUConnectionReuse" envconfig:"no_vu_connection_reuse" js:"noVUConnectionReuse"`
 
 	// These values are for third party collectors' benefit.
 	// Can't be set through env vars.
-	External map[string]json.RawMessage `json:"ext" ignored:"true"`
+	External map[string]json.RawMessage `json:"ext" ignored:"true" js:"ext"`
 
 	// Summary trend stats for trend metrics (response times) in CLI output
-	SummaryTrendStats []string `json:"summaryTrendStats" envconfig:"summary_trend_stats"`
+	SummaryTrendStats []string `json:"summaryTrendStats" envconfig:"summary_trend_stats" js:"summaryTrendStats"`
 
 	// Summary time unit for summary metrics (response times) in CLI output
-	SummaryTimeUnit null.String `json:"summaryTimeUnit" envconfig:"summary_time_unit"`
+	SummaryTimeUnit null.String `json:"summaryTimeUnit" envconfig:"summary_time_unit" js:"summaryTimeUnit"`
 
 	// Which system tags to include with metrics ("method", "vu" etc.)
-	SystemTags TagSet `json:"systemTags" envconfig:"system_tags"`
+	SystemTags TagSet `json:"systemTags" envconfig:"system_tags" js:"systemTags"`
 
 	// Tags to be applied to all samples for this running
-	RunTags *stats.SampleTags `json:"tags" envconfig:"tags"`
+	RunTags *stats.SampleTags `json:"tags" envconfig:"tags" js:"tags"`
 
 	// Buffer size of the channel for metric samples; 0 means unbuffered
-	MetricSamplesBufferSize null.Int `json:"metricSamplesBufferSize" envconfig:"metric_samples_buffer_size"`
+	MetricSamplesBufferSize null.Int `json:"metricSamplesBufferSize" envconfig:"metric_samples_buffer_size" js:"metricSamplesBufferSize"`
 }
 
 // Returns the result of overwriting any fields with any that are set on the argument.


### PR DESCRIPTION
Fixes: [613](https://github.com/loadimpact/k6/issues/613)
The options sent from cli flags will also be saved as environment variables .

So they can be easily accessed as __ENV.XXXX

eg:
**Running**
`./k6 run  --vus 1 --iterations 1  --blacklist-ip 192.168.1.2/8,192.178.12.1/16 --duration 1s --summary-trend-stats "avg,p(95)" --system-tags check,group --tag test=p,l=0 --stage 5s:10,5m:20,10s:5  /media/sf_MCMP/Code/src/github.com/loadimpact/k6/test.js
`

**test.js**

```
export default function() {
    console.log("---START---")
    console.log("VUS" + __ENV.vus)
    console.log("duration" + __ENV.duration)
    console.log("stages" + __ENV.stages)
    console.log("throw" + __ENV.throw)
    console.log("systemTags" + __ENV.systemTags)
    console.log("blackListIPS" + __ENV.blacklistIPs)
    console.log("tags" + __ENV.tags)
    console.log("---END---")
}
```

**Output:**

> INFO[0002] Setup done                                   
> INFO[0004] ---START---                                  
> INFO[0004] VUS1                                         
> INFO[0004] duration1s                                   
> INFO[0004] stages[{"duration":"5s","target":10},{"duration":"5m0s","target":20},{"duration":"10s","target":5}] 
> INFO[0004] throwfalse                                   
> INFO[0004] systemTags{"check":true,"group":true}        
> INFO[0004] blackListIPS["192.0.0.0/8","192.178.0.0/16"] 
> INFO[0004] tags{"l":"0","test":"p"}                     
> INFO[0004] ---END---                                    
> INFO[0004] tear down done   
