### PR TITLE
Prevent the JSON collector from closing stdout

### DIFF
--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -12,3 +12,4 @@ Description of feature.
 
 * Logging: using the `--no-color` flag caused k6 to print output intended for `sdtout` to `stderr` instead. (#712)
 * Logging: some error messages originating from Go's standard library did not obey the `--logformat` option. (#712)
+* JSON output: when the standard output was used, the JSON collector closed it before k6 was finished printing the end-of-test summary to it (#715)

--- a/stats/json/collector.go
+++ b/stats/json/collector.go
@@ -41,6 +41,13 @@ type Collector struct {
 // Verify that Collector implements lib.Collector
 var _ lib.Collector = &Collector{}
 
+// Similar to ioutil.NopCloser, but for writers
+type nopCloser struct {
+	io.Writer
+}
+
+func (nopCloser) Close() error { return nil }
+
 func (c *Collector) HasSeenMetric(str string) bool {
 	for _, n := range c.seenMetrics {
 		if n == str {
@@ -53,7 +60,7 @@ func (c *Collector) HasSeenMetric(str string) bool {
 func New(fs afero.Fs, fname string) (*Collector, error) {
 	if fname == "" || fname == "-" {
 		return &Collector{
-			outfile: os.Stdout,
+			outfile: nopCloser{os.Stdout},
 			fname:   "-",
 		}, nil
 	}


### PR DESCRIPTION
This fixes https://github.com/loadimpact/k6/issues/714... `errcheck` [for the win](https://github.com/loadimpact/k6/pull/692), this has probably been silently buggy for a long long time...