### PR TITLE
Add a hint when MaxVUs is more than the total number of iterations

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -48,7 +48,7 @@ func optionFlagSet() *pflag.FlagSet {
 	flags.Int64P("vus", "u", 1, "number of virtual users")
 	flags.Int64P("max", "m", 0, "max available virtual users")
 	flags.DurationP("duration", "d", 0, "test duration limit")
-	flags.Int64P("iterations", "i", 0, "script iteration limit")
+	flags.Int64P("iterations", "i", 0, "script total iteration limit (among all VUs)")
 	flags.StringSliceP("stage", "s", nil, "add a `stage`, as `[duration]:[target]`")
 	flags.BoolP("paused", "p", false, "start the test in a paused state")
 	flags.Int64("max-redirects", 10, "follow at most n redirects")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -147,6 +147,13 @@ a commandline interface for interacting with it.`,
 			conf.Iterations = null.IntFrom(1)
 		}
 
+		if conf.Iterations.Valid && conf.Iterations.Int64 < conf.VUsMax.Int64 {
+			log.Warnf(
+				"All iterations (%d in this test run) are shared between all VUs, so some of the %d VUs will not execute even a single iteration!",
+				conf.Iterations.Int64, conf.VUsMax.Int64,
+			)
+		}
+
 		// If duration is explicitly set to 0, it means run forever.
 		if conf.Duration.Valid && conf.Duration.Duration == 0 {
 			conf.Duration = types.NullDuration{}

--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -89,6 +89,10 @@ export default function () {
 
 Thanks to @AndriiChuzhynov for implementing this! (#766)
 
+## UX
+
+* Added a warning when the maximum number of VUs is more than the total number of iterations (#802)
+
 ## Internals
 
 * Cloud output: improved outlier metric detection for small batches (#744)


### PR DESCRIPTION
Combined with mentions in the readme, docs and CLI help this should be enough to prevent confusion, so we can close https://github.com/loadimpact/k6/issues/663