### PR TITLE
Fix zero-filled and wrongly emitted metrics

### DIFF
--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -816,3 +816,5 @@ func TestSetupTeardownThresholds(t *testing.T) {
 		require.False(t, engine.IsTainted())
 	}
 }
+
+// TODO: write a test that checks if samples are emitted when the context is cancelled

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -492,13 +492,24 @@ func getMetricSum(collector *dummy.Collector, name string) (result float64) {
 	}
 	return
 }
+func getMetricCount(collector *dummy.Collector, name string) (result uint) {
+	for _, sc := range collector.SampleContainers {
+		for _, s := range sc.GetSamples() {
+			if s.Metric.Name == name {
+				result++
+			}
+		}
+	}
+	return
+}
+
+const expectedHeaderMaxLength = 500
+
 func TestSentReceivedMetrics(t *testing.T) {
 	t.Parallel()
 	tb := testutils.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 	tr := tb.Replacer.Replace
-
-	const expectedHeaderMaxLength = 500
 
 	type testScript struct {
 		Code                 string
@@ -817,4 +828,90 @@ func TestSetupTeardownThresholds(t *testing.T) {
 	}
 }
 
-// TODO: write a test that checks if samples are emitted when the context is cancelled
+func TestEmittedMetricsWhenScalingDown(t *testing.T) {
+	t.Parallel()
+	tb := testutils.NewHTTPMultiBin(t)
+	defer tb.Cleanup()
+
+	script := []byte(tb.Replacer.Replace(`
+		import http from "k6/http";
+		import { sleep } from "k6";
+
+		export let options = {
+			systemTags: ["iter", "vu", "url"],
+
+			// Start with 2 VUs for 2 second and then quickly scale down to 1 for the next 2s and then quit
+			vus: 2,
+			vusMax: 2,
+			stages: [
+				{ duration: "2s", target: 2 },
+				{ duration: "1s", target: 1 },
+				{ duration: "1s", target: 1 },
+			],
+		};
+
+		export default function () {
+			console.log("VU " + __VU + " starting iteration #" + __ITER);
+			http.get("HTTPBIN_IP_URL/bytes/15000");
+			sleep(1.7);
+			http.get("HTTPBIN_IP_URL/bytes/15000");
+			console.log("VU " + __VU + " ending iteration #" + __ITER);
+		};
+	`))
+
+	runner, err := js.New(
+		&lib.SourceData{Filename: "/script.js", Data: script},
+		afero.NewMemMapFs(),
+		lib.RuntimeOptions{},
+	)
+	require.NoError(t, err)
+
+	engine, err := NewEngine(local.New(runner), runner.GetOptions())
+	require.NoError(t, err)
+
+	collector := &dummy.Collector{}
+	engine.Collectors = []lib.Collector{collector}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errC := make(chan error)
+	go func() { errC <- engine.Run(ctx) }()
+
+	select {
+	case <-time.After(10 * time.Second):
+		cancel()
+		t.Fatal("Test timed out")
+	case err := <-errC:
+		cancel()
+		require.NoError(t, err)
+		require.False(t, engine.IsTainted())
+	}
+
+	// The 1.7 sleep in the default function would cause the first VU to comlete 2 full iterations
+	// and stat executing its third one, while the second VU will only fully complete 1 iteration
+	// and will be canceled in the middle of its second one.
+	assert.Equal(t, 3.0, getMetricSum(collector, metrics.Iterations.Name))
+
+	// That means that we expect to see 8 HTTP requests in total, 3*2=6 from the complete iterations
+	// and one each from the two iterations that would be canceled in the middle of their execution
+	assert.Equal(t, 8.0, getMetricSum(collector, metrics.HTTPReqs.Name))
+
+	// But we expect to only see the data_received for only 7 of those requests. The data for the 8th
+	// request (the 3rd one in the first VU before the test ends) gets cut off by the engine because
+	// it's emitted after the test officially ends
+	dataReceivedExpectedMin := 15000.0 * 7
+	dataReceivedExpectedMax := (15000.0 + expectedHeaderMaxLength) * 7
+	dataReceivedActual := getMetricSum(collector, metrics.DataReceived.Name)
+	if dataReceivedActual < dataReceivedExpectedMin || dataReceivedActual > dataReceivedExpectedMax {
+		t.Errorf(
+			"The data_received sum should be in the interval [%f, %f] but was %f",
+			dataReceivedExpectedMin, dataReceivedExpectedMax, dataReceivedActual,
+		)
+	}
+
+	// Also, the interrupted iterations shouldn't affect the average iteration_duration in any way, only
+	// complete iterations should be taken into account
+	durationCount := float64(getMetricCount(collector, metrics.IterationDuration.Name))
+	assert.Equal(t, 3.0, durationCount)
+	durationSum := getMetricSum(collector, metrics.IterationDuration.Name)
+	assert.InDelta(t, 1.7, durationSum/(1000*durationCount), 0.1)
+}

--- a/core/local/local_test.go
+++ b/core/local/local_test.go
@@ -549,7 +549,7 @@ func TestRealTimeAndSetupTeardownMetrics(t *testing.T) {
 		}
 	}
 	getDummyTrail := func(group string) stats.SampleContainer {
-		return netext.NewDialer(net.Dialer{}).GetTrail(time.Now(), time.Now(), getTags("group", group))
+		return netext.NewDialer(net.Dialer{}).GetTrail(time.Now(), time.Now(), true, getTags("group", group))
 	}
 
 	// Initially give a long time (5s) for the executor to start

--- a/js/modules/k6/http/http_request.go
+++ b/js/modules/k6/http/http_request.go
@@ -470,7 +470,7 @@ func (h *HTTP) request(ctx context.Context, preq *parsedHTTPRequest) (*HTTPRespo
 		}
 		trail.SaveSamples(stats.NewSampleTags(tags))
 		delete(tags, "ip")
-		state.Samples <- trail
+		stats.PushIfNotCancelled(ctx, state.Samples, trail)
 	}
 
 	if preq.auth == "ntlm" {
@@ -599,7 +599,7 @@ func (h *HTTP) request(ctx context.Context, preq *parsedHTTPRequest) (*HTTPRespo
 		}
 	}
 	trail.SaveSamples(stats.IntoSampleTags(&tags))
-	state.Samples <- trail
+	stats.PushIfNotCancelled(ctx, state.Samples, trail)
 	return resp, nil
 }
 

--- a/js/modules/k6/k6.go
+++ b/js/modules/k6/k6.go
@@ -87,12 +87,13 @@ func (*K6) Group(ctx context.Context, name string, fn goja.Callable) (goja.Value
 		tags["iter"] = strconv.FormatInt(state.Iteration, 10)
 	}
 
-	state.Samples <- stats.Sample{
+	stats.PushIfNotCancelled(ctx, state.Samples, stats.Sample{
 		Time:   t,
 		Metric: metrics.GroupDuration,
 		Tags:   stats.IntoSampleTags(&tags),
 		Value:  stats.D(t.Sub(startTime)),
-	}
+	})
+
 	return ret, err
 }
 
@@ -156,10 +157,10 @@ func (*K6) Check(ctx context.Context, arg0, checks goja.Value, extras ...goja.Va
 		default:
 			if val.ToBoolean() {
 				atomic.AddInt64(&check.Passes, 1)
-				state.Samples <- stats.Sample{Time: t, Metric: metrics.Checks, Tags: sampleTags, Value: 1}
+				stats.PushIfNotCancelled(ctx, state.Samples, stats.Sample{Time: t, Metric: metrics.Checks, Tags: sampleTags, Value: 1})
 			} else {
 				atomic.AddInt64(&check.Fails, 1)
-				state.Samples <- stats.Sample{Time: t, Metric: metrics.Checks, Tags: sampleTags, Value: 0}
+				stats.PushIfNotCancelled(ctx, state.Samples, stats.Sample{Time: t, Metric: metrics.Checks, Tags: sampleTags, Value: 0})
 				// A single failure makes the return value false.
 				succ = false
 			}

--- a/js/modules/k6/metrics/metrics.go
+++ b/js/modules/k6/metrics/metrics.go
@@ -67,7 +67,7 @@ func (m Metric) Add(ctx context.Context, v goja.Value, addTags ...map[string]str
 		vfloat = 1.0
 	}
 
-	state.Samples <- stats.Sample{Time: time.Now(), Metric: m.metric, Value: vfloat, Tags: stats.IntoSampleTags(&tags)}
+	stats.PushIfNotCancelled(ctx, state.Samples, stats.Sample{Time: time.Now(), Metric: m.metric, Value: vfloat, Tags: stats.IntoSampleTags(&tags)})
 }
 
 type Metrics struct{}

--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -275,39 +275,41 @@ func (*WS) Connect(ctx context.Context, url string, args ...goja.Value) (*WSHTTP
 
 			sampleTags := stats.IntoSampleTags(&tags)
 
-			state.Samples <- stats.ConnectedSamples{
-				[]stats.Sample{
+			stats.PushIfNotCancelled(ctx, state.Samples, stats.ConnectedSamples{
+				Samples: []stats.Sample{
 					{Metric: metrics.WSSessions, Time: start, Tags: sampleTags, Value: 1},
 					{Metric: metrics.WSConnecting, Time: start, Tags: sampleTags, Value: connectionDuration},
 					{Metric: metrics.WSSessionDuration, Time: start, Tags: sampleTags, Value: sessionDuration},
-				}, sampleTags, start,
-			}
+				},
+				Tags: sampleTags,
+				Time: start,
+			})
 
 			for _, msgSentTimestamp := range socket.msgSentTimestamps {
-				state.Samples <- stats.Sample{
+				stats.PushIfNotCancelled(ctx, state.Samples, stats.Sample{
 					Metric: metrics.WSMessagesSent,
 					Time:   msgSentTimestamp,
 					Tags:   sampleTags,
 					Value:  1,
-				}
+				})
 			}
 
 			for _, msgReceivedTimestamp := range socket.msgReceivedTimestamps {
-				state.Samples <- stats.Sample{
+				stats.PushIfNotCancelled(ctx, state.Samples, stats.Sample{
 					Metric: metrics.WSMessagesReceived,
 					Time:   msgReceivedTimestamp,
 					Tags:   sampleTags,
 					Value:  1,
-				}
+				})
 			}
 
 			for _, pingDelta := range socket.pingTimestamps {
-				state.Samples <- stats.Sample{
+				stats.PushIfNotCancelled(ctx, state.Samples, stats.Sample{
 					Metric: metrics.WSPing,
 					Time:   pingDelta.pong,
 					Tags:   sampleTags,
 					Value:  stats.D(pingDelta.pong.Sub(pingDelta.ping)),
-				}
+				})
 			}
 
 			return wsResponse, nil

--- a/js/runner.go
+++ b/js/runner.go
@@ -395,7 +395,7 @@ func (u *VU) runFn(ctx context.Context, group *lib.Group, fn goja.Callable, args
 		u.HTTPTransport.CloseIdleConnections()
 	}
 
-	state.Samples <- u.Dialer.GetTrail(startTime, endTime, stats.IntoSampleTags(&tags))
+	stats.PushIfNotCancelled(ctx, state.Samples, u.Dialer.GetTrail(startTime, endTime, stats.IntoSampleTags(&tags)))
 
 	return v, state, err
 }

--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -13,3 +13,4 @@ Description of feature.
 * Logging: using the `--no-color` flag caused k6 to print output intended for `sdtout` to `stderr` instead. (#712)
 * Logging: some error messages originating from Go's standard library did not obey the `--logformat` option. (#712)
 * JSON output: when the standard output was used, the JSON collector closed it before k6 was finished printing the end-of-test summary to it (#715)
+* Metrics: some zero-filled metrics were emitted when scaling down the number of VUs (#710)

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -21,6 +21,7 @@
 package stats
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -384,6 +385,18 @@ func GetBufferedSamples(input <-chan SampleContainer) (result []SampleContainer)
 			return
 		}
 	}
+}
+
+// PushIfNotCancelled first checks if the supplied context is cancelled and doesn't push
+// the sample container if it is.
+func PushIfNotCancelled(ctx context.Context, output chan<- SampleContainer, sample SampleContainer) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	default: // Do nothing
+	}
+	output <- sample
+	return true
 }
 
 // A Metric defines the shape of a set of data.


### PR DESCRIPTION
The fix is not to emit metric samples when a VU's context is canceled. This should fix https://github.com/loadimpact/k6/issues/708, but it still needs unit tests and more checks in general. For example, are there some metrics we actually want to emit even from VUs that are canceled?