### PR TITLE
Add a flag to disable the end-of-test summary

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -56,6 +56,7 @@ func configFlagSet() *pflag.FlagSet {
 	flags.BoolP("linger", "l", false, "keep the API server alive past test end")
 	flags.Bool("no-usage-report", false, "don't send anonymous stats to the developers")
 	flags.Bool("no-thresholds", false, "don't run thresholds")
+	flags.Bool("no-summary", false, "don't show the summary at the end of the test")
 	flags.AddFlagSet(configFileFlagSet())
 	return flags
 }
@@ -67,6 +68,7 @@ type Config struct {
 	Linger        null.Bool `json:"linger" envconfig:"linger"`
 	NoUsageReport null.Bool `json:"noUsageReport" envconfig:"no_usage_report"`
 	NoThresholds  null.Bool `json:"noThresholds" envconfig:"no_thresholds"`
+	NoSummary     null.Bool `json:"noSummary" envconfig:"no_summary"`
 
 	Collectors struct {
 		InfluxDB influxdb.Config `json:"influxdb"`
@@ -88,6 +90,9 @@ func (c Config) Apply(cfg Config) Config {
 	}
 	if cfg.NoThresholds.Valid {
 		c.NoThresholds = cfg.NoThresholds
+	}
+	if cfg.NoSummary.Valid {
+		c.NoSummary = cfg.NoSummary
 	}
 	c.Collectors.InfluxDB = c.Collectors.InfluxDB.Apply(cfg.Collectors.InfluxDB)
 	c.Collectors.Cloud = c.Collectors.Cloud.Apply(cfg.Collectors.Cloud)
@@ -111,6 +116,7 @@ func getConfig(flags *pflag.FlagSet) (Config, error) {
 		Linger:        getNullBool(flags, "linger"),
 		NoUsageReport: getNullBool(flags, "no-usage-report"),
 		NoThresholds:  getNullBool(flags, "no-thresholds"),
+		NoSummary:     getNullBool(flags, "no-summary"),
 	}, nil
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -188,6 +188,9 @@ a commandline interface for interacting with it.`,
 		if conf.NoThresholds.Valid {
 			engine.NoThresholds = conf.NoThresholds.Bool
 		}
+		if conf.NoSummary.Valid {
+			engine.NoSummary = conf.NoSummary.Bool
+		}
 
 		// Create a collector and assign it to the engine if requested.
 		fprintf(stdout, "%s   collector\r", initBar.String())
@@ -409,7 +412,7 @@ a commandline interface for interacting with it.`,
 		}
 
 		// Print the end-of-test summary.
-		if !quiet {
+		if !quiet && !conf.NoSummary.Bool {
 			fprintf(stdout, "\n")
 			ui.Summarize(stdout, "", ui.SummaryData{
 				Opts:    conf.Options,

--- a/core/engine.go
+++ b/core/engine.go
@@ -53,6 +53,7 @@ type Engine struct {
 	Options      lib.Options
 	Collectors   []lib.Collector
 	NoThresholds bool
+	NoSummary    bool
 
 	logger *log.Logger
 
@@ -343,11 +344,7 @@ func (e *Engine) processThresholds(abort func()) {
 	}
 }
 
-func (e *Engine) processSamples(sampleCointainers []stats.SampleContainer) {
-	if len(sampleCointainers) == 0 {
-		return
-	}
-
+func (e *Engine) processSamplesForMetrics(sampleCointainers []stats.SampleContainer) {
 	e.MetricsLock.Lock()
 	defer e.MetricsLock.Unlock()
 
@@ -383,6 +380,18 @@ func (e *Engine) processSamples(sampleCointainers []stats.SampleContainer) {
 			}
 		}
 	}
+}
+
+func (e *Engine) processSamples(sampleCointainers []stats.SampleContainer) {
+	if len(sampleCointainers) == 0 {
+		return
+	}
+
+	// TODO: run this and the below code in goroutines?
+	if !(e.NoSummary && e.NoThresholds) {
+		e.processSamplesForMetrics(sampleCointainers)
+	}
+
 	if len(e.Collectors) > 0 {
 		for _, collector := range e.Collectors {
 			collector.Collect(sampleCointainers)


### PR DESCRIPTION
This, when used in conjunction with `--no-thresholds`, should reduce the k6 memory usage for long-running tests substantially. This is something like an all-or-nothing approach to https://github.com/loadimpact/k6/issues/764 - even though it's not the best solution, it's pretty easy to implement and support and we can always extend it later.