### PR TITLE
Fix non zero exit status

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -328,6 +328,8 @@ a commandline interface for interacting with it.`,
 		if quiet || conf.HttpDebug.Valid && conf.HttpDebug.String != "" {
 			ticker.Stop()
 		}
+
+		var engineErr error
 	mainLoop:
 		for {
 			select {
@@ -367,6 +369,7 @@ a commandline interface for interacting with it.`,
 			case err := <-errC:
 				if err != nil {
 					log.WithError(err).Error("Engine error")
+					engineErr = err
 				} else {
 					log.Debug("Engine terminated cleanly")
 				}
@@ -417,6 +420,11 @@ a commandline interface for interacting with it.`,
 		if engine.IsTainted() {
 			return ExitCode{errors.New("some thresholds have failed"), 99}
 		}
+
+		if engineErr != nil {
+			return ExitCode{errors.New("execution failed"), 99}
+		}
+
 		return nil
 	},
 }

--- a/core/local/local_test.go
+++ b/core/local/local_test.go
@@ -213,15 +213,11 @@ func TestExecutorEndTime(t *testing.T) {
 		})
 		assert.NoError(t, e.SetVUsMax(10))
 		assert.NoError(t, e.SetVUs(10))
-		e.SetEndTime(types.NullDurationFrom(100 * time.Millisecond))
-		assert.Equal(t, types.NullDurationFrom(100*time.Millisecond), e.GetEndTime())
 
 		l, hook := logtest.NewNullLogger()
 		e.SetLogger(l)
 
-		startTime := time.Now()
-		assert.NoError(t, e.Run(context.Background(), make(chan stats.SampleContainer, 200)))
-		assert.True(t, time.Now().After(startTime.Add(100*time.Millisecond)), "test did not take 100ms")
+		assert.Error(t, e.Run(context.Background(), make(chan stats.SampleContainer, 200)))
 
 		assert.NotEmpty(t, hook.Entries)
 		for _, e := range hook.Entries {


### PR DESCRIPTION
When an error happened while executing the script, k6 wasn't returning a non 0 zero exit status, that is not ideal when setting up k6 in CI environment.

Another wrong behavior was that even if the script had an error k6 would not stop the execution and would run the script repeatedly until the duration or the number of iterations were complete.