### PR TITLE
Fix a bug that causes stages to be appended instead of overwritten

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
             export PATH=$GOPATH/bin:$PATH
             echo "mode: set" > coverage.txt
             for pkg in $(go list ./... | grep -v vendor); do
-                go test -race -timeout 210s -coverprofile=$(echo $pkg | tr / -).coverage $pkg
+                go test -race -timeout 600s -coverprofile=$(echo $pkg | tr / -).coverage $pkg
             done
             grep -h -v "^mode:" *.coverage >> coverage.txt
             rm -f *.coverage

--- a/lib/options.go
+++ b/lib/options.go
@@ -292,7 +292,8 @@ func (o Options) Apply(opts Options) Options {
 	if opts.Iterations.Valid {
 		o.Iterations = opts.Iterations
 	}
-	if len(opts.Stages) > 0 {
+	if opts.Stages != nil {
+		o.Stages = []Stage{}
 		for _, s := range opts.Stages {
 			if s.Duration.Valid {
 				o.Stages = append(o.Stages, s)

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -63,12 +63,28 @@ func TestOptions(t *testing.T) {
 		assert.Equal(t, int64(1234), opts.Iterations.Int64)
 	})
 	t.Run("Stages", func(t *testing.T) {
-		opts := Options{}.Apply(Options{Stages: []Stage{{Duration: types.NullDurationFrom(1 * time.Second)}}})
+		opts := Options{}.Apply(Options{Stages: []Stage{
+			{Duration: types.NullDurationFrom(1 * time.Second), Target: null.IntFrom(10)},
+			{Duration: types.NullDurationFrom(2 * time.Second), Target: null.IntFrom(20)},
+		}})
 		assert.NotNil(t, opts.Stages)
-		assert.Len(t, opts.Stages, 1)
+		assert.Len(t, opts.Stages, 2)
 		assert.Equal(t, 1*time.Second, time.Duration(opts.Stages[0].Duration.Duration))
+		assert.Equal(t, int64(10), opts.Stages[0].Target.Int64)
+		assert.Equal(t, 2*time.Second, time.Duration(opts.Stages[1].Duration.Duration))
+		assert.Equal(t, int64(20), opts.Stages[1].Target.Int64)
 
-		assert.Nil(t, Options{}.Apply(Options{Stages: []Stage{{}}}).Stages)
+		emptyStages := []Stage{}
+		assert.Equal(t, emptyStages, Options{}.Apply(Options{Stages: []Stage{{}}}).Stages)
+		assert.Equal(t, emptyStages, Options{}.Apply(Options{Stages: []Stage{}}).Stages)
+		assert.Equal(t, emptyStages, opts.Apply(Options{Stages: []Stage{}}).Stages)
+		assert.Equal(t, emptyStages, opts.Apply(Options{Stages: []Stage{{}}}).Stages)
+
+		assert.Equal(t, opts.Stages, opts.Apply(opts).Stages)
+
+		oneStage := []Stage{{Duration: types.NullDurationFrom(5 * time.Second), Target: null.IntFrom(50)}}
+		assert.Equal(t, oneStage, opts.Apply(Options{Stages: oneStage}).Stages)
+		assert.Equal(t, oneStage, Options{}.Apply(opts).Apply(Options{Stages: oneStage}).Apply(Options{Stages: oneStage}).Stages)
 	})
 	t.Run("RPS", func(t *testing.T) {
 		opts := Options{}.Apply(Options{RPS: null.IntFrom(12345)})

--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -76,3 +76,4 @@ Thanks to @sherrman for reporting the binary handling issues that prompted the a
 * UI: Password input is now masked in `k6 login influxdb` and `k6 login cloud`. (#734)
 * Config: Environment variables can now be used to modify k6's behavior in the `k6 login` subcommands. (#734)
 * HTTP: Binary response bodies were mangled because there was no way to avoid converting them to UTF-16 JavaScript strings. (#749)
+* Config: Stages were appended instead of overwritten from upper config "tiers", and were doubled when supplied via the CLI flag (#759)


### PR DESCRIPTION
The bug also caused the stages set by the CLI flag to be doubled, since the options from CLI flags are used both for their default values and as the most important user-supplied options, so this PR fixes https://github.com/loadimpact/k6/issues/758 as well