### PR TITLE
Show reasonable rate when t is 0

### DIFF
--- a/ui/summary.go
+++ b/ui/summary.go
@@ -212,7 +212,10 @@ func NonTrendMetricValueForSum(t time.Duration, timeUnit string, m *stats.Metric
 	switch sink := m.Sink.(type) {
 	case *stats.CounterSink:
 		value := sink.Value
-		rate := value / (float64(t) / float64(time.Second))
+		rate := 0.0
+		if t > 0 {
+			rate = value / (float64(t) / float64(time.Second))
+		}
 		return m.HumanizeValue(value, timeUnit), []string{m.HumanizeValue(rate, timeUnit) + "/s"}
 	case *stats.GaugeSink:
 		value := sink.Value


### PR DESCRIPTION
As reported in #789 , when running an empty test, the rate for `data_received`, `data_sent` and `iterations` are unexpectedly huge. It happens when the execution time `t` is `0`.

This change fixes that by setting the rate to 0 when t is 0, which is reasonable.