### PR TITLE
Retouching how files are handled when running from archive fixes #819

### DIFF
--- a/js/bundle.go
+++ b/js/bundle.go
@@ -23,6 +23,7 @@ package js
 import (
 	"context"
 	"encoding/json"
+	"os"
 
 	"github.com/dop251/goja"
 	"github.com/loadimpact/k6/js/common"
@@ -140,20 +141,8 @@ func NewBundleFromArchive(arc *lib.Archive, rtOpts lib.RuntimeOptions) (*Bundle,
 		return nil, errors.Errorf("expected bundle type 'js', got '%s'", arc.Type)
 	}
 
-	pgm, _, err := compiler.Compile(string(arc.Data), arc.Filename, "", "", true)
-	if err != nil {
-		return nil, err
-	}
-
-	initctx := NewInitContext(goja.New(), compiler, new(context.Context), nil, arc.Pwd)
-	for filename, data := range arc.Scripts {
-		src := string(data)
-		pgm, err := initctx.compileImport(src, filename)
-		if err != nil {
-			return nil, err
-		}
-		initctx.programs[filename] = programWithSource{pgm, src}
-	}
+	initctx := NewInitContext(goja.New(), compiler, new(context.Context), arc.FS, arc.Pwd)
+	pgm, err := initctx.compileImport(string(arc.Data), arc.Filename)
 	initctx.files = arc.Files
 
 	env := arc.Env
@@ -175,9 +164,10 @@ func NewBundleFromArchive(arc *lib.Archive, rtOpts lib.RuntimeOptions) (*Bundle,
 	}, nil
 }
 
-func (b *Bundle) MakeArchive() *lib.Archive {
+func (b *Bundle) makeArchive() *lib.Archive {
 	arc := &lib.Archive{
 		Type:     "js",
+		FS:       afero.NewMemMapFs(),
 		Options:  b.Options,
 		Filename: b.Filename,
 		Data:     []byte(b.Source),
@@ -192,6 +182,10 @@ func (b *Bundle) MakeArchive() *lib.Archive {
 	arc.Scripts = make(map[string][]byte, len(b.BaseInitContext.programs))
 	for name, pgm := range b.BaseInitContext.programs {
 		arc.Scripts[name] = []byte(pgm.src)
+		err := afero.WriteFile(arc.FS, name, []byte(pgm.src), os.ModePerm)
+		if err != nil {
+			return nil
+		}
 	}
 	arc.Files = b.BaseInitContext.files
 

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -55,7 +55,7 @@ type BundleInstance struct {
 	Default goja.Callable
 }
 
-// Creates a new bundle from a source file and a filesystem.
+// NewBundle creates a new bundle from a source file and a filesystem.
 func NewBundle(src *lib.SourceData, fs afero.Fs, rtOpts lib.RuntimeOptions) (*Bundle, error) {
 	compiler, err := compiler.New()
 	if err != nil {
@@ -131,6 +131,7 @@ func NewBundle(src *lib.SourceData, fs afero.Fs, rtOpts lib.RuntimeOptions) (*Bu
 	return &bundle, nil
 }
 
+// NewBundleFromArchive creates a new bundle from an lib.Archive.
 func NewBundleFromArchive(arc *lib.Archive, rtOpts lib.RuntimeOptions) (*Bundle, error) {
 	compiler, err := compiler.New()
 	if err != nil {
@@ -143,6 +144,9 @@ func NewBundleFromArchive(arc *lib.Archive, rtOpts lib.RuntimeOptions) (*Bundle,
 
 	initctx := NewInitContext(goja.New(), compiler, new(context.Context), arc.FS, arc.Pwd)
 	pgm, err := initctx.compileImport(string(arc.Data), arc.Filename)
+	if err != nil {
+		return nil, err
+	}
 	initctx.files = arc.Files
 
 	env := arc.Env

--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -376,7 +376,7 @@ func TestNewBundleFromArchive(t *testing.T) {
 	}
 	assert.Equal(t, "hi!", v.Export())
 
-	arc := b.MakeArchive()
+	arc := b.makeArchive()
 	assert.Equal(t, "js", arc.Type)
 	assert.Equal(t, lib.Options{VUs: null.IntFrom(12345)}, arc.Options)
 	assert.Equal(t, "/path/to/script.js", arc.Filename)
@@ -456,7 +456,7 @@ func TestBundleEnv(t *testing.T) {
 		return
 	}
 
-	b2, err := NewBundleFromArchive(b1.MakeArchive(), lib.RuntimeOptions{})
+	b2, err := NewBundleFromArchive(b1.makeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -74,8 +74,9 @@ func newBoundInitContext(base *InitContext, ctxPtr *context.Context, rt *goja.Ru
 		runtime: rt,
 		ctxPtr:  ctxPtr,
 
-		fs:  nil,
-		pwd: base.pwd,
+		fs:       base.fs,
+		pwd:      base.pwd,
+		compiler: base.compiler,
 
 		programs: base.programs,
 		files:    base.files,

--- a/js/runner.go
+++ b/js/runner.go
@@ -99,7 +99,7 @@ func NewFromBundle(b *Bundle) (*Runner, error) {
 }
 
 func (r *Runner) MakeArchive() *lib.Archive {
-	return r.Bundle.MakeArchive()
+	return r.Bundle.makeArchive()
 }
 
 func (r *Runner) NewVU(samplesOut chan<- stats.SampleContainer) (lib.VU, error) {

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -1400,11 +1400,11 @@ func TestArchiveNotPanicing(t *testing.T) {
 	defer tb.Cleanup()
 
 	fs := afero.NewMemMapFs()
-	require.NoError(t, afero.WriteFile(fs, "/non/existant", []byte(`42`), os.ModePerm))
+	require.NoError(t, afero.WriteFile(fs, "/non/existent", []byte(`42`), os.ModePerm))
 	r1, err := New(&lib.SourceData{
 		Filename: "/script.js",
 		Data: []byte(tb.Replacer.Replace(`
-			let fput = open("/non/existant");
+			let fput = open("/non/existent");
 			export default function(data) {
 			}
 		`)),

--- a/lib/archive.go
+++ b/lib/archive.go
@@ -33,6 +33,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/spf13/afero"
 )
 
 var volumeRE = regexp.MustCompile(`^([a-zA-Z]):(.*)`)
@@ -47,6 +49,18 @@ func NormalizeAndAnonymizePath(path string) string {
 	p = strings.Replace(p, "\\", "/", -1)
 	p = sharedRE.ReplaceAllString(p, `/nobody`)
 	return homeDirRE.ReplaceAllString(p, `$1/$2/nobody`)
+}
+
+type normalizedFS struct {
+	afero.Fs
+}
+
+func (m *normalizedFS) Open(name string) (afero.File, error) {
+	return m.Fs.Open(NormalizeAndAnonymizePath(name))
+}
+
+func (m *normalizedFS) OpenFile(name string, flag int, mode os.FileMode) (afero.File, error) {
+	return m.Fs.OpenFile(NormalizeAndAnonymizePath(name), flag, mode)
 }
 
 // An Archive is a rollup of all resources and options needed to reproduce a test identically elsewhere.
@@ -68,6 +82,8 @@ type Archive struct {
 	Scripts map[string][]byte `json:"-"` // included scripts
 	Files   map[string][]byte `json:"-"` // non-script resources
 
+	FS afero.Fs `json:"-"`
+
 	// Environment variables
 	Env map[string]string `json:"env"`
 }
@@ -78,6 +94,7 @@ func ReadArchive(in io.Reader) (*Archive, error) {
 	arc := &Archive{
 		Scripts: make(map[string][]byte),
 		Files:   make(map[string][]byte),
+		FS:      &normalizedFS{Fs: afero.NewMemMapFs()},
 	}
 
 	for {
@@ -133,6 +150,11 @@ func ReadArchive(in io.Reader) (*Archive, error) {
 		}
 
 		dst[name] = data
+
+		err = afero.WriteFile(arc.FS, name, data, os.ModePerm)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return arc, nil

--- a/lib/archive_test.go
+++ b/lib/archive_test.go
@@ -78,6 +78,7 @@ func TestArchiveReadWrite(t *testing.T) {
 		assert.NoError(t, arc1.Write(buf))
 
 		arc2, err := ReadArchive(buf)
+		arc2.FS = nil
 		assert.NoError(t, err)
 		assert.Equal(t, arc1, arc2)
 	})
@@ -135,6 +136,7 @@ func TestArchiveReadWrite(t *testing.T) {
 			assert.NoError(t, arc1.Write(buf))
 
 			arc2, err := ReadArchive(buf)
+			arc2.FS = nil
 			assert.NoError(t, err)
 			assert.Equal(t, arc1Anon, arc2)
 		}


### PR DESCRIPTION
Before this commit running an archive meant that all the files will be
loaded and cached before execution. This also included precompiling all
the javascript files without actually running any of them.
This in itself wasn't a problem the problem came from anonymazation of
usernames in directories. This when the paths are absolute meant that we
had to change the script as well in order for them to match - we both
didn't do it and it wouldn't have worked in all cases as they could be
made concatinating strings for example.

The solution - either remove anonymization or anonymize everything
coming trough open. The second solution was choosen for now.

This commit also makes it so that we have an afero.Fs when running from
archive that is populated with all the files from the archive with their
correct anonymized paths. This prevents the panic that was previously
happening.

Also now we just compile and run the test script and it will
automatically load whatever scripts it need from the afero.fs the same
way as this is when just using 'k6 run test.js'