### PR TITLE
Simplify Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ RUN apk --no-cache add --virtual .build-deps git make build-base && \
   go get . && CGO_ENABLED=0 go install -a -ldflags '-s -w'
 
 FROM alpine:3.7
-WORKDIR /root/
-COPY --from=builder /go/bin/k6 /root
-COPY --from=builder /etc/ssl /etc/ssl
-ENV PATH "$PATH:/root"
-ENTRYPOINT ["./k6"]
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /go/bin/k6 /usr/bin/k6
+ENTRYPOINT ["k6"]


### PR DESCRIPTION
The current Dockerfile has an entrypoint relative to its working directory, which makes it slightly awkward to use, e.g.

```
$ docker run -it --rm -v $(pwd):$(pwd) -w $(pwd) loadimpact/k6:0.22.0 run script.js
docker: Error response from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused "exec: \"./k6\": stat ./k6: no such file or directory": unknown.
```

This PR makes it so the Docker image is less coupled to its working directory. The pipe-script-to-stdin workflow should continue to work as before.