### PR TITLE
Return timeout error when appropriate for setup/teardown fix #869

### DIFF
--- a/lib/timeout_error.go
+++ b/lib/timeout_error.go
@@ -1,0 +1,18 @@
+package lib
+
+// TimeoutError is used when somethings timeouts
+type TimeoutError string
+
+// NewTimeoutError returns a new TimeoutError reporting that timeout has happened at the provieded
+// place
+func NewTimeoutError(place string) TimeoutError {
+	return TimeoutError("Timeout during " + place)
+}
+
+func (t TimeoutError) String() string {
+	return (string)(t)
+}
+
+func (t TimeoutError) Error() string {
+	return t.String()
+}


### PR DESCRIPTION
Previously because of the way js interrupt works it was that the js vm
will not get interrupt signal for some time after the timeout has
happened. This would be especially true in cases of lower (1) cpu counts
or under heavy load.
Because calls from inside js to go code will return when the
context is *Done* we will probably still end setup/teardown functions in
approximately timeout time but it might not actually be marked as
timeouted.

To fix this after calls to js functions we check that the timeout has
been passed if setted. If this has happened we return a new specific
timeout error that can later be used to distinguish that timeout has
happened. There is also some additional code to catch that an actual
interrupt has happened and that it is because of timeout.