### PR TITLE
Enable console in the init context

### DIFF
--- a/js/bundle.go
+++ b/js/bundle.go
@@ -246,6 +246,7 @@ func (b *Bundle) instantiate(rt *goja.Runtime, init *InitContext) error {
 	rt.Set("module", module)
 
 	rt.Set("__ENV", b.Env)
+	rt.Set("console", common.Bind(rt, newConsole(), init.ctxPtr))
 
 	*init.ctxPtr = common.WithRuntime(context.Background(), rt)
 	unbindInit := common.BindToGlobal(rt, common.Bind(rt, init, init.ctxPtr))

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -357,6 +357,28 @@ func TestSetupDataNoSetup(t *testing.T) {
 	};`)
 }
 
+func TestConsoleInInitContext(t *testing.T) {
+	r1, err := getSimpleRunner("/script.js", `
+			console.log("1");
+			export default function(data) {
+			};
+		`)
+	require.NoError(t, err)
+
+	testdata := map[string]*Runner{"Source": r1}
+	for name, r := range testdata {
+		r := r
+		t.Run(name, func(t *testing.T) {
+			samples := make(chan stats.SampleContainer, 100)
+			vu, err := r.NewVU(samples)
+			if assert.NoError(t, err) {
+				err := vu.RunOnce(context.Background())
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestSetupDataNoReturn(t *testing.T) {
 	testSetupDataHelper(t, `
 	export let options = { setupTimeout: "1s", teardownTimeout: "1s" };


### PR DESCRIPTION
This commit does the bare minimal to enable useage of console init
context. Unfortunetely this means that redirection to file is currently
not supported in init context.

This fixes #951

Message for the release notes:

> bugfix: `console` is now usable inside the init context. Unfortunately this doesn't respect `--console-output` (#1131) , and will be fixed in the future.  
