### PR TITLE
errcheck fixes

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -70,6 +70,8 @@ func WithEngine(engine *core.Engine) negroni.HandlerFunc {
 func HandlePing() http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		rw.Header().Add("Content-Type", "text/plain; charset=utf-8")
-		fmt.Fprint(rw, "ok")
+		if _, err := fmt.Fprint(rw, "ok"); err != nil {
+			log.WithError(err).Error("Error while printing ok")
+		}
 	})
 }

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -37,7 +37,9 @@ import (
 
 func testHTTPHandler(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Add("Content-Type", "text/plain; charset=utf-8")
-	fmt.Fprint(rw, "ok")
+	if _, err := fmt.Fprint(rw, "ok"); err != nil {
+		panic(err.Error())
+	}
 }
 
 func TestLogger(t *testing.T) {

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -22,7 +22,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -59,7 +58,7 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 			Width: 60,
 			Left:  func() string { return "    uploading script" },
 		}
-		fmt.Fprintf(stdout, "%s \r", initBar.String())
+		fprintf(stdout, "%s \r", initBar.String())
 
 		// Runner
 		pwd, err := os.Getwd()
@@ -135,11 +134,11 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 		}
 
 		testURL := cloud.URLForResults(refID, cloudConfig)
-		fmt.Fprint(stdout, "\n\n")
-		fmt.Fprintf(stdout, "     execution: %s\n", ui.ValueColor.Sprint("cloud"))
-		fmt.Fprintf(stdout, "     script: %s\n", ui.ValueColor.Sprint(filename))
-		fmt.Fprintf(stdout, "     output: %s\n", ui.ValueColor.Sprint(testURL))
-		fmt.Fprint(stdout, "\n")
+		fprintf(stdout, "\n\n")
+		fprintf(stdout, "     execution: %s\n", ui.ValueColor.Sprint("cloud"))
+		fprintf(stdout, "     script: %s\n", ui.ValueColor.Sprint(filename))
+		fprintf(stdout, "     output: %s\n", ui.ValueColor.Sprint(testURL))
+		fprintf(stdout, "\n")
 
 		// The quiet option hides the progress bar and disallow aborting the test
 		if quiet {
@@ -173,7 +172,7 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 						shouldExitLoop = true
 					}
 					progress.Progress = testProgress.Progress
-					fmt.Fprintf(stdout, "%s\x1b[0K\r", progress.String())
+					fprintf(stdout, "%s\x1b[0K\r", progress.String())
 				} else {
 					log.WithError(progressErr).Error("Test progress error")
 				}
@@ -194,7 +193,7 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 			return ExitCode{errors.New("Test progress error"), 98}
 		}
 
-		fmt.Fprintf(stdout, "     test status: %s\n", ui.ValueColor.Sprint(testProgress.RunStatusText))
+		fprintf(stdout, "     test status: %s\n", ui.ValueColor.Sprint(testProgress.RunStatusText))
 
 		if testProgress.ResultStatus == cloud.ResultStatusFailed {
 			return ExitCode{errors.New("The test has failed"), 99}

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -72,7 +72,7 @@ func TestConfigCmd(t *testing.T) {
 				t.Run(`"`+test.Name+`"`, func(t *testing.T) {
 					fs := configFlagSet()
 					fs.AddFlagSet(optionFlagSet())
-					fs.Parse(test.Args)
+					assert.NoError(t, fs.Parse(test.Args))
 
 					config, err := getConfig(fs)
 					assert.NoError(t, err)

--- a/cmd/convert_test.go
+++ b/cmd/convert_test.go
@@ -132,18 +132,18 @@ func TestIntegrationConvertCmd(t *testing.T) {
 		buf := &bytes.Buffer{}
 		defaultWriter = buf
 
-		convertCmd.Flags().Set("correlate", "true")
-		convertCmd.Flags().Set("no-batch", "true")
-		convertCmd.Flags().Set("enable-status-code-checks", "true")
-		convertCmd.Flags().Set("return-on-failed-check", "true")
+		assert.NoError(t, convertCmd.Flags().Set("correlate", "true"))
+		assert.NoError(t, convertCmd.Flags().Set("no-batch", "true"))
+		assert.NoError(t, convertCmd.Flags().Set("enable-status-code-checks", "true"))
+		assert.NoError(t, convertCmd.Flags().Set("return-on-failed-check", "true"))
 
 		err = convertCmd.RunE(convertCmd, []string{"/input.har"})
 
 		// reset the convertCmd to default flags. There must be a nicer and less error prone way to do this...
-		convertCmd.Flags().Set("correlate", "false")
-		convertCmd.Flags().Set("no-batch", "false")
-		convertCmd.Flags().Set("enable-status-code-checks", "false")
-		convertCmd.Flags().Set("return-on-failed-check", "false")
+		assert.NoError(t, convertCmd.Flags().Set("correlate", "false"))
+		assert.NoError(t, convertCmd.Flags().Set("no-batch", "false"))
+		assert.NoError(t, convertCmd.Flags().Set("enable-status-code-checks", "false"))
+		assert.NoError(t, convertCmd.Flags().Set("return-on-failed-check", "false"))
 
 		if assert.NoError(t, err) {
 			// assert.Equal suppresses the diff it is too big, so we add it as the test error message manually as well.

--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -21,7 +21,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"gopkg.in/guregu/null.v3"
@@ -66,7 +65,7 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 		switch {
 		case reset.Valid:
 			conf.Token = null.StringFromPtr(nil)
-			fmt.Fprintf(stdout, "  token reset\n")
+			fprintf(stdout, "  token reset\n")
 		case show.Bool:
 		case token.Valid:
 			conf.Token = token
@@ -109,7 +108,7 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 		}
 
 		if conf.Token.Valid {
-			fmt.Fprintf(stdout, "  token: %s\n", ui.ValueColor.Sprint(conf.Token.String))
+			fprintf(stdout, "  token: %s\n", ui.ValueColor.Sprint(conf.Token.String))
 		}
 		return nil
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -104,6 +105,15 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&address, "address", "a", "localhost:6565", "address for the api server")
 	RootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file"+defaultConfigPathMsg)
 	must(cobra.MarkFlagFilename(RootCmd.PersistentFlags(), "config"))
+}
+
+// fprintf panics when where's an error writing to the supplied io.Writer
+func fprintf(w io.Writer, format string, a ...interface{}) (n int) {
+	n, err := fmt.Fprintf(w, format, a...)
+	if err != nil {
+		panic(err.Error())
+	}
+	return n
 }
 
 // RawFormatter it does nothing with the message just prints it

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -99,7 +99,7 @@ a commandline interface for interacting with it.`,
 		}
 
 		// Create the Runner.
-		fmt.Fprintf(stdout, "%s runner\r", initBar.String())
+		fprintf(stdout, "%s runner\r", initBar.String())
 		pwd, err := os.Getwd()
 		if err != nil {
 			return err
@@ -124,7 +124,7 @@ a commandline interface for interacting with it.`,
 		// Assemble options; start with the CLI-provided options to get shadowed (non-Valid)
 		// defaults in there, override with Runner-provided ones, then merge the CLI opts in
 		// on top to give them priority.
-		fmt.Fprintf(stdout, "%s options\r", initBar.String())
+		fprintf(stdout, "%s options\r", initBar.String())
 		cliConf, err := getConfig(cmd.Flags())
 		if err != nil {
 			return err
@@ -165,7 +165,7 @@ a commandline interface for interacting with it.`,
 		r.SetOptions(conf.Options)
 
 		// Create a local executor wrapping the runner.
-		fmt.Fprintf(stdout, "%s executor\r", initBar.String())
+		fprintf(stdout, "%s executor\r", initBar.String())
 		ex := local.New(r)
 		if runNoSetup {
 			ex.SetRunSetup(false)
@@ -175,7 +175,7 @@ a commandline interface for interacting with it.`,
 		}
 
 		// Create an engine.
-		fmt.Fprintf(stdout, "%s   engine\r", initBar.String())
+		fprintf(stdout, "%s   engine\r", initBar.String())
 		engine, err := core.NewEngine(ex, conf.Options)
 		if err != nil {
 			return err
@@ -187,7 +187,7 @@ a commandline interface for interacting with it.`,
 		}
 
 		// Create a collector and assign it to the engine if requested.
-		fmt.Fprintf(stdout, "%s   collector\r", initBar.String())
+		fprintf(stdout, "%s   collector\r", initBar.String())
 		for _, out := range conf.Out {
 			t, arg := parseCollector(out)
 			collector, err := newCollector(t, arg, src, conf)
@@ -201,7 +201,7 @@ a commandline interface for interacting with it.`,
 		}
 
 		// Create an API server.
-		fmt.Fprintf(stdout, "%s   server\r", initBar.String())
+		fprintf(stdout, "%s   server\r", initBar.String())
 		go func() {
 			if err := api.ListenAndServe(address, engine); err != nil {
 				log.WithError(err).Warn("Error from API server")
@@ -226,10 +226,10 @@ a commandline interface for interacting with it.`,
 				}
 			}
 
-			fmt.Fprintf(stdout, "  execution: %s\n", ui.ValueColor.Sprint("local"))
-			fmt.Fprintf(stdout, "     output: %s%s\n", ui.ValueColor.Sprint(out), ui.ExtraColor.Sprint(link))
-			fmt.Fprintf(stdout, "     script: %s\n", ui.ValueColor.Sprint(filename))
-			fmt.Fprintf(stdout, "\n")
+			fprintf(stdout, "  execution: %s\n", ui.ValueColor.Sprint("local"))
+			fprintf(stdout, "     output: %s%s\n", ui.ValueColor.Sprint(out), ui.ExtraColor.Sprint(link))
+			fprintf(stdout, "     script: %s\n", ui.ValueColor.Sprint(filename))
+			fprintf(stdout, "\n")
 
 			duration := ui.GrayColor.Sprint("-")
 			iterations := ui.GrayColor.Sprint("-")
@@ -249,13 +249,13 @@ a commandline interface for interacting with it.`,
 			durationPad := strings.Repeat(" ", leftWidth-ui.StrWidth(duration))
 			vusPad := strings.Repeat(" ", leftWidth-ui.StrWidth(vus))
 
-			fmt.Fprintf(stdout, "    duration: %s,%s iterations: %s\n", duration, durationPad, iterations)
-			fmt.Fprintf(stdout, "         vus: %s,%s max: %s\n", vus, vusPad, max)
-			fmt.Fprintf(stdout, "\n")
+			fprintf(stdout, "    duration: %s,%s iterations: %s\n", duration, durationPad, iterations)
+			fprintf(stdout, "         vus: %s,%s max: %s\n", vus, vusPad, max)
+			fprintf(stdout, "\n")
 		}
 
 		// Run the engine with a cancellable context.
-		fmt.Fprintf(stdout, "%s starting\r", initBar.String())
+		fprintf(stdout, "%s starting\r", initBar.String())
 		ctx, cancel := context.WithCancel(context.Background())
 		errC := make(chan error)
 		go func() { errC <- engine.Run(ctx) }()
@@ -371,7 +371,7 @@ a commandline interface for interacting with it.`,
 					}
 				}
 				progress.Progress = prog
-				fmt.Fprintf(stdout, "%s\x1b[0K\r", progress.String())
+				fprintf(stdout, "%s\x1b[0K\r", progress.String())
 			case err := <-errC:
 				if err != nil {
 					log.WithError(err).Error("Engine error")
@@ -397,7 +397,7 @@ a commandline interface for interacting with it.`,
 			fn("Test finished")
 		} else {
 			progress.Progress = 1
-			fmt.Fprintf(stdout, "%s\x1b[0K\n", progress.String())
+			fprintf(stdout, "%s\x1b[0K\n", progress.String())
 		}
 
 		// Warn if no iterations could be completed.
@@ -407,14 +407,14 @@ a commandline interface for interacting with it.`,
 
 		// Print the end-of-test summary.
 		if !quiet {
-			fmt.Fprintf(stdout, "\n")
+			fprintf(stdout, "\n")
 			ui.Summarize(stdout, "", ui.SummaryData{
 				Opts:    conf.Options,
 				Root:    engine.Executor.GetRunner().GetDefaultGroup(),
 				Metrics: engine.Metrics,
 				Time:    engine.Executor.GetTime(),
 			})
-			fmt.Fprintf(stdout, "\n")
+			fprintf(stdout, "\n")
 		}
 
 		if conf.Linger.Bool {

--- a/cmd/runtime_options_test.go
+++ b/cmd/runtime_options_test.go
@@ -215,7 +215,7 @@ func TestEnvVars(t *testing.T) {
 
 			archive := runner.MakeArchive()
 			archiveBuf := &bytes.Buffer{}
-			archive.Write(archiveBuf)
+			assert.NoError(t, archive.Write(archiveBuf))
 
 			getRunnerErr := func(rtOpts lib.RuntimeOptions) (lib.Runner, error) {
 				r, err := newRunner(

--- a/converter/har/converter.go
+++ b/converter/har/converter.go
@@ -25,6 +25,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
 	"sort"
 	"strings"
@@ -32,6 +33,28 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tidwall/pretty"
 )
+
+// fprint panics when where's an error writing to the supplied io.Writer
+// since this will be used on in-memory expandable buffers, that should
+// happen only when we run out of memory...
+func fprint(w io.Writer, a ...interface{}) int {
+	n, err := fmt.Fprint(w, a...)
+	if err != nil {
+		panic(err.Error())
+	}
+	return n
+}
+
+// fprintf panics when where's an error writing to the supplied io.Writer
+// since this will be used on in-memory expandable buffers, that should
+// happen only when we run out of memory...
+func fprintf(w io.Writer, format string, a ...interface{}) int {
+	n, err := fmt.Fprintf(w, format, a...)
+	if err != nil {
+		panic(err.Error())
+	}
+	return n
+}
 
 func Convert(h HAR, enableChecks bool, returnOnFailedCheck bool, batchTime uint, nobatch bool, correlate bool, only, skip []string) (string, error) {
 	var b bytes.Buffer
@@ -46,25 +69,25 @@ func Convert(h HAR, enableChecks bool, returnOnFailedCheck bool, batchTime uint,
 	}
 
 	if enableChecks {
-		fmt.Fprint(w, "import { group, check, sleep } from 'k6';\n")
+		fprint(w, "import { group, check, sleep } from 'k6';\n")
 	} else {
-		fmt.Fprint(w, "import { group, sleep } from 'k6';\n")
+		fprint(w, "import { group, sleep } from 'k6';\n")
 	}
-	fmt.Fprint(w, "import http from 'k6/http';\n\n")
+	fprint(w, "import http from 'k6/http';\n\n")
 
-	fmt.Fprintf(w, "// Version: %v\n", h.Log.Version)
-	fmt.Fprintf(w, "// Creator: %v\n", h.Log.Creator.Name)
+	fprintf(w, "// Version: %v\n", h.Log.Version)
+	fprintf(w, "// Creator: %v\n", h.Log.Creator.Name)
 	if h.Log.Browser != nil {
-		fmt.Fprintf(w, "// Browser: %v\n", h.Log.Browser.Name)
+		fprintf(w, "// Browser: %v\n", h.Log.Browser.Name)
 	}
 	if h.Log.Comment != "" {
-		fmt.Fprintf(w, "// %v\n", h.Log.Comment)
+		fprintf(w, "// %v\n", h.Log.Comment)
 	}
 
 	// recordings include redirections as separate requests, and we dont want to trigger them twice
-	fmt.Fprint(w, "\nexport let options = { maxRedirects: 0 };\n\n")
+	fprint(w, "\nexport let options = { maxRedirects: 0 };\n\n")
 
-	fmt.Fprint(w, "export default function() {\n\n")
+	fprint(w, "export default function() {\n\n")
 
 	pages := h.Log.Pages
 	sort.Sort(PageByStarted(pages))
@@ -98,7 +121,7 @@ func Convert(h HAR, enableChecks bool, returnOnFailedCheck bool, batchTime uint,
 	for i, page := range pages {
 
 		entries := pageEntries[page.ID]
-		fmt.Fprintf(w, "\tgroup(\"%s - %s\", function() {\n", page.ID, page.Title)
+		fprintf(w, "\tgroup(\"%s - %s\", function() {\n", page.ID, page.Title)
 
 		sort.Sort(EntryByStarted(entries))
 
@@ -106,7 +129,7 @@ func Convert(h HAR, enableChecks bool, returnOnFailedCheck bool, batchTime uint,
 			var recordedRedirectURL string
 			previousResponse := map[string]interface{}{}
 
-			fmt.Fprint(w, "\t\tlet res, redirectUrl, json;\n")
+			fprint(w, "\t\tlet res, redirectUrl, json;\n")
 
 			for entryIndex, e := range entries {
 
@@ -114,7 +137,7 @@ func Convert(h HAR, enableChecks bool, returnOnFailedCheck bool, batchTime uint,
 				var cookies []string
 				var body string
 
-				fmt.Fprintf(w, "\t\t// Request #%d\n", entryIndex)
+				fprintf(w, "\t\t// Request #%d\n", entryIndex)
 
 				if e.Request.PostData != nil {
 					body = e.Request.PostData.Text
@@ -131,16 +154,16 @@ func Convert(h HAR, enableChecks bool, returnOnFailedCheck bool, batchTime uint,
 					params = append(params, fmt.Sprintf("\"headers\": {\n\t\t\t\t\t%s\n\t\t\t\t}", strings.Join(headers, ",\n\t\t\t\t\t")))
 				}
 
-				fmt.Fprintf(w, "\t\tres = http.%s(", strings.ToLower(e.Request.Method))
+				fprintf(w, "\t\tres = http.%s(", strings.ToLower(e.Request.Method))
 
 				if correlate && recordedRedirectURL != "" {
 					if recordedRedirectURL != e.Request.URL {
 						return "", errors.Errorf("The har file contained a redirect but the next request did not match that redirect. Possibly a misbehaving client or concurrent requests?")
 					}
-					fmt.Fprintf(w, "redirectUrl")
+					fprintf(w, "redirectUrl")
 					recordedRedirectURL = ""
 				} else {
-					fmt.Fprintf(w, "%q", e.Request.URL)
+					fprintf(w, "%q", e.Request.URL)
 				}
 
 				if e.Request.Method != "GET" {
@@ -159,30 +182,30 @@ func Convert(h HAR, enableChecks bool, returnOnFailedCheck bool, batchTime uint,
 						requestText, err := json.Marshal(requestMap)
 						if err == nil {
 							prettyJSONString := string(pretty.PrettyOptions(requestText, &pretty.Options{Width: 999999, Prefix: "\t\t\t", Indent: "\t", SortKeys: true})[:])
-							fmt.Fprintf(w, ",\n\t\t\t`%s`", strings.TrimSpace(prettyJSONString))
+							fprintf(w, ",\n\t\t\t`%s`", strings.TrimSpace(prettyJSONString))
 						} else {
 							return "", err
 						}
 
 					} else {
-						fmt.Fprintf(w, ",\n\t\t%q", body)
+						fprintf(w, ",\n\t\t%q", body)
 					}
 				}
 
 				if len(params) > 0 {
-					fmt.Fprintf(w, ",\n\t\t\t{\n\t\t\t\t%s\n\t\t\t}", strings.Join(params, ",\n\t\t\t"))
+					fprintf(w, ",\n\t\t\t{\n\t\t\t\t%s\n\t\t\t}", strings.Join(params, ",\n\t\t\t"))
 				}
 
-				fmt.Fprintf(w, "\n\t\t)\n")
+				fprintf(w, "\n\t\t)\n")
 
 				if e.Response != nil {
 					// the response is nil if there is a failed request in the recording, or if responses were not recorded
 					if enableChecks {
 						if e.Response.Status > 0 {
 							if returnOnFailedCheck {
-								fmt.Fprintf(w, "\t\tif (!check(res, {\"status is %v\": (r) => r.status === %v })) { return };\n", e.Response.Status, e.Response.Status)
+								fprintf(w, "\t\tif (!check(res, {\"status is %v\": (r) => r.status === %v })) { return };\n", e.Response.Status, e.Response.Status)
 							} else {
-								fmt.Fprintf(w, "\t\tcheck(res, {\"status is %v\": (r) => r.status === %v });\n", e.Response.Status, e.Response.Status)
+								fprintf(w, "\t\tcheck(res, {\"status is %v\": (r) => r.status === %v });\n", e.Response.Status, e.Response.Status)
 							}
 						}
 					}
@@ -190,7 +213,7 @@ func Convert(h HAR, enableChecks bool, returnOnFailedCheck bool, batchTime uint,
 					if e.Response.Headers != nil {
 						for _, header := range e.Response.Headers {
 							if header.Name == "Location" {
-								fmt.Fprintf(w, "\t\tredirectUrl = res.headers.Location;\n")
+								fprintf(w, "\t\tredirectUrl = res.headers.Location;\n")
 								recordedRedirectURL = header.Value
 								break
 							}
@@ -204,38 +227,38 @@ func Convert(h HAR, enableChecks bool, returnOnFailedCheck bool, batchTime uint,
 						if err := json.Unmarshal([]byte(e.Response.Content.Text), &previousResponse); err != nil {
 							return "", err
 						}
-						fmt.Fprint(w, "\t\tjson = JSON.parse(res.body);\n")
+						fprint(w, "\t\tjson = JSON.parse(res.body);\n")
 					}
 				}
 			}
 		} else {
 			batches := SplitEntriesInBatches(entries, batchTime)
 
-			fmt.Fprint(w, "\t\tlet req, res;\n")
+			fprint(w, "\t\tlet req, res;\n")
 
 			for j, batchEntries := range batches {
 
-				fmt.Fprint(w, "\t\treq = [")
+				fprint(w, "\t\treq = [")
 				for k, e := range batchEntries {
 					r, err := buildK6RequestObject(e.Request)
 					if err != nil {
 						return "", err
 					}
-					fmt.Fprintf(w, "%v", r)
+					fprintf(w, "%v", r)
 					if k != len(batchEntries)-1 {
-						fmt.Fprint(w, ",")
+						fprint(w, ",")
 					}
 				}
-				fmt.Fprint(w, "];\n")
-				fmt.Fprint(w, "\t\tres = http.batch(req);\n")
+				fprint(w, "];\n")
+				fprint(w, "\t\tres = http.batch(req);\n")
 
 				if enableChecks {
 					for k, e := range batchEntries {
 						if e.Response.Status > 0 {
 							if returnOnFailedCheck {
-								fmt.Fprintf(w, "\t\tif (!check(res, {\"status is %v\": (r) => r.status === %v })) { return };\n", e.Response.Status, e.Response.Status)
+								fprintf(w, "\t\tif (!check(res, {\"status is %v\": (r) => r.status === %v })) { return };\n", e.Response.Status, e.Response.Status)
 							} else {
-								fmt.Fprintf(w, "\t\tcheck(res[%v], {\"status is %v\": (r) => r.status === %v });\n", k, e.Response.Status, e.Response.Status)
+								fprintf(w, "\t\tcheck(res[%v], {\"status is %v\": (r) => r.status === %v });\n", k, e.Response.Status, e.Response.Status)
 							}
 						}
 					}
@@ -245,14 +268,14 @@ func Convert(h HAR, enableChecks bool, returnOnFailedCheck bool, batchTime uint,
 					lastBatchEntry := batchEntries[len(batchEntries)-1]
 					firstBatchEntry := batches[j+1][0]
 					t := firstBatchEntry.StartedDateTime.Sub(lastBatchEntry.StartedDateTime).Seconds()
-					fmt.Fprintf(w, "\t\tsleep(%.2f);\n", t)
+					fprintf(w, "\t\tsleep(%.2f);\n", t)
 				}
 			}
 
 			if i == len(pages)-1 {
 				// Last page; add random sleep time at the group completion
-				fmt.Fprint(w, "\t\t// Random sleep between 20s and 40s\n")
-				fmt.Fprint(w, "\t\tsleep(Math.floor(Math.random()*20+20));\n")
+				fprint(w, "\t\t// Random sleep between 20s and 40s\n")
+				fprint(w, "\t\tsleep(Math.floor(Math.random()*20+20));\n")
 			} else {
 				// Add sleep time at the end of the group
 				nextPage := pages[i+1]
@@ -261,14 +284,14 @@ func Convert(h HAR, enableChecks bool, returnOnFailedCheck bool, batchTime uint,
 				if t < 0.01 {
 					t = 0.5
 				}
-				fmt.Fprintf(w, "\t\tsleep(%.2f);\n", t)
+				fprintf(w, "\t\tsleep(%.2f);\n", t)
 			}
 		}
 
-		fmt.Fprint(w, "\t});\n")
+		fprint(w, "\t});\n")
 	}
 
-	fmt.Fprint(w, "\n}\n")
+	fprint(w, "\n}\n")
 	if err := w.Flush(); err != nil {
 		return "", err
 	}
@@ -279,22 +302,22 @@ func buildK6RequestObject(req *Request) (string, error) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 
-	fmt.Fprint(w, "{\n")
+	fprint(w, "{\n")
 
 	method := strings.ToLower(req.Method)
 	if method == "delete" {
 		method = "del"
 	}
-	fmt.Fprintf(w, `"method": %q, "url": %q`, method, req.URL)
+	fprintf(w, `"method": %q, "url": %q`, method, req.URL)
 
 	if req.PostData != nil && method != "get" {
 		postParams, plainText, err := buildK6Body(req)
 		if err != nil {
 			return "", err
 		} else if len(postParams) > 0 {
-			fmt.Fprintf(w, `, "body": { %s }`, strings.Join(postParams, ", "))
+			fprintf(w, `, "body": { %s }`, strings.Join(postParams, ", "))
 		} else if plainText != "" {
-			fmt.Fprintf(w, `, "body": %q`, plainText)
+			fprintf(w, `, "body": %q`, plainText)
 		}
 	}
 
@@ -312,10 +335,10 @@ func buildK6RequestObject(req *Request) (string, error) {
 	}
 
 	if len(params) > 0 {
-		fmt.Fprintf(w, `, "params": { %s }`, strings.Join(params, ", "))
+		fprintf(w, `, "params": { %s }`, strings.Join(params, ", "))
 	}
 
-	fmt.Fprint(w, "}")
+	fprint(w, "}")
 	if err := w.Flush(); err != nil {
 		return "", err
 	}

--- a/core/local/local_test.go
+++ b/core/local/local_test.go
@@ -485,8 +485,8 @@ func TestRealTimeAndSetupTeardownMetrics(t *testing.T) {
 
 	executor := New(runner)
 	executor.SetEndIterations(null.IntFrom(2))
-	executor.SetVUsMax(1)
-	executor.SetVUs(1)
+	require.NoError(t, executor.SetVUsMax(1))
+	require.NoError(t, executor.SetVUs(1))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/js/initcontext_test.go
+++ b/js/initcontext_test.go
@@ -317,10 +317,12 @@ func TestRequestWithBinaryFile(t *testing.T) {
 			ch <- true
 		}()
 
-		r.ParseMultipartForm(32 << 20)
+		assert.NoError(t, r.ParseMultipartForm(32<<20))
 		file, _, err := r.FormFile("file")
 		assert.NoError(t, err)
-		defer file.Close()
+		defer func() {
+			assert.NoError(t, file.Close())
+		}()
 		bytes := make([]byte, 3)
 		_, err = file.Read(bytes)
 		assert.NoError(t, err)

--- a/js/modules/k6/http/http_request_test.go
+++ b/js/modules/k6/http/http_request_test.go
@@ -1237,6 +1237,8 @@ func ntlmHandler(username, password string) func(w http.ResponseWriter, r *http.
 
 		data := "authenticated"
 		w.Header().Set("Content-Length", fmt.Sprint(len(data)))
-		fmt.Fprint(w, data)
+		if _, err := fmt.Fprint(w, data); err != nil {
+			panic(err.Error())
+		}
 	}
 }

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -40,6 +40,7 @@ import (
 	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v3"
 )
 
@@ -544,8 +545,12 @@ func TestVUIntegrationHosts(t *testing.T) {
 		}),
 		ErrorLog: stdlog.New(ioutil.Discard, "", 0),
 	}
-	go srv.ListenAndServe()
-	defer srv.Shutdown(context.TODO())
+	go func() {
+		require.NoError(t, srv.ListenAndServe())
+	}()
+	defer func() {
+		require.NoError(t, srv.Shutdown(context.TODO()))
+	}()
 
 	r1, err := New(&lib.SourceData{
 		Filename: "/script.js",

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -125,7 +125,8 @@ func TestLoad(t *testing.T) {
 			http.Error(w, "Internal server error", 500)
 			return
 		}
-		fmt.Fprint(w, responseStr)
+		_, err := fmt.Fprint(w, responseStr)
+		assert.NoError(t, err)
 	})
 
 	t.Run("No _k6=1 Fallback", func(t *testing.T) {

--- a/stats/cloud/collector_test.go
+++ b/stats/cloud/collector_test.go
@@ -119,7 +119,7 @@ func TestCloudCollector(t *testing.T) {
 	t.Parallel()
 	tb := testutils.NewHTTPMultiBin(t)
 	tb.Mux.HandleFunc("/v1/tests", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, `{
+		_, err := fmt.Fprintf(w, `{
 			"reference_id": "123",
 			"config": {
 				"metricPushInterval": "10ms",
@@ -128,6 +128,7 @@ func TestCloudCollector(t *testing.T) {
 				"aggregationWaitPeriod": "5ms"
 			}
 		}`)
+		require.NoError(t, err)
 	}))
 	defer tb.Cleanup()
 

--- a/ui/form.go
+++ b/ui/form.go
@@ -47,7 +47,9 @@ type Form struct {
 // Runs the form against the specified input and output.
 func (f Form) Run(r io.Reader, w io.Writer) (map[string]interface{}, error) {
 	if f.Banner != "" {
-		fmt.Fprintln(w, color.BlueString(f.Banner)+"\n")
+		if _, err := fmt.Fprintln(w, color.BlueString(f.Banner)+"\n"); err != nil {
+			return nil, err
+		}
 	}
 
 	buf := bufio.NewReader(r)
@@ -58,7 +60,9 @@ func (f Form) Run(r io.Reader, w io.Writer) (map[string]interface{}, error) {
 			if extra := field.GetLabelExtra(); extra != "" {
 				displayLabel += " " + color.New(color.Faint, color.FgCyan).Sprint("["+extra+"]")
 			}
-			fmt.Fprintf(w, "  "+displayLabel+": ")
+			if _, err := fmt.Fprintf(w, "  "+displayLabel+": "); err != nil {
+				return nil, err
+			}
 
 			color.Set(color.FgCyan)
 			s, err := buf.ReadString('\n')
@@ -69,7 +73,9 @@ func (f Form) Run(r io.Reader, w io.Writer) (map[string]interface{}, error) {
 
 			v, err := field.Clean(s)
 			if err != nil {
-				fmt.Fprintln(w, color.RedString("- "+err.Error()))
+				if _, printErr := fmt.Fprintln(w, color.RedString("- "+err.Error())); printErr != nil {
+					return nil, printErr
+				}
 				continue
 			}
 

--- a/ui/summary.go
+++ b/ui/summary.go
@@ -196,7 +196,7 @@ func SummarizeGroup(w io.Writer, indent string, group *lib.Group) {
 		SummarizeCheck(w, indent, group.Checks[name])
 	}
 	if len(checkNames) > 0 {
-		fmt.Fprintf(w, "\n")
+		_, _ = fmt.Fprintf(w, "\n")
 	}
 
 	var groupNames []string
@@ -343,7 +343,7 @@ func SummarizeMetrics(w io.Writer, indent string, t time.Duration, timeUnit stri
 				fmtData = fmtData + " " + ExtraColor.Sprint(strings.Join(parts, " "))
 			}
 		}
-		fmt.Fprint(w, indent+fmtIndent+markColor.Sprint(mark)+" "+fmtName+" "+fmtData+"\n")
+		_, _ = fmt.Fprint(w, indent+fmtIndent+markColor.Sprint(mark)+" "+fmtName+" "+fmtData+"\n")
 	}
 }
 


### PR DESCRIPTION
It seems like `errcheck` won't ignore unchecked `fmt.Fprint*()` calls anymore, this should fix all of the issues we had in k6.