### PR TITLE
Improve options exporting in HAR conversion and to JS runtime

### DIFF
--- a/cmd/convert_test.go
+++ b/cmd/convert_test.go
@@ -95,7 +95,7 @@ import http from 'k6/http';
 // Creator: WebInspector
 
 export let options = {
-    "maxRedirects": 0
+    maxRedirects: 0,
 };
 
 export default function() {

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -138,11 +138,12 @@ func getOptions(flags *pflag.FlagSet) (lib.Options, error) {
 	if err != nil {
 		return opts, err
 	}
-	if summaryTimeUnit != "" && summaryTimeUnit != "s" && summaryTimeUnit != "ms" && summaryTimeUnit != "us" {
-		return opts, errors.New("invalid summary time unit. Use: 's', 'ms' or 'us'")
+	if summaryTimeUnit != "" {
+		if summaryTimeUnit != "s" && summaryTimeUnit != "ms" && summaryTimeUnit != "us" {
+			return opts, errors.New("invalid summary time unit. Use: 's', 'ms' or 'us'")
+		}
+		opts.SummaryTimeUnit = null.StringFrom(summaryTimeUnit)
 	}
-
-	opts.SummaryTimeUnit = null.StringFrom(summaryTimeUnit)
 
 	systemTagList, err := flags.GetStringSlice("system-tags")
 	if err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -141,7 +141,7 @@ a commandline interface for interacting with it.`,
 
 		// If -m/--max isn't specified, figure out the max that should be needed.
 		if !conf.VUsMax.Valid {
-			conf.VUsMax = null.IntFrom(conf.VUs.Int64)
+			conf.VUsMax = null.NewInt(conf.VUs.Int64, conf.VUs.Valid)
 			for _, stage := range conf.Stages {
 				if stage.Target.Valid && stage.Target.Int64 > conf.VUsMax.Int64 {
 					conf.VUsMax = stage.Target

--- a/cmd/testdata/example.js
+++ b/cmd/testdata/example.js
@@ -5,7 +5,7 @@ import http from 'k6/http';
 // Creator: BrowserMob Proxy
 
 export let options = {
-    "maxRedirects": 0
+    maxRedirects: 0,
 };
 
 export default function() {

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -198,8 +198,8 @@ func (b *Bundle) MakeArchive() *lib.Archive {
 	return arc
 }
 
-// Instantiates a new runtime from this bundle.
-func (b *Bundle) Instantiate() (*BundleInstance, error) {
+// Instantiate creates a new runtime from this bundle.
+func (b *Bundle) Instantiate() (bi *BundleInstance, instErr error) {
 	// Placeholder for a real context.
 	ctxPtr := new(context.Context)
 
@@ -226,14 +226,16 @@ func (b *Bundle) Instantiate() (*BundleInstance, error) {
 		jsOptionsObj = jsOptions.ToObject(rt)
 	}
 	b.Options.ForEachValid("json", func(key string, val interface{}) {
-		jsOptionsObj.Set(key, val)
+		if err := jsOptionsObj.Set(key, val); err != nil {
+			instErr = err
+		}
 	})
 
 	return &BundleInstance{
 		Runtime: rt,
 		Context: ctxPtr,
 		Default: def,
-	}, nil
+	}, instErr
 }
 
 // Instantiates the bundle into an existing runtime. Not public because it also messes with a bunch

--- a/js/runner.go
+++ b/js/runner.go
@@ -176,7 +176,6 @@ func (r *Runner) newVU(samplesOut chan<- stats.SampleContainer) (*VU, error) {
 		Samples:        samplesOut,
 	}
 	vu.Runtime.Set("console", common.Bind(vu.Runtime, vu.Console, vu.Context))
-	vu.Runtime.Set("options", r.GetOptions())
 	common.BindToGlobal(vu.Runtime, map[string]interface{}{
 		"open": func() {
 			common.Throw(vu.Runtime, errors.New("\"open\" function is only available to the init code (aka global scope), see https://docs.k6.io/docs/test-life-cycle for more information"))

--- a/lib/options.go
+++ b/lib/options.go
@@ -21,10 +21,11 @@
 package lib
 
 import (
-	"bytes"
 	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	"net"
+	"reflect"
 
 	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/stats"
@@ -187,80 +188,80 @@ type Options struct {
 
 	// Initial values for VUs, max VUs, duration cap, iteration cap, and stages.
 	// See the Runner or Executor interfaces for more information.
-	VUs        null.Int           `json:"vus" envconfig:"vus" js:"vus"`
-	VUsMax     null.Int           `json:"vusMax" envconfig:"vus_max" js:"vusMax"`
-	Duration   types.NullDuration `json:"duration" envconfig:"duration" js:"duration"`
-	Iterations null.Int           `json:"iterations" envconfig:"iterations" js:"iterations"`
-	Stages     []Stage            `json:"stages" envconfig:"stages" js:"stages"`
+	VUs        null.Int           `json:"vus" envconfig:"vus"`
+	VUsMax     null.Int           `json:"vusMax" envconfig:"vus_max"`
+	Duration   types.NullDuration `json:"duration" envconfig:"duration"`
+	Iterations null.Int           `json:"iterations" envconfig:"iterations"`
+	Stages     []Stage            `json:"stages" envconfig:"stages"`
 
 	// Timeouts for the setup() and teardown() functions
-	SetupTimeout    types.NullDuration `json:"setupTimeout" envconfig:"setup_timeout" js:"setupTimeout"`
-	TeardownTimeout types.NullDuration `json:"teardownTimeout" envconfig:"teardown_timeout" js:"teardownTimeout"`
+	SetupTimeout    types.NullDuration `json:"setupTimeout" envconfig:"setup_timeout"`
+	TeardownTimeout types.NullDuration `json:"teardownTimeout" envconfig:"teardown_timeout"`
 
 	// Limit HTTP requests per second.
-	RPS null.Int `json:"rps" envconfig:"rps" js:"rps"`
+	RPS null.Int `json:"rps" envconfig:"rps"`
 
 	// How many HTTP redirects do we follow?
-	MaxRedirects null.Int `json:"maxRedirects" envconfig:"max_redirects" js:"maxRedirects"`
+	MaxRedirects null.Int `json:"maxRedirects" envconfig:"max_redirects"`
 
 	// Default User Agent string for HTTP requests.
-	UserAgent null.String `json:"userAgent" envconfig:"user_agent" js:"userAgent"`
+	UserAgent null.String `json:"userAgent" envconfig:"user_agent"`
 
 	// How many batch requests are allowed in parallel, in total and per host?
-	Batch        null.Int `json:"batch" envconfig:"batch" js:"batch"`
-	BatchPerHost null.Int `json:"batchPerHost" envconfig:"batch_per_host" js:"batchPerHost"`
+	Batch        null.Int `json:"batch" envconfig:"batch"`
+	BatchPerHost null.Int `json:"batchPerHost" envconfig:"batch_per_host"`
 
 	// Should all HTTP requests and responses be logged (excluding body)?
-	HttpDebug null.String `json:"httpDebug" envconfig:"http_debug" js:"httpDebug"`
+	HttpDebug null.String `json:"httpDebug" envconfig:"http_debug"`
 
 	// Accept invalid or untrusted TLS certificates.
-	InsecureSkipTLSVerify null.Bool `json:"insecureSkipTLSVerify" envconfig:"insecure_skip_tls_verify" js:"insecureSkipTLSVerify"`
+	InsecureSkipTLSVerify null.Bool `json:"insecureSkipTLSVerify" envconfig:"insecure_skip_tls_verify"`
 
 	// Specify TLS versions and cipher suites, and present client certificates.
-	TLSCipherSuites *TLSCipherSuites `json:"tlsCipherSuites" envconfig:"tls_cipher_suites" js:"tlsCipherSuites"`
-	TLSVersion      *TLSVersions     `json:"tlsVersion" envconfig:"tls_version" js:"tlsVersion"`
-	TLSAuth         []*TLSAuth       `json:"tlsAuth" envconfig:"tlsauth" js:"tlsAuth"`
+	TLSCipherSuites *TLSCipherSuites `json:"tlsCipherSuites" envconfig:"tls_cipher_suites"`
+	TLSVersion      *TLSVersions     `json:"tlsVersion" envconfig:"tls_version"`
+	TLSAuth         []*TLSAuth       `json:"tlsAuth" envconfig:"tlsauth"`
 
 	// Throw warnings (eg. failed HTTP requests) as errors instead of simply logging them.
-	Throw null.Bool `json:"throw" envconfig:"throw" js:"throw"`
+	Throw null.Bool `json:"throw" envconfig:"throw"`
 
 	// Define thresholds; these take the form of 'metric=["snippet1", "snippet2"]'.
 	// To create a threshold on a derived metric based on tag queries ("submetrics"), create a
 	// metric on a nonexistent metric named 'real_metric{tagA:valueA,tagB:valueB}'.
-	Thresholds map[string]stats.Thresholds `json:"thresholds" envconfig:"thresholds" js:"thresholds"`
+	Thresholds map[string]stats.Thresholds `json:"thresholds" envconfig:"thresholds"`
 
 	// Blacklist IP ranges that tests may not contact. Mainly useful in hosted setups.
-	BlacklistIPs []*net.IPNet `json:"blacklistIPs" envconfig:"blacklist_ips" js:"blacklistIPs"`
+	BlacklistIPs []*net.IPNet `json:"blacklistIPs" envconfig:"blacklist_ips"`
 
 	// Hosts overrides dns entries for given hosts
-	Hosts map[string]net.IP `json:"hosts" envconfig:"hosts" js:"hosts"`
+	Hosts map[string]net.IP `json:"hosts" envconfig:"hosts"`
 
 	// Disable keep-alive connections
-	NoConnectionReuse null.Bool `json:"noConnectionReuse" envconfig:"no_connection_reuse" js:"noConnectionReuse"`
+	NoConnectionReuse null.Bool `json:"noConnectionReuse" envconfig:"no_connection_reuse"`
 
 	// Do not reuse connections between VU iterations. This gives more realistic results (depending
 	// on what you're looking for), but you need to raise various kernel limits or you'll get
 	// errors about running out of file handles or sockets, or being unable to bind addresses.
-	NoVUConnectionReuse null.Bool `json:"noVUConnectionReuse" envconfig:"no_vu_connection_reuse" js:"noVUConnectionReuse"`
+	NoVUConnectionReuse null.Bool `json:"noVUConnectionReuse" envconfig:"no_vu_connection_reuse"`
 
 	// These values are for third party collectors' benefit.
 	// Can't be set through env vars.
-	External map[string]json.RawMessage `json:"ext" ignored:"true" js:"ext"`
+	External map[string]json.RawMessage `json:"ext" ignored:"true"`
 
 	// Summary trend stats for trend metrics (response times) in CLI output
-	SummaryTrendStats []string `json:"summaryTrendStats" envconfig:"summary_trend_stats" js:"summaryTrendStats"`
+	SummaryTrendStats []string `json:"summaryTrendStats" envconfig:"summary_trend_stats"`
 
 	// Summary time unit for summary metrics (response times) in CLI output
-	SummaryTimeUnit null.String `json:"summaryTimeUnit" envconfig:"summary_time_unit" js:"summaryTimeUnit"`
+	SummaryTimeUnit null.String `json:"summaryTimeUnit" envconfig:"summary_time_unit"`
 
 	// Which system tags to include with metrics ("method", "vu" etc.)
-	SystemTags TagSet `json:"systemTags" envconfig:"system_tags" js:"systemTags"`
+	SystemTags TagSet `json:"systemTags" envconfig:"system_tags"`
 
 	// Tags to be applied to all samples for this running
-	RunTags *stats.SampleTags `json:"tags" envconfig:"tags" js:"tags"`
+	RunTags *stats.SampleTags `json:"tags" envconfig:"tags"`
 
 	// Buffer size of the channel for metric samples; 0 means unbuffered
-	MetricSamplesBufferSize null.Int `json:"metricSamplesBufferSize" envconfig:"metric_samples_buffer_size" js:"metricSamplesBufferSize"`
+	MetricSamplesBufferSize null.Int `json:"metricSamplesBufferSize" envconfig:"metric_samples_buffer_size"`
 }
 
 // Returns the result of overwriting any fields with any that are set on the argument.
@@ -367,29 +368,37 @@ func (o Options) Apply(opts Options) Options {
 	return o
 }
 
-// GetPrettyJSON is a massive hack that works around the fact that some
-// of the null-able types used in Options are marshalled to `null` when
-// their `valid` flag is false.
-// TODO: figure out something better or at least use reflect to do it, that
-// way field order could be preserved, we could optionally emit JS objects
-// (without mandatory quoted keys)` and we won't needlessly marshal and
-// unmarshal things...
-func (o Options) GetPrettyJSON(prefix, indent string) ([]byte, error) {
-	nullyResult, err := json.MarshalIndent(o, prefix, indent)
-	if err != nil {
-		return nil, err
-	}
+// ForEachValid enumerates all struct fields and calls the supplied function with each
+// element that is valid. It panics for any unfamiliar or unexpected fields, so make sure
+// new fields in Options are accounted for.
+func (o Options) ForEachValid(structTag string, callback func(key string, value interface{})) {
+	structType := reflect.TypeOf(o)
+	structVal := reflect.ValueOf(o)
+	for i := 0; i < structType.NumField(); i++ {
+		fieldType := structType.Field(i)
+		fieldVal := structVal.Field(i)
 
-	var tmpMap map[string]json.RawMessage
-	if err := json.Unmarshal(nullyResult, &tmpMap); err != nil {
-		return nil, err
-	}
+		shouldCall := false
+		switch fieldType.Type.Kind() {
+		case reflect.Struct:
+			shouldCall = fieldVal.FieldByName("Valid").Bool()
+		case reflect.Slice:
+			shouldCall = fieldVal.Len() > 0
+		case reflect.Map:
+			shouldCall = fieldVal.Len() > 0
+		case reflect.Ptr:
+			shouldCall = !fieldVal.IsNil()
+		default:
+			panic(fmt.Sprintf("Unknown Options field %#v", fieldType))
+		}
 
-	null := []byte("null")
-	for k, v := range tmpMap {
-		if bytes.Equal(v, null) {
-			delete(tmpMap, k)
+		if shouldCall {
+			key, ok := fieldType.Tag.Lookup(structTag)
+			if !ok {
+				key = fieldType.Name
+			}
+
+			callback(key, fieldVal.Interface())
 		}
 	}
-	return json.MarshalIndent(tmpMap, prefix, indent)
 }

--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -8,6 +8,10 @@ Description of feature.
 
 **Docs**: [Title](http://k6.readme.io/docs/TODO)
 
+## UX
+
+* The consolidated user-supplied options (the final combination of config file options, exported script `options`, environment variables and command-line flags) are now exported back into the `options` script variable and can be accessed from the script. Thanks to @mohanprasaths for working on this! (#681 and #713)
+
 ## Bugs fixed!
 
 * Category: description of bug. (#PR)


### PR DESCRIPTION
After merging https://github.com/loadimpact/k6/pull/681, I realized that my advice to @mohanprasaths there to use something like `rt.Set("options", runner.GetOptions())` probably wasn't the best idea... The main reason for that was very similar to the reason I recently had to do [this hack](https://github.com/loadimpact/k6/pull/694/files#diff-2a3d79a0a11711742c3804c5e3846597R373) in for the options injection in the HAR file conversion. Basically, directly exporting the null-able types in `lib.Options` to JSON produces a lot of `null` and empty array/object values. Another slight drawback is that if a user adds their own non-k6 keys in the `options` object, they would have been overwritten and lost.

This PR adds a new method to `lib.Options` that allows us to flexibly traverse the `lib.Options` fields that are set. This improves both the HAR export format (it now uses unquoted JS keys) and the options propagation back to the JS runtime (no extra nulls and non-k6 user-defined options there won't be overwritten).

It's still not perfect... The current output of simply running script like this without any extra parameters:
```js
export let options = {
	myOption: "test"
};

export default function (data) {
	console.log(JSON.stringify(options));
}
```

would be something like this:
```
{"myOption":"test","iterations":1,"tlsVersion":{"min":"","max":""},"systemTags":["proto","method","group","error","subproto","status","url","name","check","tls_version"]}
```
 `iterations` and `myOption` are fine, `tlsVersion` appears due to [this bug](https://github.com/kelseyhightower/envconfig/issues/113) and `systemTags` is included due to a limitation in the way we (don't) track and handle complex default values...

Also, both this and in the [original fix](https://github.com/loadimpact/k6/pull/681) for https://github.com/loadimpact/k6/issues/613 won't properly work when executing the script in the cloud (especially when there are multiple k6 instances), but fixing that would probably have to wait until we have proper cluster execution in k6 itself...

