### PR TITLE
Configure editor to trim whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,9 +7,6 @@ trim_trailing_whitespace = true
 indent_style = tab
 indent_size = 4
 
-[*.go]
-trim_trailing_whitespace = false
-
 [*.md]
 indent_style = space
 trim_trailing_whitespace = false


### PR DESCRIPTION
Configures editor to trim trailing whitespace in Golang code.

Uses the approach suggested in #924 of removing the Golang setting to fall through to the global setting.