### PR TITLE
Add HAR converter options

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -28,9 +28,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var output = ""
-
 var (
+	output              string
+	options             string
 	enableChecks        bool
 	returnOnFailedCheck bool
 	correlate           bool
@@ -75,7 +75,7 @@ var convertCmd = &cobra.Command{
 			return err
 		}
 
-		script, err := har.Convert(h, enableChecks, returnOnFailedCheck, threshold, nobatch, correlate, only, skip)
+		script, err := har.Convert(h, options, enableChecks, returnOnFailedCheck, threshold, nobatch, correlate, only, skip)
 		if err != nil {
 			return err
 		}
@@ -108,6 +108,7 @@ func init() {
 	RootCmd.AddCommand(convertCmd)
 	convertCmd.Flags().SortFlags = false
 	convertCmd.Flags().StringVarP(&output, "output", "O", output, "k6 script output filename (stdout by default)")
+	convertCmd.Flags().StringVarP(&options, "options", "", output, "path to a JSON file with options that would be injected in the output script")
 	convertCmd.Flags().StringSliceVarP(&only, "only", "", []string{}, "include only requests from the given domains")
 	convertCmd.Flags().StringSliceVarP(&skip, "skip", "", []string{}, "skip requests from the given domains")
 	convertCmd.Flags().UintVarP(&threshold, "batch-threshold", "", 500, "batch request idle time threshold (see example)")

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -35,6 +35,8 @@ import (
 var (
 	output              string
 	optionsFilePath     string
+	minSleep            uint
+	maxSleep            uint
 	enableChecks        bool
 	returnOnFailedCheck bool
 	correlate           bool
@@ -94,7 +96,8 @@ var convertCmd = &cobra.Command{
 			options = options.Apply(injectedOptions)
 		}
 
-		script, err := har.Convert(h, options, enableChecks, returnOnFailedCheck, threshold, nobatch, correlate, only, skip)
+		//TODO: refactor...
+		script, err := har.Convert(h, options, minSleep, maxSleep, enableChecks, returnOnFailedCheck, threshold, nobatch, correlate, only, skip)
 		if err != nil {
 			return err
 		}
@@ -135,4 +138,6 @@ func init() {
 	convertCmd.Flags().BoolVarP(&enableChecks, "enable-status-code-checks", "", false, "add a status code check for each HTTP response")
 	convertCmd.Flags().BoolVarP(&returnOnFailedCheck, "return-on-failed-check", "", false, "return from iteration if we get an unexpected response status code")
 	convertCmd.Flags().BoolVarP(&correlate, "correlate", "", false, "detect values in responses being used in subsequent requests and try adapt the script accordingly (only redirects and JSON values for now)")
+	convertCmd.Flags().UintVarP(&minSleep, "min-sleep", "", 20, "the minimum amount of seconds to sleep after each iteration")
+	convertCmd.Flags().UintVarP(&maxSleep, "max-sleep", "", 40, "the maximum amount of seconds to sleep after each iteration")
 }

--- a/cmd/convert_test.go
+++ b/cmd/convert_test.go
@@ -94,7 +94,9 @@ import http from 'k6/http';
 // Version: 1.2
 // Creator: WebInspector
 
-export let options = { maxRedirects: 0 };
+export let options = {
+    "maxRedirects": 0
+};
 
 export default function() {
 
@@ -185,4 +187,6 @@ func TestIntegrationConvertCmd(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, testHARConvertResult, string(output))
 	})
+	// TODO: test options injection; right now that's difficult because when there are multiple
+	// options, they can be emitted in different order in the JSON
 }

--- a/cmd/testdata/example.js
+++ b/cmd/testdata/example.js
@@ -4,7 +4,9 @@ import http from 'k6/http';
 // Version: 1.2
 // Creator: BrowserMob Proxy
 
-export let options = { maxRedirects: 0 };
+export let options = {
+    "maxRedirects": 0
+};
 
 export default function() {
 

--- a/converter/har/converter.go
+++ b/converter/har/converter.go
@@ -58,7 +58,7 @@ func fprintf(w io.Writer, format string, a ...interface{}) int {
 }
 
 // TODO: refactor this to have fewer parameters... or just refactor in general...
-func Convert(h HAR, options lib.Options, enableChecks bool, returnOnFailedCheck bool, batchTime uint, nobatch bool, correlate bool, only, skip []string) (string, error) {
+func Convert(h HAR, options lib.Options, minSleep, maxSleep uint, enableChecks bool, returnOnFailedCheck bool, batchTime uint, nobatch bool, correlate bool, only, skip []string) (string, error) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 
@@ -280,8 +280,8 @@ func Convert(h HAR, options lib.Options, enableChecks bool, returnOnFailedCheck 
 
 			if i == len(pages)-1 {
 				// Last page; add random sleep time at the group completion
-				fprint(w, "\t\t// Random sleep between 20s and 40s\n")
-				fprint(w, "\t\tsleep(Math.floor(Math.random()*20+20));\n")
+				fprintf(w, "\t\t// Random sleep between %ds and %ds\n", minSleep, maxSleep)
+				fprintf(w, "\t\tsleep(Math.floor(Math.random()*%d+%d));\n", maxSleep-minSleep, minSleep)
 			} else {
 				// Add sleep time at the end of the group
 				nextPage := pages[i+1]

--- a/converter/har/converter.go
+++ b/converter/har/converter.go
@@ -79,7 +79,7 @@ func Convert(h HAR, optionsFilePath string, enableChecks bool, returnOnFailedChe
 		scriptOptions = scriptOptions.Apply(injectedOptions)
 	}
 
-	scriptOptionsSrc, err := json.Marshal(scriptOptions)
+	scriptOptionsSrc, err := scriptOptions.GetCleanJSON()
 	if err != nil {
 		return "", err
 	}

--- a/lib/options.go
+++ b/lib/options.go
@@ -367,11 +367,15 @@ func (o Options) Apply(opts Options) Options {
 	return o
 }
 
-// GetCleanJSON is a massive hack that works arround the fact that some
+// GetPrettyJSON is a massive hack that works around the fact that some
 // of the null-able types used in Options are marshalled to `null` when
 // their `valid` flag is false.
-func (o Options) GetCleanJSON() ([]byte, error) {
-	nullyResult, err := json.Marshal(o)
+// TODO: figure out something better or at least use reflect to do it, that
+// way field order could be preserved, we could optionally emit JS objects
+// (without mandatory quoted keys)` and we won't needlessly marshal and
+// unmarshal things...
+func (o Options) GetPrettyJSON(prefix, indent string) ([]byte, error) {
+	nullyResult, err := json.MarshalIndent(o, prefix, indent)
 	if err != nil {
 		return nil, err
 	}
@@ -387,5 +391,5 @@ func (o Options) GetCleanJSON() ([]byte, error) {
 			delete(tmpMap, k)
 		}
 	}
-	return json.Marshal(tmpMap)
+	return json.MarshalIndent(tmpMap, prefix, indent)
 }

--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -12,7 +12,8 @@ console.log(rnd)
 ```
 
 * A new option `--no-vu-connection-reuse` lets users close HTTP `keep-alive` connections between iterations of a VU. (#676)
-* New options were added to the HAR converter. You can set the minimum and maximum sleep time at the end of an iteration with the new `--min-sleep` and `--max-sleep` CLI flags of `k6 convert`. You can also specify a JSON file with [script options](https://docs.k6.io/docs/options) that would be added to the options of the generated scripts with the new `--options` flag. (#694)
+* You can now set the minimum and maximum sleep time at the end of an iteration with the new `--min-sleep` and `--max-sleep` HAR coverter CLI flags. (#694)
+* Another new feature in the HAR converter enabled users to specify a JSON file with [script options](https://docs.k6.io/docs/options) that would be added to the options of the generated scripts with the new `--options` flag. (#694)
 
 
 ## UX

--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -12,7 +12,7 @@ console.log(rnd)
 ```
 
 * A new option `--no-vu-connection-reuse` lets users close HTTP `keep-alive` connections between iterations of a VU. (#676)
-* Script options can now be injected when converting HAR files with the new `--options` CLI flag. (#694)
+* New options were added to the HAR converter. You can set the minimum and maximum sleep time at the end of an iteration with the new `--min-sleep` and `--max-sleep` CLI flags of `k6 convert`. You can also specify a JSON file with [script options](https://docs.k6.io/docs/options) that would be added to the options of the generated scripts with the new `--options` flag. (#694)
 
 
 ## UX

--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -12,6 +12,7 @@ console.log(rnd)
 ```
 
 * A new option `--no-vu-connection-reuse` lets users close HTTP `keep-alive` connections between iterations of a VU. (#676)
+* Script options can now be injected when converting HAR files with the new `--options` CLI flag. (#694)
 
 
 ## UX


### PR DESCRIPTION
This adds a new `--options` flag for injecting options in the HAR converter output script (and closes https://github.com/loadimpact/k6/issues/690). It also adds new `--min-sleep` and `--max-sleep` flags that determine the minimum and maximum sleep times at the end of the iteration in the output script.