### PR TITLE
Fix the creation of an options map in the runtime when setting options

### DIFF
--- a/js/bundle.go
+++ b/js/bundle.go
@@ -220,8 +220,9 @@ func (b *Bundle) Instantiate() (bi *BundleInstance, instErr error) {
 
 	jsOptions := rt.Get("options")
 	var jsOptionsObj *goja.Object
-	if jsOptions == nil {
+	if jsOptions == nil || goja.IsNull(jsOptions) || goja.IsUndefined(jsOptions) {
 		jsOptionsObj = rt.NewObject()
+		rt.Set("options", jsOptionsObj)
 	} else {
 		jsOptionsObj = jsOptions.ToObject(rt)
 	}


### PR DESCRIPTION
This should fix the panic from and close https://github.com/loadimpact/k6/issues/720