### PR TITLE
Pin Grafana version and run as root

### DIFF
--- a/Dockerfile.grafana
+++ b/Dockerfile.grafana
@@ -1,6 +1,8 @@
-FROM grafana/grafana
+FROM grafana/grafana:5.2.4
 
-RUN apt-get update && apt-get -y install curl
+USER root
+
+RUN apt-get -y install curl
 
 # Change the default data directory (otherwise grafana.db won't persist)
 RUN mkdir /var/lib/grafanadb

--- a/Dockerfile.grafana
+++ b/Dockerfile.grafana
@@ -2,7 +2,8 @@ FROM grafana/grafana:5.2.4
 
 USER root
 
-RUN apt-get -y install curl
+RUN apt-get update && apt-get -y install curl
+
 
 # Change the default data directory (otherwise grafana.db won't persist)
 RUN mkdir /var/lib/grafanadb


### PR DESCRIPTION
As of Grafana 5, they don't run as root in the container anymore. This broke the ability to update apt sources and install curl. This PR pins Grafana to the current latest version 5.2.4, and runs as root.