### PR TITLE
Run imported scripts only once

### DIFF
--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -133,3 +133,5 @@ A new option that disables the end-of-test summary has been added. That summary 
 * Metric names are now restricted to only allow Unicode letters or numbers, spaces, dots, underscores, and
   hyphens. They also need to be between 1 and 128 characters. Previously practically anything was a
   valid metric name. (#810)
+* We are now running imported scripts only once instead of for each time it was imported/required.
+  (#827)


### PR DESCRIPTION
Previously scripts would've been ran for each time they were imported
this is both slower and not how it works in most(all?) interpreters
so we are changing the behavious to be more compliant.