### PR TITLE
--quiet should allow the display of summary stats

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -436,7 +436,7 @@ a commandline interface for interacting with it.`,
 		}
 
 		// Print the end-of-test summary.
-		if !quiet && !conf.NoSummary.Bool {
+		if !conf.NoSummary.Bool {
 			fprintf(stdout, "\n")
 			ui.Summarize(stdout, "", ui.SummaryData{
 				Opts:    conf.Options,


### PR DESCRIPTION
As the help summary implies:  
```
-q, --quiet              disable progress updates
```
The --quiet flag should not prevent summary stats to be displayed