### PR TITLE
Fix blacklistIPs JS configuration

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -121,9 +121,9 @@ func getOptions(flags *pflag.FlagSet) (lib.Options, error) {
 		return opts, err
 	}
 	for _, s := range blacklistIPStrings {
-		net, err := lib.ParseCIDR(s)
-		if err != nil {
-			return opts, errors.Wrap(err, "blacklist-ip")
+		net, parseErr := lib.ParseCIDR(s)
+		if parseErr != nil {
+			return opts, errors.Wrap(parseErr, "blacklist-ip")
 		}
 		opts.BlacklistIPs = append(opts.BlacklistIPs, net)
 	}

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -22,7 +22,6 @@ package cmd
 
 import (
 	"fmt"
-	"net"
 	"strings"
 	"time"
 
@@ -122,7 +121,7 @@ func getOptions(flags *pflag.FlagSet) (lib.Options, error) {
 		return opts, err
 	}
 	for _, s := range blacklistIPStrings {
-		_, net, err := net.ParseCIDR(s)
+		net, err := lib.ParseCIDR(s)
 		if err != nil {
 			return opts, errors.Wrap(err, "blacklist-ip")
 		}

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -812,6 +812,7 @@ func TestVUIntegrationBlacklistScript(t *testing.T) {
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
 
 	for name, r := range runners {
+		r := r
 		t.Run(name, func(t *testing.T) {
 			vu, err := r.NewVU(make(chan stats.SampleContainer, 100))
 			if !assert.NoError(t, err) {

--- a/lib/netext/dialer.go
+++ b/lib/netext/dialer.go
@@ -81,9 +81,9 @@ func (d *Dialer) DialContext(ctx context.Context, proto, addr string) (net.Conn,
 		}
 	}
 
-	for _, net := range d.Blacklist {
-		if net.Contains(ip) {
-			return nil, BlackListedIPError{ip: ip, net: net}
+	for _, ipnet := range d.Blacklist {
+		if (*net.IPNet)(ipnet).Contains(ip) {
+			return nil, BlackListedIPError{ip: ip, net: ipnet}
 		}
 	}
 	ipStr := ip.String()

--- a/lib/netext/dialer.go
+++ b/lib/netext/dialer.go
@@ -28,6 +28,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/lib/metrics"
 	"github.com/loadimpact/k6/stats"
 
@@ -40,7 +41,7 @@ type Dialer struct {
 	net.Dialer
 
 	Resolver  *dnscache.Resolver
-	Blacklist []*net.IPNet
+	Blacklist []*lib.IPNet
 	Hosts     map[string]net.IP
 
 	BytesRead    int64
@@ -58,7 +59,7 @@ func NewDialer(dialer net.Dialer) *Dialer {
 // BlackListedIPError is an error that is returned when a given IP is blacklisted
 type BlackListedIPError struct {
 	ip  net.IP
-	net *net.IPNet
+	net *lib.IPNet
 }
 
 func (b BlackListedIPError) Error() string {

--- a/lib/options.go
+++ b/lib/options.go
@@ -206,18 +206,15 @@ func (c *TLSAuth) Certificate() (*tls.Certificate, error) {
 }
 
 // IPNet is a wrapper around net.IPNet for JSON unmarshalling
-type IPNet struct {
-	net.IPNet
+type IPNet net.IPNet
+
+func (ipnet *IPNet) String() string {
+	return (*net.IPNet)(ipnet).String()
 }
 
-// UnmarshalJSON populates the IPNet from the given CIDR JSON
-func (ipnet *IPNet) UnmarshalJSON(b []byte) error {
-	var cidr string
-	if err := json.Unmarshal(b, &cidr); err != nil {
-		return err
-	}
-
-	newIPNet, err := ParseCIDR(cidr)
+// UnmarshalText populates the IPNet from the given CIDR
+func (ipnet *IPNet) UnmarshalText(b []byte) error {
+	newIPNet, err := ParseCIDR(string(b))
 	if err != nil {
 		return errors.Wrap(err, "Failed to parse CIDR")
 	}
@@ -234,7 +231,9 @@ func ParseCIDR(s string) (*IPNet, error) {
 		return nil, err
 	}
 
-	return &IPNet{*ipnet}, nil
+	parsedIPNet := IPNet(*ipnet)
+
+	return &parsedIPNet, nil
 }
 
 type Options struct {

--- a/lib/options.go
+++ b/lib/options.go
@@ -229,17 +229,12 @@ func (ipnet *IPNet) UnmarshalJSON(b []byte) error {
 
 // ParseCIDR creates an IPNet out of a CIDR string
 func ParseCIDR(s string) (*IPNet, error) {
-	ip, ipnet, err := net.ParseCIDR(s)
+	_, ipnet, err := net.ParseCIDR(s)
 	if err != nil {
 		return nil, err
 	}
 
-	return &IPNet{
-		IPNet: net.IPNet{
-			IP:   ip,
-			Mask: ipnet.Mask,
-		},
-	}, nil
+	return &IPNet{*ipnet}, nil
 }
 
 type Options struct {

--- a/lib/options.go
+++ b/lib/options.go
@@ -211,7 +211,7 @@ type IPNet struct {
 }
 
 // UnmarshalJSON populates the IPNet from the given CIDR JSON
-func (ipnet *IPNet) UnmarshalJSON(b []byte) (err error) {
+func (ipnet *IPNet) UnmarshalJSON(b []byte) error {
 	var cidr string
 	if err := json.Unmarshal(b, &cidr); err != nil {
 		return err

--- a/lib/options.go
+++ b/lib/options.go
@@ -205,6 +205,43 @@ func (c *TLSAuth) Certificate() (*tls.Certificate, error) {
 	return c.certificate, nil
 }
 
+// IPNet is a wrapper around net.IPNet for JSON unmarshalling
+type IPNet struct {
+	net.IPNet
+}
+
+// UnmarshalJSON populates the IPNet from the given CIDR JSON
+func (ipnet *IPNet) UnmarshalJSON(b []byte) (err error) {
+	var cidr string
+	if err := json.Unmarshal(b, &cidr); err != nil {
+		return err
+	}
+
+	newIPNet, err := ParseCIDR(cidr)
+	if err != nil {
+		return errors.Wrap(err, "Failed to parse CIDR")
+	}
+
+	*ipnet = *newIPNet
+
+	return nil
+}
+
+// ParseCIDR creates an IPNet out of a CIDR string
+func ParseCIDR(s string) (*IPNet, error) {
+	ip, ipnet, err := net.ParseCIDR(s)
+	if err != nil {
+		return nil, err
+	}
+
+	return &IPNet{
+		IPNet: net.IPNet{
+			IP:   ip,
+			Mask: ipnet.Mask,
+		},
+	}, nil
+}
+
 type Options struct {
 	// Should the test start in a paused state?
 	Paused null.Bool `json:"paused" envconfig:"paused"`
@@ -258,7 +295,7 @@ type Options struct {
 	Thresholds map[string]stats.Thresholds `json:"thresholds" envconfig:"thresholds"`
 
 	// Blacklist IP ranges that tests may not contact. Mainly useful in hosted setups.
-	BlacklistIPs []*net.IPNet `json:"blacklistIPs" envconfig:"blacklist_ips"`
+	BlacklistIPs []*IPNet `json:"blacklistIPs" envconfig:"blacklist_ips"`
 
 	// Hosts overrides dns entries for given hosts
 	Hosts map[string]net.IP `json:"hosts" envconfig:"hosts"`

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -309,10 +309,8 @@ func TestOptions(t *testing.T) {
 	t.Run("BlacklistIPs", func(t *testing.T) {
 		opts := Options{}.Apply(Options{
 			BlacklistIPs: []*IPNet{{
-				net.IPNet{
-					IP:   net.IPv4zero,
-					Mask: net.CIDRMask(1, 1),
-				},
+				IP:   net.IPv4zero,
+				Mask: net.CIDRMask(1, 1),
 			}},
 		})
 		assert.NotNil(t, opts.BlacklistIPs)
@@ -525,18 +523,18 @@ func TestCIDRUnmarshal(t *testing.T) {
 	}{
 		{
 			"10.0.0.0/8",
-			&IPNet{IPNet: net.IPNet{
+			&IPNet{
 				IP:   net.IP{10, 0, 0, 0},
 				Mask: net.IPv4Mask(255, 0, 0, 0),
-			}},
+			},
 			false,
 		},
 		{
 			"fc00:1234:5678::/48",
-			&IPNet{IPNet: net.IPNet{
+			&IPNet{
 				IP:   net.ParseIP("fc00:1234:5678::"),
 				Mask: net.CIDRMask(48, 128),
-			}},
+			},
 			false,
 		},
 		{"10.0.0.0", nil, true},
@@ -548,7 +546,7 @@ func TestCIDRUnmarshal(t *testing.T) {
 		data := data
 		t.Run(data.input, func(t *testing.T) {
 			actualIPNet := &IPNet{}
-			err := actualIPNet.UnmarshalJSON([]byte("\"" + data.input + "\""))
+			err := actualIPNet.UnmarshalText([]byte(data.input))
 
 			if data.expactFailure {
 				require.EqualError(t, err, "Failed to parse CIDR: invalid CIDR address: "+data.input)

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -308,9 +308,11 @@ func TestOptions(t *testing.T) {
 	})
 	t.Run("BlacklistIPs", func(t *testing.T) {
 		opts := Options{}.Apply(Options{
-			BlacklistIPs: []*net.IPNet{{
-				IP:   net.IPv4zero,
-				Mask: net.CIDRMask(1, 1),
+			BlacklistIPs: []*IPNet{{
+				net.IPNet{
+					IP:   net.IPv4zero,
+					Mask: net.CIDRMask(1, 1),
+				},
 			}},
 		})
 		assert.NotNil(t, opts.BlacklistIPs)
@@ -511,5 +513,30 @@ func TestTagSetTextUnmarshal(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, (map[string]bool)(*set), expected)
+	}
+}
+
+func TestCIDRUnmarshal(t *testing.T) {
+
+	var testData = []struct {
+		input    string
+		expected *IPNet
+	}{
+		{"10.0.0.0/8", &IPNet{IPNet: net.IPNet{
+			IP:   net.ParseIP("10.0.0.0"),
+			Mask: net.IPv4Mask(255, 0, 0, 0),
+		}}},
+		{"fc00:1234:5678::/48", &IPNet{IPNet: net.IPNet{
+			IP:   net.ParseIP("fc00:1234:5678::"),
+			Mask: net.CIDRMask(48, 128),
+		}}},
+	}
+
+	for _, data := range testData {
+		actualIPNet := &IPNet{}
+		err := actualIPNet.UnmarshalJSON([]byte("\"" + data.input + "\""))
+		require.NoError(t, err)
+
+		assert.Equal(t, data.expected, actualIPNet)
 	}
 }

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -526,7 +526,7 @@ func TestCIDRUnmarshal(t *testing.T) {
 		{
 			"10.0.0.0/8",
 			&IPNet{IPNet: net.IPNet{
-				IP:   net.ParseIP("10.0.0.0"),
+				IP:   net.IP{10, 0, 0, 0},
 				Mask: net.IPv4Mask(255, 0, 0, 0),
 			}},
 			false,


### PR DESCRIPTION
Net.IPNet does not support JSON unmarshalling, causing the blacklistIPs
configuration to fail when set through JS.
Fixed by wrapping net.IPNet for the purpose of JSON unmarshalling.

Fixes #973