### PR TITLE
Fix the previous config fixes...

### DIFF
--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -66,7 +66,11 @@ An archive is a fully self-contained test run, and can be executed identically e
 			return err
 		}
 
-		conf, err := getConsolidatedConfig(fs, cmd.Flags(), r)
+		cliOpts, err := getOptions(cmd.Flags())
+		if err != nil {
+			return err
+		}
+		conf, err := getConsolidatedConfig(fs, Config{Options: cliOpts}, r)
 		if err != nil {
 			return err
 		}

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -83,7 +83,11 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 			return err
 		}
 
-		conf, err := getConsolidatedConfig(fs, cmd.Flags(), r)
+		cliOpts, err := getOptions(cmd.Flags())
+		if err != nil {
+			return err
+		}
+		conf, err := getConsolidatedConfig(fs, Config{Options: cliOpts}, r)
 		if err != nil {
 			return err
 		}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -173,15 +173,7 @@ func readEnvConfig() (conf Config, err error) {
 // - merge the user-supplied CLI flags back in on top, to give them the greatest priority
 // - set some defaults if they weren't previously specified
 // TODO: add better validation, more explicit default values and improve consistency between formats
-func getConsolidatedConfig(fs afero.Fs, flags *pflag.FlagSet, runner lib.Runner) (conf Config, err error) {
-	cliConf := Config{}
-	if flags != nil {
-		cliConf, err = getConfig(flags)
-		if err != nil {
-			return conf, err
-		}
-	}
-
+func getConsolidatedConfig(fs afero.Fs, cliConf Config, runner lib.Runner) (conf Config, err error) {
 	cliConf.Collectors.InfluxDB = influxdb.NewConfig().Apply(cliConf.Collectors.InfluxDB)
 	cliConf.Collectors.Cloud = cloud.NewConfig().Apply(cliConf.Collectors.Cloud)
 	cliConf.Collectors.Kafka = kafka.NewConfig().Apply(cliConf.Collectors.Kafka)

--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -52,7 +52,7 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fs := afero.NewOsFs()
 
-		k6Conf, err := getConsolidatedConfig(fs, nil, nil)
+		k6Conf, err := getConsolidatedConfig(fs, Config{}, nil)
 		if err != nil {
 			return err
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -123,7 +123,11 @@ a commandline interface for interacting with it.`,
 
 		fprintf(stdout, "%s options\r", initBar.String())
 
-		conf, err := getConsolidatedConfig(fs, cmd.Flags(), r)
+		cliConf, err := getConfig(cmd.Flags())
+		if err != nil {
+			return err
+		}
+		conf, err := getConsolidatedConfig(fs, cliConf, r)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Unfortunately https://github.com/loadimpact/k6/pull/734 introduced bugs in the `k6 cloud` and `k6 archive` commands - different commands have different CLI flags and trying to read improper flags causes k6 to panic. In this case the flag `out` that makes sense for `k6 run`, but not for `cloud` and `archive`. Due to insufficient testing on my part (running only `k6 run something.js`) this slipped by...