### PR TITLE
Config fixes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,7 +3,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4311a599af4d1d002593505731fd92b46bec2809aa5be0b486f2d0beb3f5da86"
+  digest = "1:7d8fe22a434ddfb29d95e10a0231eb2d96100b9eaaf7bff7312eee7df7a34bfa"
   name = "github.com/GeertJohan/go.rice"
   packages = [
     ".",
@@ -38,7 +38,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:959fa1e95b8a8b28e22071a7af5e3eade3e4fcf5c682ef257b443cf14168b8b2"
+  digest = "1:69dabd9ff5154eba205b9c049a1716b4ce0e6d7da55e3d1a96fa1da2a3540158"
   name = "github.com/ThomsonReutersEikon/go-ntlm"
   packages = [
     "ntlm",
@@ -84,7 +84,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ae5067125af1b735941a3abf4d055dc072ff4825a0606d85383dc7ddb97767d0"
+  digest = "1:9af09d68bd80a20b3fae068ab7c6476c9b53a145963b57df6d508180aabae7b9"
   name = "github.com/dop251/goja"
   packages = [
     ".",
@@ -161,7 +161,7 @@
   revision = "22d885f9ecc78bf4ee5d72b937e4bbcdc58e8cae"
 
 [[projects]]
-  digest = "1:9ab37684216559c96004c817c212154f514feef7755093414ee7fbc6881dca8f"
+  digest = "1:10095a140b7829bcf199c8447725c0b1b9874a527b3d73cb2fc9ffc4a5fe8178"
   name = "github.com/gin-gonic/gin"
   packages = [
     ".",
@@ -173,7 +173,7 @@
   version = "v1.2"
 
 [[projects]]
-  digest = "1:e7ea8ffe5d3fffce277bdd05b9956aa567ceb8f6b28bd7516b54a78a8b4ee13f"
+  digest = "1:7d5c6757be75cd60d5936e26b2894c16bbb555bd8dad4724b0fa19efb3a6f78b"
   name = "github.com/go-sourcemap/sourcemap"
   packages = [
     ".",
@@ -232,7 +232,7 @@
   version = "v1.0"
 
 [[projects]]
-  digest = "1:613e96a9d28627ab67a7dc1edeffb63a53df8512882d347ad104dad2afe50461"
+  digest = "1:32b1db7dd0c6cee1e65ab3841b7f8d8a9f0a6d97f85229137efee95a0dfcfddd"
   name = "github.com/influxdata/influxdb"
   packages = [
     "client/v2",
@@ -268,7 +268,7 @@
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:8e06d4e0c6f1327dff8efc263812aff62a95f4b72dce24a1b3f688a94fbe7c76"
+  digest = "1:2578ea84d8555a62f49e5f750848ec5d3bad2e5ba9e3977186e407c7501d3b95"
   name = "github.com/kubernetes/helm"
   packages = ["pkg/strvals"]
   pruneopts = "NUT"
@@ -284,7 +284,7 @@
   version = "3.2.6"
 
 [[projects]]
-  digest = "1:442eda44a7dd2637db80d34b6132e6901487dd2f72c77d6cb9c9d2e711a94518"
+  digest = "1:3e5716c10e24021c0c44dd1e3043b6d23a83cd143f8225281fba1b4d0143e4b7"
   name = "github.com/labstack/gommon"
   packages = [
     "color",
@@ -296,7 +296,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:d0f36a7fa3aa5d4932c7ddd9535334b95c35770626c131da5ee6611fe91fea12"
+  digest = "1:afbe9705722abb0d54d4ee48404ef173ba0cfd04fb0c4a76f927e8a68bfaea8a"
   name = "github.com/manyminds/api2go"
   packages = [
     ".",
@@ -324,7 +324,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:518f43f2e2a44dcc572c834208a408e12e3c31c8d56c7fdb0b27ca127de1dfd8"
+  digest = "1:a74203e799dbd148a873dc57fc2ef086b3a2c79d1390ab8a693992b1b25dadd7"
   name = "github.com/mccutchen/go-httpbin"
   packages = [
     "httpbin",
@@ -416,7 +416,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c33813a8c5cfa48c41c7b446cc1fadd1291f1a5dede939aea0983479b1a48f54"
+  digest = "1:f9e30881a5a427fe87c58273f511fb6a10ee2c8ea55d409d7256ede192f7f4b7"
   name = "github.com/sirupsen/logrus"
   packages = [
     ".",
@@ -427,7 +427,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a36d61943d51cd4a1d7ecaf6993190527535a57382114ebf6549956b3e4cb612"
+  digest = "1:330e9062b308ac597e28485699c02223bd052437a6eed32a173c9227dcb9d95a"
   name = "github.com/spf13/afero"
   packages = [
     ".",
@@ -438,7 +438,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:47a4d5abe130024f15fc43f8395aaeeebc4eb1e1310c79b59770ed59d856d50e"
+  digest = "1:234b95cdbb31612ff4f97e0ac69abdede0c60f5f84e5d3f40123859f77d8bc2c"
   name = "github.com/spf13/cobra"
   packages = ["."]
   pruneopts = "NT"
@@ -453,7 +453,7 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:1b70b055ad90a0471dff7f92a31a0b85a970f513f7ff5c9e0536aec9e5ee30be"
+  digest = "1:0d3d375df794ab11a192668f4eacdb116ccd99aa574fe357185a2d463e07f2fb"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
@@ -521,7 +521,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7634e83afe58d30c5a8468405daf3904619e740dc0a2a3f4ea9a7b7bfbb8913d"
+  digest = "1:5710f443edd59a8b20c6786b23b3fc873ff9267ec050dd520ec2416db884b3fe"
   name = "golang.org/x/crypto"
   packages = [
     "acme",
@@ -536,7 +536,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:44794dfe91ede43417d2355565cd67cdf81ea0820d4c510c9ea4e1d938597d75"
+  digest = "1:3d87ae21dd01efa1a49fdc98479b49eb59dc6d57f480e3968cf2c36de07d745e"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -552,7 +552,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7bd8da6d1b5bb6d9a0ad7be56ac677f50ca469171dc74c65609a61b7b067858f"
+  digest = "1:b1a955501003b967a2c814e41ded50c7b29dfdeb7f266b7987b8ed38f65205d6"
   name = "golang.org/x/sys"
   packages = [
     "unix",
@@ -562,7 +562,7 @@
   revision = "c28acc882ebcbfbe8ce9f0f14b9ac26ee138dd51"
 
 [[projects]]
-  digest = "1:ea70ecfb936e4ca93523ebf61f74c2d5a777b954fb11e28554ef2cb5b1ebf53d"
+  digest = "1:0a6ace3c8a521f2c8861e89b8a22fc869c831e9bf6ad21fc62eb59afa16a8bff"
   name = "golang.org/x/text"
   packages = [
     "cases",
@@ -662,6 +662,7 @@
     "golang.org/x/crypto/md4",
     "golang.org/x/crypto/ocsp",
     "golang.org/x/crypto/ripemd160",
+    "golang.org/x/crypto/ssh/terminal",
     "golang.org/x/net/html",
     "golang.org/x/net/http2",
     "golang.org/x/text/unicode/norm",

--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -61,26 +61,17 @@ An archive is a fully self-contained test run, and can be executed identically e
 			return err
 		}
 
-		r, err := newRunner(src, runType, afero.NewOsFs(), runtimeOptions)
+		r, err := newRunner(src, runType, fs, runtimeOptions)
 		if err != nil {
 			return err
 		}
 
-		// Options.
-		cliOpts, err := getOptions(cmd.Flags())
+		conf, err := getConsolidatedConfig(fs, cmd.Flags(), r)
 		if err != nil {
 			return err
 		}
-		fileConf, _, err := readDiskConfig(fs)
-		if err != nil {
-			return err
-		}
-		envConf, err := readEnvConfig()
-		if err != nil {
-			return err
-		}
-		opts := cliOpts.Apply(fileConf.Options).Apply(r.GetOptions()).Apply(envConf.Options).Apply(cliOpts)
-		r.SetOptions(opts)
+
+		r.SetOptions(conf.Options)
 
 		// Archive.
 		arc := r.MakeArchive()

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/stats/cloud"
 	"github.com/loadimpact/k6/stats/influxdb"
 	"github.com/loadimpact/k6/stats/kafka"
@@ -154,4 +155,55 @@ func writeDiskConfig(fs afero.Fs, cdir *configdir.Config, conf Config) error {
 func readEnvConfig() (conf Config, err error) {
 	err = envconfig.Process("k6", &conf)
 	return conf, err
+}
+
+// Assemble the final consolidated configuration from all of the different sources:
+// - start with the CLI-provided options to get shadowed (non-Valid) defaults in there
+// - add the global file config options
+// - if supplied, add the Runner-provided options
+// - add the environment variables
+// - merge the user-supplied CLI flags back in on top, to give them the greatest priority
+// - set some defaults if they weren't previously specified
+// TODO: add better validation, improve consistency between formats
+func getConsolidatedConfig(fs afero.Fs, flags *pflag.FlagSet, runner lib.Runner) (conf Config, err error) {
+	cliConf, err := getConfig(flags)
+	if err != nil {
+		return conf, err
+	}
+	fileConf, _, err := readDiskConfig(fs)
+	if err != nil {
+		return conf, err
+	}
+	envConf, err := readEnvConfig()
+	if err != nil {
+		return conf, err
+	}
+
+	conf = cliConf.Apply(fileConf)
+	if runner != nil {
+		conf = conf.Apply(Config{Options: runner.GetOptions()})
+	}
+	conf = conf.Apply(envConf).Apply(cliConf)
+
+	// If -m/--max isn't specified, figure out the max that should be needed.
+	if !conf.VUsMax.Valid {
+		conf.VUsMax = null.NewInt(conf.VUs.Int64, conf.VUs.Valid)
+		for _, stage := range conf.Stages {
+			if stage.Target.Valid && stage.Target.Int64 > conf.VUsMax.Int64 {
+				conf.VUsMax = stage.Target
+			}
+		}
+	}
+
+	// If -d/--duration, -i/--iterations and -s/--stage are all unset, run to one iteration.
+	if !conf.Duration.Valid && !conf.Iterations.Valid && conf.Stages == nil {
+		conf.Iterations = null.IntFrom(1)
+	}
+
+	// If duration is explicitly set to 0, it means run forever.
+	if conf.Duration.Valid && conf.Duration.Duration == 0 {
+		conf.Duration = types.NullDuration{}
+	}
+
+	return conf, nil
 }

--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -52,7 +52,7 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fs := afero.NewOsFs()
 
-		k6Conf, err := getConsolidatedConfig(fs, cmd.Flags(), nil)
+		k6Conf, err := getConsolidatedConfig(fs, nil, nil)
 		if err != nil {
 			return err
 		}
@@ -82,7 +82,7 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 						Key:   "Email",
 						Label: "Email",
 					},
-					ui.StringField{
+					ui.PasswordField{
 						Key:   "Password",
 						Label: "Password",
 					},

--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -51,7 +51,13 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fs := afero.NewOsFs()
-		config, cdir, err := readDiskConfig(fs)
+
+		k6Conf, err := getConsolidatedConfig(fs, cmd.Flags(), nil)
+		if err != nil {
+			return err
+		}
+
+		currentDiskConf, cdir, err := readDiskConfig(fs)
 		if err != nil {
 			return err
 		}
@@ -60,15 +66,15 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 		reset := getNullBool(cmd.Flags(), "reset")
 		token := getNullString(cmd.Flags(), "token")
 
-		conf := cloud.NewConfig().Apply(config.Collectors.Cloud)
+		newCloudConf := cloud.NewConfig().Apply(currentDiskConf.Collectors.Cloud)
 
 		switch {
 		case reset.Valid:
-			conf.Token = null.StringFromPtr(nil)
+			newCloudConf.Token = null.StringFromPtr(nil)
 			fprintf(stdout, "  token reset\n")
 		case show.Bool:
 		case token.Valid:
-			conf.Token = token
+			newCloudConf.Token = token
 		default:
 			form := ui.Form{
 				Fields: []ui.Field{
@@ -89,7 +95,7 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 			email := vals["Email"].(string)
 			password := vals["Password"].(string)
 
-			client := cloud.NewClient("", conf.Host.String, Version)
+			client := cloud.NewClient("", k6Conf.Collectors.Cloud.Host.String, Version)
 			res, err := client.Login(email, password)
 			if err != nil {
 				return err
@@ -99,16 +105,16 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 				return errors.New(`Your account has no API token, please generate one: "https://app.loadimpact.com/account/token".`)
 			}
 
-			conf.Token = null.StringFrom(res.Token)
+			newCloudConf.Token = null.StringFrom(res.Token)
 		}
 
-		config.Collectors.Cloud = conf
-		if err := writeDiskConfig(fs, cdir, config); err != nil {
+		currentDiskConf.Collectors.Cloud = newCloudConf
+		if err := writeDiskConfig(fs, cdir, currentDiskConf); err != nil {
 			return err
 		}
 
-		if conf.Token.Valid {
-			fprintf(stdout, "  token: %s\n", ui.ValueColor.Sprint(conf.Token.String))
+		if newCloudConf.Token.Valid {
+			fprintf(stdout, "  token: %s\n", ui.ValueColor.Sprint(newCloudConf.Token.String))
 		}
 		return nil
 	},

--- a/cmd/login_influxdb.go
+++ b/cmd/login_influxdb.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/stats/influxdb"
 	"github.com/loadimpact/k6/ui"
 	"github.com/mitchellh/mapstructure"
@@ -72,10 +73,9 @@ This will set the default server used when just "-o influxdb" is passed.`,
 					Label:   "Username",
 					Default: conf.Username.String,
 				},
-				ui.StringField{
-					Key:     "Password",
-					Label:   "Password",
-					Default: conf.Password.String,
+				ui.PasswordField{
+					Key:   "Password",
+					Label: "Password",
 				},
 			},
 		}
@@ -83,7 +83,16 @@ This will set the default server used when just "-o influxdb" is passed.`,
 		if err != nil {
 			return err
 		}
-		if err := mapstructure.Decode(vals, &conf); err != nil {
+
+		dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+			DecodeHook: types.NullDecoder,
+			Result:     &conf,
+		})
+		if err != nil {
+			return err
+		}
+
+		if err := dec.Decode(vals); err != nil {
 			return err
 		}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -42,14 +42,12 @@ import (
 	"github.com/loadimpact/k6/core/local"
 	"github.com/loadimpact/k6/js"
 	"github.com/loadimpact/k6/lib"
-	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/loader"
 	"github.com/loadimpact/k6/ui"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	null "gopkg.in/guregu/null.v3"
 )
 
 const (
@@ -116,46 +114,18 @@ a commandline interface for interacting with it.`,
 			return err
 		}
 
-		r, err := newRunner(src, runType, afero.NewOsFs(), runtimeOptions)
+		r, err := newRunner(src, runType, fs, runtimeOptions)
 		if err != nil {
 			return err
 		}
 
-		// Assemble options; start with the CLI-provided options to get shadowed (non-Valid)
-		// defaults in there, override with Runner-provided ones, then merge the CLI opts in
-		// on top to give them priority.
 		fprintf(stdout, "%s options\r", initBar.String())
-		cliConf, err := getConfig(cmd.Flags())
-		if err != nil {
-			return err
-		}
-		fileConf, _, err := readDiskConfig(fs)
-		if err != nil {
-			return err
-		}
-		envConf, err := readEnvConfig()
-		if err != nil {
-			return err
-		}
-		conf := cliConf.Apply(fileConf).Apply(Config{Options: r.GetOptions()}).Apply(envConf).Apply(cliConf)
 
-		// If -m/--max isn't specified, figure out the max that should be needed.
-		if !conf.VUsMax.Valid {
-			conf.VUsMax = null.NewInt(conf.VUs.Int64, conf.VUs.Valid)
-			for _, stage := range conf.Stages {
-				if stage.Target.Valid && stage.Target.Int64 > conf.VUsMax.Int64 {
-					conf.VUsMax = stage.Target
-				}
-			}
+		conf, err := getConsolidatedConfig(fs, cmd.Flags(), r)
+		if err != nil {
+			return err
 		}
-		// If -d/--duration, -i/--iterations and -s/--stage are all unset, run to one iteration.
-		if !conf.Duration.Valid && !conf.Iterations.Valid && conf.Stages == nil {
-			conf.Iterations = null.IntFrom(1)
-		}
-		// If duration is explicitly set to 0, it means run forever.
-		if conf.Duration.Valid && conf.Duration.Duration == 0 {
-			conf.Duration = types.NullDuration{}
-		}
+
 		// If summary trend stats are defined, update the UI to reflect them
 		if len(conf.SummaryTrendStats) > 0 {
 			ui.UpdateTrendColumns(conf.SummaryTrendStats)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -42,12 +42,14 @@ import (
 	"github.com/loadimpact/k6/core/local"
 	"github.com/loadimpact/k6/js"
 	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/loader"
 	"github.com/loadimpact/k6/ui"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	null "gopkg.in/guregu/null.v3"
 )
 
 const (
@@ -124,6 +126,26 @@ a commandline interface for interacting with it.`,
 		conf, err := getConsolidatedConfig(fs, cmd.Flags(), r)
 		if err != nil {
 			return err
+		}
+
+		// If -m/--max isn't specified, figure out the max that should be needed.
+		if !conf.VUsMax.Valid {
+			conf.VUsMax = null.NewInt(conf.VUs.Int64, conf.VUs.Valid)
+			for _, stage := range conf.Stages {
+				if stage.Target.Valid && stage.Target.Int64 > conf.VUsMax.Int64 {
+					conf.VUsMax = stage.Target
+				}
+			}
+		}
+
+		// If -d/--duration, -i/--iterations and -s/--stage are all unset, run to one iteration.
+		if !conf.Duration.Valid && !conf.Iterations.Valid && conf.Stages == nil {
+			conf.Iterations = null.IntFrom(1)
+		}
+
+		// If duration is explicitly set to 0, it means run forever.
+		if conf.Duration.Valid && conf.Duration.Duration == 0 {
+			conf.Duration = types.NullDuration{}
 		}
 
 		// If summary trend stats are defined, update the UI to reflect them

--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -11,4 +11,6 @@ Description of feature.
 
 ## Bugs fixed!
 
-* Category: description of bug. (#PR)
+* UI: The interactive `k6 login influxdb` command failed to write the supplied options to the config file. (#734)
+* UI: Password input is now masked in `k6 login influxdb` and `k6 login cloud`. (#734)
+* Config: Environment variables can now be used to modify k6's behavior in the `k6 login` subcommands. (#734)

--- a/ui/form.go
+++ b/ui/form.go
@@ -21,7 +21,6 @@
 package ui
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 
@@ -30,9 +29,10 @@ import (
 
 // A Field in a form.
 type Field interface {
-	GetKey() string        // Key for the data map.
-	GetLabel() string      // Label to print as the prompt.
-	GetLabelExtra() string // Extra info for the label, eg. defaults.
+	GetKey() string                        // Key for the data map.
+	GetLabel() string                      // Label to print as the prompt.
+	GetLabelExtra() string                 // Extra info for the label, eg. defaults.
+	GetContents(io.Reader) (string, error) // Read the field contents from the supplied reader
 
 	// Sanitize user input and return the field's native type.
 	Clean(s string) (interface{}, error)
@@ -44,7 +44,7 @@ type Form struct {
 	Fields []Field
 }
 
-// Runs the form against the specified input and output.
+// Run executes the form against the specified input and output.
 func (f Form) Run(r io.Reader, w io.Writer) (map[string]interface{}, error) {
 	if f.Banner != "" {
 		if _, err := fmt.Fprintln(w, color.BlueString(f.Banner)+"\n"); err != nil {
@@ -52,7 +52,6 @@ func (f Form) Run(r io.Reader, w io.Writer) (map[string]interface{}, error) {
 		}
 	}
 
-	buf := bufio.NewReader(r)
 	data := make(map[string]interface{}, len(f.Fields))
 	for _, field := range f.Fields {
 		for {
@@ -65,7 +64,7 @@ func (f Form) Run(r io.Reader, w io.Writer) (map[string]interface{}, error) {
 			}
 
 			color.Set(color.FgCyan)
-			s, err := buf.ReadString('\n')
+			s, err := field.GetContents(r)
 			color.Unset()
 			if err != nil {
 				return nil, err

--- a/ui/form_fields.go
+++ b/ui/form_fields.go
@@ -21,13 +21,19 @@
 package ui
 
 import (
+	"io"
+	"os"
 	"strings"
 
 	"github.com/pkg/errors"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
+// Verify that the fields implement the interface
 var _ Field = StringField{}
+var _ Field = PasswordField{}
 
+// StringField is just a simple field for reading cleartext strings
 type StringField struct {
 	Key     string
 	Label   string
@@ -37,18 +43,42 @@ type StringField struct {
 	Min, Max int
 }
 
+// GetKey returns the field's key
 func (f StringField) GetKey() string {
 	return f.Key
 }
 
+// GetLabel returns the field's label
 func (f StringField) GetLabel() string {
 	return f.Label
 }
 
+// GetLabelExtra returns the field's default value
 func (f StringField) GetLabelExtra() string {
 	return f.Default
 }
 
+// GetContents simply reads a string in cleartext from the supplied reader
+// It's compllicated and doesn't use t he bufio utils because we can't read ahead
+// of the newline and consume more of the stdin, because we'll mess up the next form field
+func (f StringField) GetContents(r io.Reader) (string, error) {
+	result := make([]byte, 0, 20)
+	buf := make([]byte, 1, 1)
+	for {
+		n, err := io.ReadAtLeast(r, buf, 1)
+		if err != nil {
+			return string(result), err
+		} else if n != 1 {
+			// Shouldn't happen, but just in case
+			return string(result), errors.New("Unexpected input when reading string field")
+		} else if buf[0] == '\n' {
+			return string(result), nil
+		}
+		result = append(result, buf[0])
+	}
+}
+
+// Clean trims the spaces in the string and checks for min and max length
 func (f StringField) Clean(s string) (interface{}, error) {
 	s = strings.TrimSpace(s)
 	if f.Min != 0 && len(s) < f.Min {
@@ -59,6 +89,46 @@ func (f StringField) Clean(s string) (interface{}, error) {
 	}
 	if s == "" {
 		s = f.Default
+	}
+	return s, nil
+}
+
+// PasswordField masks password input
+type PasswordField struct {
+	Key   string
+	Label string
+	Min   int
+}
+
+// GetKey returns the field's key
+func (f PasswordField) GetKey() string {
+	return f.Key
+}
+
+// GetLabel returns the field's label
+func (f PasswordField) GetLabel() string {
+	return f.Label
+}
+
+// GetLabelExtra doesn't return anything so we don't expose the current password
+func (f PasswordField) GetLabelExtra() string {
+	return ""
+}
+
+// GetContents simply reads a string in cleartext from the supplied reader
+func (f PasswordField) GetContents(r io.Reader) (string, error) {
+	stdin, ok := r.(*os.File)
+	if !ok {
+		return "", errors.New("Cannot read password from the supplied terminal")
+	}
+	password, err := terminal.ReadPassword(int(stdin.Fd()))
+	return string(password), err
+}
+
+// Clean just checks if the minimum length is exceeded, it doesn't trim the string!
+func (f PasswordField) Clean(s string) (interface{}, error) {
+	if f.Min != 0 && len(s) < f.Min {
+		return nil, errors.Errorf("invalid input, min length is %d", f.Min)
 	}
 	return s, nil
 }


### PR DESCRIPTION
This should fix #640 and #695 and also fix a another newly found bug where `k6 login influxdb` failed because we forgot to use `types.NullDecoder` for the mapstructure library.

I'm now also more convinced than ever that we need to wholly redesign/refactor/rewrite how we deal with configuration. The current way is super easy to mess up due to human error and it's just plain annoying to work with.