### PR TITLE
Fix a bug with --no-color and wrap Go's std logger with logrus

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ package cmd
 import (
 	"fmt"
 	"io"
+	golog "log"
 	"os"
 	"path/filepath"
 	"sync"
@@ -74,8 +75,9 @@ var RootCmd = &cobra.Command{
 		setupLoggers(logFmt)
 		if noColor {
 			stdout.Writer = colorable.NewNonColorable(os.Stdout)
-			stdout.Writer = colorable.NewNonColorable(os.Stderr)
+			stderr.Writer = colorable.NewNonColorable(os.Stderr)
 		}
+		golog.SetOutput(log.StandardLogger().Writer())
 	},
 }
 

--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -10,4 +10,5 @@ Description of feature.
 
 ## Bugs fixed!
 
-* Category: description of bug. (#PR)
+* Logging: using the `--no-color` flag caused k6 to print output intended for `sdtout` to `stderr` instead. (#712)
+* Logging: some error messages originating from Go's standard library did not obey the `--logformat` option. (#712)


### PR DESCRIPTION
As noted in https://github.com/loadimpact/k6/issues/711, for some reason Go's standard library sometimes logs errors and warnings instead of returning them... But since we exclusively use [`github.com/sirupsen/logrus`](https://github.com/sirupsen/logrus) for logging in k6, those messages looked very different and didn't obey the `--logformat` configuration...

While fixing this, I noticed the (probably copy-paste) error `stdout.Writer = colorable.NewNonColorable(os.Stderr)` and fixed that as well :sweat_smile: