### PR TITLE
Fix a bunch of HTTP measurement and handling issues

### DIFF
--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -1756,7 +1756,7 @@ func BenchmarkHandlingOfResponseBodies(b *testing.B) {
 	`)
 
 	testResponseType := func(responseType string) func(b *testing.B) {
-		testCode := strings.ReplaceAll(testCodeTemplate, "TEST_RESPONSE_TYPE", responseType)
+		testCode := strings.Replace(testCodeTemplate, "TEST_RESPONSE_TYPE", responseType, -1)
 		return func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, err := common.RunString(rt, testCode)

--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -162,9 +162,90 @@ func compressBody(algos []CompressionType, body io.ReadCloser) (io.Reader, int64
 	return buf, int64(buf.Len()), contentEncoding, body.Close()
 }
 
+func readResponseBody(
+	state *lib.State, respType ResponseType, resp *http.Response, respErr error,
+) (interface{}, error) {
+
+	if resp == nil || respErr != nil {
+		return nil, respErr
+	}
+
+	// Transperently decompress the body if it's has a content-encoding we
+	// support. If not, simply return it as it is.
+	contentEncoding := strings.TrimSpace(resp.Header.Get("Content-Encoding"))
+	if compression, err := CompressionTypeString(contentEncoding); err == nil {
+		switch compression {
+		case CompressionTypeDeflate:
+			resp.Body, respErr = zlib.NewReader(resp.Body)
+		case CompressionTypeGzip:
+			resp.Body, respErr = gzip.NewReader(resp.Body)
+		default:
+			// We have not implemented a compression ... :(
+			respErr = fmt.Errorf(
+				"unsupported compression type %s for decompression - this is a bug in k6, please report it",
+				compression,
+			)
+		}
+	}
+
+	if respType == ResponseTypeNone {
+		_, err := io.Copy(ioutil.Discard, resp.Body)
+		_ = resp.Body.Close()
+		if err != nil && err != io.EOF {
+			respErr = err
+		}
+		return nil, respErr
+	}
+
+	buf := state.BPool.Get()
+	buf.Reset()
+	_, err := io.Copy(buf, resp.Body)
+	_ = resp.Body.Close()
+	if err != nil && err != io.EOF {
+		respErr = err
+	}
+
+	var result interface{}
+	// Binary or string
+	switch respType {
+	case ResponseTypeText:
+		result = buf.String()
+		state.BPool.Put(buf)
+	case ResponseTypeBinary:
+		result = buf.Bytes()
+		// We don't return the buffer to the pool, because the byte
+		// slice could still point to its underlying slice.
+	default:
+		respErr = fmt.Errorf("unknown responseType %s", respType)
+		state.BPool.Put(buf)
+	}
+
+	return result, respErr
+}
+
+func updateK6Response(k6Response *Response, finishedReq *finishedRequest) {
+	k6Response.ErrorCode = int(finishedReq.errorCode)
+	k6Response.Error = finishedReq.errorMsg
+	trail := finishedReq.trcerTrail
+
+	if trail.ConnRemoteAddr != nil {
+		remoteHost, remotePortStr, _ := net.SplitHostPort(trail.ConnRemoteAddr.String())
+		remotePort, _ := strconv.Atoi(remotePortStr)
+		k6Response.RemoteIP = remoteHost
+		k6Response.RemotePort = remotePort
+	}
+	k6Response.Timings = ResponseTimings{
+		Duration:       stats.D(trail.Duration),
+		Blocked:        stats.D(trail.Blocked),
+		Connecting:     stats.D(trail.Connecting),
+		TLSHandshaking: stats.D(trail.TLSHandshaking),
+		Sending:        stats.D(trail.Sending),
+		Waiting:        stats.D(trail.Waiting),
+		Receiving:      stats.D(trail.Receiving),
+	}
+}
+
 // MakeRequest makes http request for tor the provided ParsedHTTPRequest
-//TODO break this function up
-//nolint: gocyclo
 func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error) {
 	state := lib.GetState(ctx)
 
@@ -248,7 +329,7 @@ func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error
 		}
 	}
 
-	tracerTransport := newTransport(state.Transport, state.Samples, &state.Options, tags)
+	tracerTransport := newTransport(state, tags)
 	var transport http.RoundTripper = tracerTransport
 	if preq.Auth == "ntlm" {
 		transport = ntlmssp.Negotiator{
@@ -293,6 +374,7 @@ func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error
 	// if digest authentication option is passed, make an initial request
 	// to get the authentication params to compute the authorization header
 	if preq.Auth == "digest" {
+		// TODO: refactor this as a separate transport, like how NTLM auth works
 		username := preq.URL.u.User.Username()
 		password, _ := preq.URL.u.User.Password()
 
@@ -301,15 +383,20 @@ func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error
 
 		debugRequest(state, preq.Req, "DigestRequest")
 		res, err := client.Do(preq.Req.WithContext(ctx))
-		debugRequest(state, preq.Req, "DigestResponse")
-		resp.Error = tracerTransport.errorMsg
-		resp.ErrorCode = int(tracerTransport.errorCode)
+		debugResponse(state, res, "DigestResponse")
+		body, err := readResponseBody(state, ResponseTypeText, res, err)
+		finishedReq := tracerTransport.processLastSavedRequest()
+		if finishedReq != nil {
+			resp.ErrorCode = int(finishedReq.errorCode)
+			resp.Error = finishedReq.errorMsg
+		}
+
 		if err != nil {
 			// Do *not* log errors about the contex being cancelled.
 			select {
 			case <-ctx.Done():
 			default:
-				state.Logger.WithField("error", res).Warn("Digest request failed")
+				state.Logger.WithField("error", err).Warn("Digest request failed")
 			}
 
 			// In case we have an error but resp.Error is not set it means the error is not from
@@ -322,84 +409,24 @@ func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error
 		}
 
 		if res.StatusCode == http.StatusUnauthorized {
-			body := ""
-			if b, err := ioutil.ReadAll(res.Body); err == nil {
-				body = string(b)
-			}
-
 			challenge := digest.GetChallengeFromHeader(&res.Header)
-			challenge.ComputeResponse(preq.Req.Method, preq.Req.URL.RequestURI(), body, username, password)
+			challenge.ComputeResponse(preq.Req.Method, preq.Req.URL.RequestURI(), body.(string), username, password)
 			authorization := challenge.ToAuthorizationStr()
 			preq.Req.Header.Set(digest.KEY_AUTHORIZATION, authorization)
 		}
+		// TODO: fix - this is very broken! we're always making 2 HTTP requests
+		// when digest authentication is enabled...
 	}
 
 	debugRequest(state, preq.Req, "Request")
-	res, resErr := client.Do(preq.Req.WithContext(ctx))
+	mreq := preq.Req.WithContext(ctx)
+	res, resErr := client.Do(mreq)
 	debugResponse(state, res, "Response")
-	resp.Error = tracerTransport.errorMsg
-	resp.ErrorCode = int(tracerTransport.errorCode)
-	if resErr == nil && res != nil {
-		compression, err := CompressionTypeString(strings.TrimSpace(res.Header.Get("Content-Encoding")))
-		if err == nil { // in case of error we just won't uncompress
-			switch compression {
-			case CompressionTypeDeflate:
-				res.Body, resErr = zlib.NewReader(res.Body)
-			case CompressionTypeGzip:
-				res.Body, resErr = gzip.NewReader(res.Body)
-			default:
-				// We have not implemented a compression ... :(
-				resErr = fmt.Errorf(
-					"unsupported compressionType %s for uncompression. This is a bug in k6 please report it",
-					compression)
-			}
-		}
-	}
-	if resErr == nil && res != nil {
-		if preq.ResponseType == ResponseTypeNone {
-			_, err := io.Copy(ioutil.Discard, res.Body)
-			if err != nil && err != io.EOF {
-				resErr = err
-			}
-			resp.Body = nil
-		} else {
-			// Binary or string
-			buf := state.BPool.Get()
-			buf.Reset()
-			defer state.BPool.Put(buf)
-			_, err := io.Copy(buf, res.Body)
-			if err != nil && err != io.EOF {
-				resErr = err
-			}
 
-			switch preq.ResponseType {
-			case ResponseTypeText:
-				resp.Body = buf.String()
-			case ResponseTypeBinary:
-				resp.Body = buf.Bytes()
-			default:
-				resErr = fmt.Errorf("unknown responseType %s", preq.ResponseType)
-			}
-		}
-		_ = res.Body.Close()
-	}
-
-	trail := tracerTransport.GetTrail()
-
-	if trail.ConnRemoteAddr != nil {
-		remoteHost, remotePortStr, _ := net.SplitHostPort(trail.ConnRemoteAddr.String())
-		remotePort, _ := strconv.Atoi(remotePortStr)
-		resp.RemoteIP = remoteHost
-		resp.RemotePort = remotePort
-	}
-	resp.Timings = ResponseTimings{
-		Duration:       stats.D(trail.Duration),
-		Blocked:        stats.D(trail.Blocked),
-		Connecting:     stats.D(trail.Connecting),
-		TLSHandshaking: stats.D(trail.TLSHandshaking),
-		Sending:        stats.D(trail.Sending),
-		Waiting:        stats.D(trail.Waiting),
-		Receiving:      stats.D(trail.Receiving),
+	resp.Body, resErr = readResponseBody(state, preq.ResponseType, res, resErr)
+	finishedReq := tracerTransport.processLastSavedRequest()
+	if finishedReq != nil {
+		updateK6Response(resp, finishedReq)
 	}
 
 	if resErr == nil {

--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -202,7 +202,7 @@ func readResponseBody(
 	buf.Reset()
 	_, err := io.Copy(buf, resp.Body)
 	_ = resp.Body.Close()
-	if err != nil && err != io.EOF {
+	if err != nil {
 		respErr = err
 	}
 

--- a/lib/netext/httpext/tracer.go
+++ b/lib/netext/httpext/tracer.go
@@ -325,10 +325,17 @@ func (t *Tracer) Done() *Trail {
 			trail.Sending = time.Duration(wroteRequest - gotConn)
 		}
 
-		if gotFirstResponseByte != 0 && gotFirstResponseByte > wroteRequest {
-			// For some requests, especially HTTP/2, the server starts responding before the
-			// client has finished sending the full request
-			trail.Waiting = time.Duration(gotFirstResponseByte - wroteRequest)
+		if gotFirstResponseByte != 0 {
+			// We started receiving at least some response back
+
+			if gotFirstResponseByte > wroteRequest {
+				// For some requests, especially HTTP/2, the server starts responding before the
+				// client has finished sending the full request
+				trail.Waiting = time.Duration(gotFirstResponseByte - wroteRequest)
+			}
+		} else {
+			// The server never responded to our request
+			trail.Waiting = done.Sub(time.Unix(0, wroteRequest))
 		}
 	}
 	if gotFirstResponseByte != 0 {

--- a/lib/netext/httpext/transport.go
+++ b/lib/netext/httpext/transport.go
@@ -59,10 +59,10 @@ type unfinishedRequest struct {
 // processLastSavedRequest(), after reading the HTTP response body.
 type finishedRequest struct {
 	*unfinishedRequest
-	trcerTrail *Trail
-	tlsInfo    netext.TLSInfo
-	errorCode  errCode
-	errorMsg   string
+	trail     *Trail
+	tlsInfo   netext.TLSInfo
+	errorCode errCode
+	errorMsg  string
 }
 
 var _ http.RoundTripper = &transport{}
@@ -92,7 +92,7 @@ func (t *transport) measureAndEmitMetrics(unfReq *unfinishedRequest) *finishedRe
 
 	result := &finishedRequest{
 		unfinishedRequest: unfReq,
-		trcerTrail:        trail,
+		trail:             trail,
 	}
 
 	enabledTags := t.state.Options.SystemTags

--- a/lib/testutils/httpmultibin.go
+++ b/lib/testutils/httpmultibin.go
@@ -22,6 +22,7 @@
 package testutils
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -84,6 +85,7 @@ type HTTPMultiBin struct {
 	TLSClientConfig *tls.Config
 	Dialer          *netext.Dialer
 	HTTPTransport   *http.Transport
+	Context         context.Context
 	Cleanup         func()
 }
 
@@ -155,6 +157,7 @@ func NewHTTPMultiBin(t testing.TB) *HTTPMultiBin {
 	}
 	require.NoError(t, http2.ConfigureTransport(transport))
 
+	ctx, ctxCancel := context.WithCancel(context.Background())
 	return &HTTPMultiBin{
 		Mux:         mux,
 		ServerHTTP:  httpSrv,
@@ -174,9 +177,11 @@ func NewHTTPMultiBin(t testing.TB) *HTTPMultiBin {
 		TLSClientConfig: tlsConfig,
 		Dialer:          dialer,
 		HTTPTransport:   transport,
+		Context:         ctx,
 		Cleanup: func() {
 			httpsSrv.Close()
 			httpSrv.Close()
+			ctxCancel()
 		},
 	}
 }


### PR DESCRIPTION
This should fix https://github.com/loadimpact/k6/issues/1041, fix https://github.com/loadimpact/k6/issues/1044, fix https://github.com/loadimpact/k6/issues/925, and also fix a potential minor data race in the `httpext.Tracer`! Hopefully, without introducing new bugs or performance regressions...

While investigating this, I realized that we should up the priority of fixing the HTTP digest authentication: https://github.com/loadimpact/k6/issues/800