### PR TITLE
Reuse the parsed core-js library across VUs

### DIFF
--- a/js/lib/lib.go
+++ b/js/lib/lib.go
@@ -23,14 +23,26 @@
 package lib
 
 import (
+	"sync"
+
 	"github.com/GeertJohan/go.rice"
 	"github.com/dop251/goja"
 )
 
+//nolint:gochecknoglobals
+var (
+	once   sync.Once
+	coreJs *goja.Program
+)
+
 func GetCoreJS() *goja.Program {
-	return goja.MustCompile(
-		"core-js/shim.min.js",
-		rice.MustFindBox("core-js").MustString("shim.min.js"),
-		true,
-	)
+	once.Do(func() {
+		coreJs = goja.MustCompile(
+			"core-js/shim.min.js",
+			rice.MustFindBox("core-js").MustString("shim.min.js"),
+			true,
+		)
+	})
+
+	return coreJs
 }

--- a/release notes/upcoming.md
+++ b/release notes/upcoming.md
@@ -15,3 +15,7 @@ Now all http methods have an additional param called `compression` that will mak
   - windows: work with paths starting with `/` or `\` as absolute from the current drive
 
 * JS: Correctly always set `response.url` to be the URL that was ultimately fetched (i.e. after any potential redirects), even if there were non http errors. (#990)
+
+## Internals
+
+* JS: VU initialization time and memory usage has been significantly decreased by caching the parsed version of the core-js library. Thanks, @matlockx! (#1038)


### PR DESCRIPTION
This PR caches the [`*goja.Program`](https://godoc.org/github.com/dop251/goja#Program) result from parsing the core-js library so we can reuse it across VUs. Thanks to [@matlockx for suggesting this](https://github.com/loadimpact/k6/issues/1036#issuecomment-497720581), despite my attempts to misunderstand it :blush: 

Brief performance comparisons on my laptop between this code and k6 v0.24.0 show an over **2x reduction of VU memory usage and initialization times** when running the 2000 VU/empty script test from the [StackOverflow question](https://stackoverflow.com/questions/56389653/k6-memory-consumption-per-vu/56395832) that started this whole investigation!