### PR TITLE
Trim trailing whitespace in Go

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ indent_style = tab
 indent_size = 4
 
 [*.go]
-trim_trailing_whitespace = false
+trim_trailing_whitespace = true
 
 [*.md]
 indent_style = space


### PR DESCRIPTION
Does it make sense to configure editors to trim trailing whitespace? It seems to be required by the Go linter. It's caught me twice now.