### PR TITLE
Do not send interrupted iteartions' duration to the cloud ingest API

### DIFF
--- a/js/runner.go
+++ b/js/runner.go
@@ -393,6 +393,14 @@ func (u *VU) runFn(ctx context.Context, group *lib.Group, fn goja.Callable, args
 	v, err := fn(goja.Undefined(), args...) // Actually run the JS script
 	endTime := time.Now()
 
+	var isFullIteration bool
+	select {
+	case <-ctx.Done():
+		isFullIteration = false
+	default:
+		isFullIteration = true
+	}
+
 	tags := state.Options.RunTags.CloneTags()
 	if state.Options.SystemTags["vu"] {
 		tags["vu"] = strconv.FormatInt(u.ID, 10)
@@ -406,14 +414,6 @@ func (u *VU) runFn(ctx context.Context, group *lib.Group, fn goja.Callable, args
 
 	if u.Runner.Bundle.Options.NoVUConnectionReuse.Bool {
 		u.HTTPTransport.CloseIdleConnections()
-	}
-
-	var isFullIteration bool
-	select {
-	case <-ctx.Done():
-		isFullIteration = false
-	default:
-		isFullIteration = true
 	}
 
 	state.Samples <- u.Dialer.GetTrail(startTime, endTime, isFullIteration, stats.IntoSampleTags(&tags))

--- a/stats/cloud/collector.go
+++ b/stats/cloud/collector.go
@@ -232,17 +232,22 @@ func (c *Collector) Collect(sampleContainers []stats.SampleContainer) {
 			}
 		case *netext.NetTrail:
 			//TODO: aggregate?
+			values := map[string]float64{
+				metrics.DataSent.Name:     float64(sc.BytesWritten),
+				metrics.DataReceived.Name: float64(sc.BytesRead),
+			}
+
+			if sc.FullIteration {
+				values[metrics.IterationDuration.Name] = stats.D(sc.EndTime.Sub(sc.StartTime))
+			}
+
 			newSamples = append(newSamples, &Sample{
 				Type:   DataTypeMap,
 				Metric: "iter_li_all",
 				Data: &SampleDataMap{
-					Time: Timestamp(sc.GetTime()),
-					Tags: sc.GetTags(),
-					Values: map[string]float64{
-						metrics.DataSent.Name:          float64(sc.BytesWritten),
-						metrics.DataReceived.Name:      float64(sc.BytesRead),
-						metrics.IterationDuration.Name: stats.D(sc.EndTime.Sub(sc.StartTime)),
-					},
+					Time:   Timestamp(sc.GetTime()),
+					Tags:   sc.GetTags(),
+					Values: values,
 				}})
 		default:
 			for _, sample := range sampleContainer.GetSamples() {


### PR DESCRIPTION
Previously in #710 I fixed a bug in k6 so that some metrics aren't emitted when an iteration is canceled, a bug that was introduced by the [real-time metrics](https://github.com/loadimpact/k6/pull/678) refactoring (which was itself needed for the in-k6 data aggregation). In the case of the metrics emitted at the end of an iteration, I made it so that the `data_sent` and `data_received` metrics are always emitted, but the `iteration_duration` metric [would only be emitted for complete iterations](https://github.com/loadimpact/k6/pull/710/files#diff-d604a8ac10b2cdb24a6f77aa17608b8aR109).

The trouble comes from the fact that I forgot that we [bundle iteration metrics in a `iter_li_all` metric](https://github.com/loadimpact/k6/blob/c665a73e561bcef243b40207640d8099d392f488/stats/cloud/collector.go#L233-L246) for the cloud collector. So the `iteration_duration` was sent there even if the iteration was incomplete, so this PR makes the cloud collector behave like the rest.