### PR TITLE
Add crypto.randomBytes

### DIFF
--- a/js/modules/k6/crypto/crypto.go
+++ b/js/modules/k6/crypto/crypto.go
@@ -52,6 +52,9 @@ func New() *Crypto {
 }
 
 func (*Crypto) RandomBytes(ctx context.Context, size int) []byte {
+	if size < 1 {
+		common.Throw(common.GetRuntime(ctx), errors.New("Invalid size"))
+	}
 	bytes := make([]byte, size)
 	_, err := rand.Read(bytes)
 	if err != nil {

--- a/js/modules/k6/crypto/crypto.go
+++ b/js/modules/k6/crypto/crypto.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/md5"
+	"crypto/rand"
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
@@ -48,6 +49,15 @@ type Hasher struct {
 
 func New() *Crypto {
 	return &Crypto{}
+}
+
+func (*Crypto) RandomBytes(ctx context.Context, size int) []byte {
+	bytes := make([]byte, size)
+	_, err := rand.Read(bytes)
+	if err != nil {
+		common.Throw(common.GetRuntime(ctx), err)
+	}
+	return bytes
 }
 
 func (c *Crypto) Md4(ctx context.Context, input []byte, outputEncoding string) string {

--- a/js/modules/k6/crypto/crypto_test.go
+++ b/js/modules/k6/crypto/crypto_test.go
@@ -61,7 +61,7 @@ func TestCryptoAlgorithms(t *testing.T) {
 
 	t.Run("RandomBytesInvalidSize", func(t *testing.T) {
 		_, err := common.RunString(rt, `
-		crypto.RandomBytes(-1);`)
+		crypto.randomBytes(-1);`)
 
 		assert.Error(t, err)
 	})

--- a/js/modules/k6/crypto/crypto_test.go
+++ b/js/modules/k6/crypto/crypto_test.go
@@ -40,6 +40,15 @@ func TestCryptoAlgorithms(t *testing.T) {
 	ctx := context.Background()
 	ctx = common.WithRuntime(ctx, rt)
 	rt.Set("crypto", common.Bind(rt, New(), &ctx))
+	
+	t.Run("RandomBytes", func(t *testing.T) {
+		_, err := common.RunString(rt, `
+		let bytes = crypto.randomBytes(5);
+		if (bytes.length !== 5) {
+			throw new Error("Incorrect size: " + bytes.length);
+		}`)
+		assert.NoError(t, err)
+	})
 
 	t.Run("MD4", func(t *testing.T) {
 		_, err := common.RunString(rt, `

--- a/js/modules/k6/crypto/crypto_test.go
+++ b/js/modules/k6/crypto/crypto_test.go
@@ -22,9 +22,9 @@ package crypto
 
 import (
 	"context"
-	"testing"
 	"crypto/rand"
 	"errors"
+	"testing"
 
 	"github.com/dop251/goja"
 	"github.com/loadimpact/k6/js/common"
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type MockReader struct {}
+type MockReader struct{}
 
 func (MockReader) Read(p []byte) (n int, err error) {
 	return -1, errors.New("Contrived failure")
@@ -65,14 +65,14 @@ func TestCryptoAlgorithms(t *testing.T) {
 
 		assert.Error(t, err)
 	})
-	
+
 	t.Run("RandomBytesFailure", func(t *testing.T) {
 		SavedReader := rand.Reader
 		rand.Reader = MockReader{}
 		_, err := common.RunString(rt, `
 		crypto.randomBytes(5);`)
 		rand.Reader = SavedReader
-	
+
 		assert.Error(t, err)
 	})
 

--- a/js/modules/k6/crypto/crypto_test.go
+++ b/js/modules/k6/crypto/crypto_test.go
@@ -41,13 +41,21 @@ func TestCryptoAlgorithms(t *testing.T) {
 	ctx = common.WithRuntime(ctx, rt)
 	rt.Set("crypto", common.Bind(rt, New(), &ctx))
 
-	t.Run("RandomBytes", func(t *testing.T) {
+	t.Run("RandomBytesValid", func(t *testing.T) {
 		_, err := common.RunString(rt, `
 		let bytes = crypto.randomBytes(5);
 		if (bytes.length !== 5) {
 			throw new Error("Incorrect size: " + bytes.length);
 		}`)
+
 		assert.NoError(t, err)
+	})
+
+	t.Run("RandomBytesInvalid", func(t *testing.T) {
+		_, err := common.RunString(rt, `
+		crypto.RandomBytes(-1);`)
+
+		assert.Error(t, err)
 	})
 
 	t.Run("MD4", func(t *testing.T) {

--- a/js/modules/k6/crypto/crypto_test.go
+++ b/js/modules/k6/crypto/crypto_test.go
@@ -23,12 +23,20 @@ package crypto
 import (
 	"context"
 	"testing"
+	"crypto/rand"
+	"errors"
 
 	"github.com/dop251/goja"
 	"github.com/loadimpact/k6/js/common"
 	"github.com/loadimpact/k6/lib"
 	"github.com/stretchr/testify/assert"
 )
+
+type MockReader struct {}
+
+func (MockReader) Read(p []byte) (n int, err error) {
+	return -1, errors.New("Contrived failure")
+}
 
 func TestCryptoAlgorithms(t *testing.T) {
 	if testing.Short() {
@@ -55,6 +63,16 @@ func TestCryptoAlgorithms(t *testing.T) {
 		_, err := common.RunString(rt, `
 		crypto.RandomBytes(-1);`)
 
+		assert.Error(t, err)
+	})
+	
+	t.Run("RandomBytesFailure", func(t *testing.T) {
+		SavedReader := rand.Reader
+		rand.Reader = MockReader{}
+		_, err := common.RunString(rt, `
+		crypto.randomBytes(5);`)
+		rand.Reader = SavedReader
+	
 		assert.Error(t, err)
 	})
 

--- a/js/modules/k6/crypto/crypto_test.go
+++ b/js/modules/k6/crypto/crypto_test.go
@@ -41,7 +41,7 @@ func TestCryptoAlgorithms(t *testing.T) {
 	ctx = common.WithRuntime(ctx, rt)
 	rt.Set("crypto", common.Bind(rt, New(), &ctx))
 
-	t.Run("RandomBytesValid", func(t *testing.T) {
+	t.Run("RandomBytesSuccess", func(t *testing.T) {
 		_, err := common.RunString(rt, `
 		let bytes = crypto.randomBytes(5);
 		if (bytes.length !== 5) {
@@ -51,7 +51,7 @@ func TestCryptoAlgorithms(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("RandomBytesInvalid", func(t *testing.T) {
+	t.Run("RandomBytesInvalidSize", func(t *testing.T) {
 		_, err := common.RunString(rt, `
 		crypto.RandomBytes(-1);`)
 

--- a/js/modules/k6/crypto/crypto_test.go
+++ b/js/modules/k6/crypto/crypto_test.go
@@ -40,7 +40,7 @@ func TestCryptoAlgorithms(t *testing.T) {
 	ctx := context.Background()
 	ctx = common.WithRuntime(ctx, rt)
 	rt.Set("crypto", common.Bind(rt, New(), &ctx))
-	
+
 	t.Run("RandomBytes", func(t *testing.T) {
 		_, err := common.RunString(rt, `
 		let bytes = crypto.randomBytes(5);


### PR DESCRIPTION
Adds method `randomBytes` to `k6/crypto`. The method takes a single parameter `size` specifying byte count and returns an array of random bytes. Bytes are represented as number literals.

Toward #900.