### PR TITLE
Feature/504 http discard response

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -67,6 +67,7 @@ func optionFlagSet() *pflag.FlagSet {
 	flags.String("summary-time-unit", "", "define the time unit used to display the trend stats. Possible units are: 's', 'ms' and 'us'")
 	flags.StringSlice("system-tags", lib.DefaultSystemTagList, "only include these system tags in metrics")
 	flags.StringSlice("tag", nil, "add a `tag` to be applied to all samples, as `[name]=[value]`")
+	flags.Bool("discard-response-body", false, "Read but don't process response body")
 	return flags
 }
 
@@ -86,6 +87,7 @@ func getOptions(flags *pflag.FlagSet) (lib.Options, error) {
 		NoConnectionReuse:     getNullBool(flags, "no-connection-reuse"),
 		NoVUConnectionReuse:   getNullBool(flags, "no-vu-connection-reuse"),
 		Throw:                 getNullBool(flags, "throw"),
+		DiscardResponseBody:   getNullBool(flags, "discard-response-body"),
 		// Default values for options without CLI flags:
 		// TODO: find a saner and more dev-friendly and error-proof way to handle options
 		SetupTimeout:    types.NullDuration{Duration: types.Duration(10 * time.Second), Valid: false},

--- a/js/modules/k6/http/http_request.go
+++ b/js/modules/k6/http/http_request.go
@@ -114,17 +114,18 @@ func (h *HTTP) Request(ctx context.Context, method string, url goja.Value, args 
 }
 
 type parsedHTTPRequest struct {
-	url           *URL
-	body          *bytes.Buffer
-	req           *http.Request
-	timeout       time.Duration
-	auth          string
-	throw         bool
-	redirects     null.Int
-	activeJar     *cookiejar.Jar
-	cookies       map[string]*HTTPRequestCookie
-	mergedCookies map[string][]*HTTPRequestCookie
-	tags          map[string]string
+	url                 *URL
+	body                *bytes.Buffer
+	req                 *http.Request
+	timeout             time.Duration
+	auth                string
+	throw               bool
+	discardResponseBody bool
+	redirects           null.Int
+	activeJar           *cookiejar.Jar
+	cookies             map[string]*HTTPRequestCookie
+	mergedCookies       map[string][]*HTTPRequestCookie
+	tags                map[string]string
 }
 
 func (h *HTTP) parseRequest(ctx context.Context, method string, reqURL URL, body interface{}, params goja.Value) (*parsedHTTPRequest, error) {
@@ -138,11 +139,12 @@ func (h *HTTP) parseRequest(ctx context.Context, method string, reqURL URL, body
 			URL:    reqURL.URL,
 			Header: make(http.Header),
 		},
-		timeout:   60 * time.Second,
-		throw:     state.Options.Throw.Bool,
-		redirects: state.Options.MaxRedirects,
-		cookies:   make(map[string]*HTTPRequestCookie),
-		tags:      make(map[string]string),
+		timeout:             60 * time.Second,
+		throw:               state.Options.Throw.Bool,
+		discardResponseBody: state.Options.DiscardResponseBody.Bool,
+		redirects:           state.Options.MaxRedirects,
+		cookies:             make(map[string]*HTTPRequestCookie),
+		tags:                make(map[string]string),
 	}
 
 	formatFormVal := func(v interface{}) string {
@@ -329,6 +331,8 @@ func (h *HTTP) parseRequest(ctx context.Context, method string, reqURL URL, body
 				result.timeout = time.Duration(params.Get(k).ToFloat() * float64(time.Millisecond))
 			case "throw":
 				result.throw = params.Get(k).ToBoolean()
+			case "discardresponsebody":
+				result.discardResponseBody = params.Get(k).ToBoolean()
 			}
 		}
 	}
@@ -490,14 +494,19 @@ func (h *HTTP) request(ctx context.Context, preq *parsedHTTPRequest) (*HTTPRespo
 		}
 	}
 	if resErr == nil && res != nil {
-		buf := state.BPool.Get()
-		buf.Reset()
-		defer state.BPool.Put(buf)
-		_, err := io.Copy(buf, res.Body)
-		if err != nil && err != io.EOF {
-			resErr = err
+		if !preq.discardResponseBody {
+			buf := state.BPool.Get()
+			buf.Reset()
+			defer state.BPool.Put(buf)
+			_, err := io.Copy(buf, res.Body)
+			if err != nil && err != io.EOF {
+				resErr = err
+			}
+			resp.Body = buf.String()
+		} else {
+			io.Copy(ioutil.Discard, res.Body)
+			resp.Body = ""
 		}
-		resp.Body = buf.String()
 		_ = res.Body.Close()
 	}
 	trail := tracer.Done()

--- a/lib/options.go
+++ b/lib/options.go
@@ -265,6 +265,9 @@ type Options struct {
 
 	// Do not reset cookies after a VU iteration
 	NoCookiesReset null.Bool `json:"noCookiesReset" envconfig:"no_cookies_reset"`
+
+	// Discard Http Responses Body
+	DiscardResponseBody null.Bool `json:"discardResponseBody" envconfig:"discard_response_body"`
 }
 
 // Returns the result of overwriting any fields with any that are set on the argument.
@@ -370,6 +373,9 @@ func (o Options) Apply(opts Options) Options {
 	}
 	if opts.MetricSamplesBufferSize.Valid {
 		o.MetricSamplesBufferSize = opts.MetricSamplesBufferSize
+	}
+	if opts.DiscardResponseBody.Valid {
+		o.DiscardResponseBody = opts.DiscardResponseBody
 	}
 	return o
 }

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -367,6 +367,12 @@ func TestOptions(t *testing.T) {
 		opts := Options{}.Apply(Options{RunTags: tags})
 		assert.Equal(t, tags, opts.RunTags)
 	})
+	t.Run("DiscardResponseBody", func(t *testing.T) {
+		opts := Options{}.Apply(Options{DiscardResponseBody: null.BoolFrom(true)})
+		assert.True(t, opts.DiscardResponseBody.Valid)
+		assert.True(t, opts.DiscardResponseBody.Bool)
+	})
+
 }
 
 func TestOptionsEnv(t *testing.T) {


### PR DESCRIPTION
Discard Response Body Feature implementation

You can use it either globaly (k6 run --discard-response-body xxx.js)
... or per-request within a script:   

_let params =  { discardresponsebody: true  }
r= http.get("http://your.test.com/url", params);


