### PR TITLE
Exit with non zero code when setup/teardown timeouts fix #868

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -55,6 +55,11 @@ import (
 const (
 	typeJS      = "js"
 	typeArchive = "archive"
+
+	setupTimeoutErrorCode    = 100
+	teardownTimeoutErrorCode = 101
+	genericTimeoutErrorCode  = 102
+	genericEngineErrorCode   = 103
 )
 
 var (
@@ -379,13 +384,29 @@ a commandline interface for interacting with it.`,
 				progress.Progress = prog
 				fprintf(stdout, "%s\x1b[0K\r", progress.String())
 			case err := <-errC:
-				if err != nil {
-					log.WithError(err).Error("Engine error")
-				} else {
-					log.Debug("Engine terminated cleanly")
-				}
 				cancel()
-				break mainLoop
+				if err == nil {
+					log.Debug("Engine terminated cleanly")
+					break mainLoop
+				}
+
+				switch e := errors.Cause(err).(type) {
+				case lib.TimeoutError:
+					switch string(e) {
+					case "setup":
+						log.WithError(err).Error("Setup timeout")
+						return ExitCode{errors.New("Setup timeout"), setupTimeoutErrorCode}
+					case "teardown":
+						log.WithError(err).Error("Teardown timeout")
+						return ExitCode{errors.New("Teardown timeout"), teardownTimeoutErrorCode}
+					default:
+						log.WithError(err).Error("Engine timeout")
+						return ExitCode{errors.New("Engine timeout"), genericTimeoutErrorCode}
+					}
+				default:
+					log.WithError(err).Error("Engine error")
+					return ExitCode{errors.New("Engine Error"), genericEngineErrorCode}
+				}
 			case sig := <-sigC:
 				log.WithField("sig", sig).Debug("Exiting in response to signal")
 				cancel()

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -56,10 +56,11 @@ const (
 	typeJS      = "js"
 	typeArchive = "archive"
 
-	setupTimeoutErrorCode    = 100
-	teardownTimeoutErrorCode = 101
-	genericTimeoutErrorCode  = 102
-	genericEngineErrorCode   = 103
+	thresholdHaveFailedErroCode = 99
+	setupTimeoutErrorCode       = 100
+	teardownTimeoutErrorCode    = 101
+	genericTimeoutErrorCode     = 102
+	genericEngineErrorCode      = 103
 )
 
 var (
@@ -450,7 +451,7 @@ a commandline interface for interacting with it.`,
 		}
 
 		if engine.IsTainted() {
-			return ExitCode{errors.New("some thresholds have failed"), 99}
+			return ExitCode{errors.New("some thresholds have failed"), thresholdHaveFailedErroCode}
 		}
 		return nil
 	},

--- a/lib/timeout_error.go
+++ b/lib/timeout_error.go
@@ -6,11 +6,11 @@ type TimeoutError string
 // NewTimeoutError returns a new TimeoutError reporting that timeout has happened at the provieded
 // place
 func NewTimeoutError(place string) TimeoutError {
-	return TimeoutError("Timeout during " + place)
+	return TimeoutError(place)
 }
 
 func (t TimeoutError) String() string {
-	return (string)(t)
+	return "Timeout during " + (string)(t)
 }
 
 func (t TimeoutError) Error() string {

--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -12,3 +12,4 @@ Description of feature.
 
 * JS: Consistently report setup/teardown timeouts as such and switch the error message to be more
   expressive (#890)
+* JS: Correctly exit with non zero exit code when setup or teardown timeouts (#892)


### PR DESCRIPTION
There are now 4 new non zero exit codes that will be revisioned at later
date when we more exit codes arise.

The 4 new ones are for each of setup and teardown timeouts, if it is a
timeout in the engine but it is not in setup/teardown - no such is known
at this time and 1 for engine error which is not timeout.