### PR TITLE
Fix a panic in HAR conversion due to missing length check

### DIFF
--- a/converter/har/converter.go
+++ b/converter/har/converter.go
@@ -291,12 +291,15 @@ func Convert(h HAR, options lib.Options, minSleep, maxSleep uint, enableChecks b
 			} else {
 				// Add sleep time at the end of the group
 				nextPage := pages[i+1]
-				lastEntry := entries[len(entries)-1]
-				t := nextPage.StartedDateTime.Sub(lastEntry.StartedDateTime).Seconds()
-				if t < 0.01 {
-					t = 0.5
+				sleepTime := 0.5
+				if len(entries) > 0 {
+					lastEntry := entries[len(entries)-1]
+					t := nextPage.StartedDateTime.Sub(lastEntry.StartedDateTime).Seconds()
+					if t >= 0.01 {
+						sleepTime = t
+					}
 				}
-				fprintf(w, "\t\tsleep(%.2f);\n", t)
+				fprintf(w, "\t\tsleep(%.2f);\n", sleepTime)
 			}
 		}
 

--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -77,3 +77,4 @@ Thanks to @sherrman for reporting the binary handling issues that prompted the a
 * Config: Environment variables can now be used to modify k6's behavior in the `k6 login` subcommands. (#734)
 * HTTP: Binary response bodies were mangled because there was no way to avoid converting them to UTF-16 JavaScript strings. (#749)
 * Config: Stages were appended instead of overwritten from upper config "tiers", and were doubled when supplied via the CLI flag (#759)
+* HAR converter: Fixed a panic in due to a missing array length check (#760)

--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -77,4 +77,4 @@ Thanks to @sherrman for reporting the binary handling issues that prompted the a
 * Config: Environment variables can now be used to modify k6's behavior in the `k6 login` subcommands. (#734)
 * HTTP: Binary response bodies were mangled because there was no way to avoid converting them to UTF-16 JavaScript strings. (#749)
 * Config: Stages were appended instead of overwritten from upper config "tiers", and were doubled when supplied via the CLI flag (#759)
-* HAR converter: Fixed a panic in due to a missing array length check (#760)
+* HAR converter: Fixed a panic due to a missing array length check (#760)


### PR DESCRIPTION
Edit: the root cause of reaching the state with 0 `entries` was simply using something invalid with the `--only` flag in `k6 convert` like the URL instead of the domain name