### PR TITLE
Fix the execution derivation bug and work around the k6 0.24.0 wrong tar metadata

### DIFF
--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -76,7 +76,7 @@ An archive is a fully self-contained test run, and can be executed identically e
 			return err
 		}
 
-		if cerr := validateConfig(conf); cerr != nil {
+		if _, cerr := deriveAndValidateConfig(conf); cerr != nil {
 			return ExitCode{cerr, invalidConfigErrorCode}
 		}
 

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/consts"
 	"github.com/loadimpact/k6/stats/cloud"
 	"github.com/loadimpact/k6/ui"
 	"github.com/pkg/errors"
@@ -56,7 +57,7 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 	Args: exactArgsWithMsg(1, "arg should either be \"-\", if reading script from stdin, or a path to a script file"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		//TODO: disable in quiet mode?
-		_, _ = BannerColor.Fprintf(stdout, "\n%s\n\n", Banner)
+		_, _ = BannerColor.Fprintf(stdout, "\n%s\n\n", consts.Banner)
 		initBar := ui.ProgressBar{
 			Width: 60,
 			Left:  func() string { return "    uploading script" },
@@ -161,7 +162,7 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 		}
 
 		// Start cloud test run
-		client := cloud.NewClient(cloudConfig.Token.String, cloudConfig.Host.String, Version)
+		client := cloud.NewClient(cloudConfig.Token.String, cloudConfig.Host.String, consts.Version)
 		if err := client.ValidateOptions(arc.Options); err != nil {
 			return err
 		}

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -96,7 +96,8 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 			return err
 		}
 
-		if cerr := validateConfig(conf); cerr != nil {
+		derivedConf, cerr := deriveAndValidateConfig(conf)
+		if cerr != nil {
 			return ExitCode{cerr, invalidConfigErrorCode}
 		}
 
@@ -106,7 +107,7 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 		}
 
 		// Cloud config
-		cloudConfig := cloud.NewConfig().Apply(conf.Collectors.Cloud)
+		cloudConfig := cloud.NewConfig().Apply(derivedConf.Collectors.Cloud)
 		if err := envconfig.Process("k6", &cloudConfig); err != nil {
 			return err
 		}

--- a/cmd/collectors.go
+++ b/cmd/collectors.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/consts"
 	"github.com/loadimpact/k6/stats/cloud"
 	"github.com/loadimpact/k6/stats/datadog"
 	"github.com/loadimpact/k6/stats/influxdb"
@@ -84,7 +85,7 @@ func newCollector(collectorName, arg string, src *lib.SourceData, conf Config) (
 			if arg != "" {
 				config.Name = null.StringFrom(arg)
 			}
-			return cloud.New(config, src, conf.Options, Version)
+			return cloud.New(config, src, conf.Options, consts.Version)
 		case collectorKafka:
 			config := kafka.NewConfig().Apply(conf.Collectors.Kafka)
 			if err := envconfig.Process("k6", &config); err != nil {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"errors"
@@ -32,6 +33,7 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/lib/scheduler"
+	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/stats/cloud"
 	"github.com/loadimpact/k6/stats/datadog"
 	"github.com/loadimpact/k6/stats/influxdb"
@@ -187,9 +189,49 @@ func (e executionConflictConfigError) Error() string {
 
 var _ error = executionConflictConfigError("")
 
+func getConstantLoopingVUsExecution(duration types.NullDuration, vus null.Int) scheduler.ConfigMap {
+	ds := scheduler.NewConstantLoopingVUsConfig(lib.DefaultSchedulerName)
+	ds.VUs = vus
+	ds.Duration = duration
+	return scheduler.ConfigMap{lib.DefaultSchedulerName: ds}
+}
+
+func getVariableLoopingVUsExecution(stages []lib.Stage, startVUs null.Int) scheduler.ConfigMap {
+	ds := scheduler.NewVariableLoopingVUsConfig(lib.DefaultSchedulerName)
+	ds.StartVUs = startVUs
+	for _, s := range stages {
+		if s.Duration.Valid {
+			ds.Stages = append(ds.Stages, scheduler.Stage{Duration: s.Duration, Target: s.Target})
+		}
+	}
+	return scheduler.ConfigMap{lib.DefaultSchedulerName: ds}
+}
+
+func getSharedIterationsExecution(iterations null.Int, vus null.Int) scheduler.ConfigMap {
+	ds := scheduler.NewSharedIterationsConfig(lib.DefaultSchedulerName)
+	ds.VUs = vus
+	ds.Iterations = iterations
+	return scheduler.ConfigMap{lib.DefaultSchedulerName: ds}
+}
+
+func checkExecutionMismatch(observedExecution, derivedExecution scheduler.ConfigMap, shortcutField string) error {
+	if observedExecution == nil {
+		return nil
+	}
+
+	// Work around the v0.24.0 archive metadata.js options that wrongly contain execution
+	if !reflect.DeepEqual(observedExecution, derivedExecution) {
+		errMsg := fmt.Sprintf("specifying both `%s` and `execution` is not supported", shortcutField)
+		return executionConflictConfigError(errMsg)
+	}
+
+	log.Warnf("ignoring the specified `execution` options because they match the ones derived from `%s`", shortcutField)
+	return nil
+}
+
 // This checks for conflicting options and turns any shortcut options (i.e. duration, iterations,
 // stages) into the proper scheduler configuration
-func buildExecutionConfig(conf Config) (Config, error) {
+func deriveExecutionConfig(conf Config) (Config, error) {
 	result := conf
 	switch {
 	case conf.Duration.Valid:
@@ -203,19 +245,16 @@ func buildExecutionConfig(conf Config) (Config, error) {
 			log.Warnf("Specifying both duration and stages is deprecated and won't be supported in the future k6 versions")
 		}
 
-		if conf.Execution != nil {
-			return result, executionConflictConfigError("specifying both duration and execution is not supported")
+		derivedExecConfig := getConstantLoopingVUsExecution(conf.Duration, conf.VUs)
+		if err := checkExecutionMismatch(conf.Execution, derivedExecConfig, "duration"); err != nil {
+			return conf, err
 		}
 
 		if conf.Duration.Duration <= 0 {
 			//TODO: make this an executionConflictConfigError in the next version
 			log.Warnf("Specifying infinite duration in this way is deprecated and won't be supported in the future k6 versions")
 		} else {
-			ds := scheduler.NewConstantLoopingVUsConfig(lib.DefaultSchedulerName)
-			ds.VUs = conf.VUs
-			ds.Duration = conf.Duration
-			ds.Interruptible = null.NewBool(true, false) // Preserve backwards compatibility
-			result.Execution = scheduler.ConfigMap{lib.DefaultSchedulerName: ds}
+			result.Execution = derivedExecConfig
 		}
 
 	case len(conf.Stages) > 0: // stages isn't nil (not set) and isn't explicitly set to empty
@@ -224,30 +263,17 @@ func buildExecutionConfig(conf Config) (Config, error) {
 			log.Warnf("Specifying both iterations and stages is deprecated and won't be supported in the future k6 versions")
 		}
 
-		if conf.Execution != nil {
-			return conf, executionConflictConfigError("specifying both stages and execution is not supported")
+		result.Execution = getVariableLoopingVUsExecution(conf.Stages, conf.VUs)
+		if err := checkExecutionMismatch(conf.Execution, result.Execution, "stages"); err != nil {
+			return conf, err
 		}
-
-		ds := scheduler.NewVariableLoopingVUsConfig(lib.DefaultSchedulerName)
-		ds.StartVUs = conf.VUs
-		for _, s := range conf.Stages {
-			if s.Duration.Valid {
-				ds.Stages = append(ds.Stages, scheduler.Stage{Duration: s.Duration, Target: s.Target})
-			}
-		}
-		ds.Interruptible = null.NewBool(true, false) // Preserve backwards compatibility
-		result.Execution = scheduler.ConfigMap{lib.DefaultSchedulerName: ds}
 
 	case conf.Iterations.Valid:
-		if conf.Execution != nil {
-			return conf, executionConflictConfigError("specifying both iterations and execution is not supported")
+		result.Execution = getSharedIterationsExecution(conf.Iterations, conf.VUs)
+		if err := checkExecutionMismatch(conf.Execution, result.Execution, "iterations"); err != nil {
+			return conf, err
 		}
 		// TODO: maybe add a new flag that will be used as a shortcut to per-VU iterations?
-
-		ds := scheduler.NewSharedIterationsConfig(lib.DefaultSchedulerName)
-		ds.VUs = conf.VUs
-		ds.Iterations = conf.Iterations
-		result.Execution = scheduler.ConfigMap{lib.DefaultSchedulerName: ds}
 
 	default:
 		if conf.Execution != nil { // If someone set this, regardless if its empty
@@ -302,7 +328,15 @@ func getConsolidatedConfig(fs afero.Fs, cliConf Config, runner lib.Runner) (conf
 	}
 	conf = conf.Apply(envConf).Apply(cliConf)
 
-	return buildExecutionConfig(conf)
+	return conf, nil
+}
+
+func deriveAndValidateConfig(conf Config) (Config, error) {
+	result, err := deriveExecutionConfig(conf)
+	if err != nil {
+		return result, err
+	}
+	return result, validateConfig(conf)
 }
 
 //TODO: remove ↓

--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -25,6 +25,7 @@ import (
 
 	"gopkg.in/guregu/null.v3"
 
+	"github.com/loadimpact/k6/lib/consts"
 	"github.com/loadimpact/k6/stats/cloud"
 	"github.com/loadimpact/k6/ui"
 	"github.com/pkg/errors"
@@ -95,7 +96,7 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 			email := vals["Email"].(string)
 			password := vals["Password"].(string)
 
-			client := cloud.NewClient("", k6Conf.Collectors.Cloud.Host.String, Version)
+			client := cloud.NewClient("", k6Conf.Collectors.Cloud.Host.String, consts.Version)
 			res, err := client.Login(email, password)
 			if err != nil {
 				return err

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/consts"
 	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/stats"
 	"github.com/loadimpact/k6/ui"
@@ -53,7 +54,7 @@ func optionFlagSet() *pflag.FlagSet {
 	flags.Int64("batch", 20, "max parallel batch reqs")
 	flags.Int64("batch-per-host", 20, "max parallel batch reqs per host")
 	flags.Int64("rps", 0, "limit requests per second")
-	flags.String("user-agent", fmt.Sprintf("k6/%s (https://k6.io/)", Version), "user agent for http requests")
+	flags.String("user-agent", fmt.Sprintf("k6/%s (https://k6.io/)", consts.Version), "user agent for http requests")
 	flags.String("http-debug", "", "log all HTTP requests and responses. Excludes body by default. To include body use '--http-debug=full'")
 	flags.Lookup("http-debug").NoOptDefVal = "headers"
 	flags.Bool("insecure-skip-tls-verify", false, "skip verification of TLS certificates")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,10 +26,10 @@ import (
 	golog "log"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 
 	"github.com/fatih/color"
+	"github.com/loadimpact/k6/lib/consts"
 	"github.com/mattn/go-colorable"
 	"github.com/mattn/go-isatty"
 	"github.com/shibukawa/configdir"
@@ -38,20 +38,6 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// Version contains the current semantic version of k6.
-//nolint:gochecknoglobals
-var Version = "0.24.0"
-
-// Banner contains the ASCII-art banner with the k6 logo and stylized website URL
-//TODO: make these into methods, only the version needs to be a variable
-//nolint:gochecknoglobals
-var Banner = strings.Join([]string{
-	`          /\      |‾‾|  /‾‾/  /‾/   `,
-	`     /\  /  \     |  |_/  /  / /    `,
-	`    /  \/    \    |      |  /  ‾‾\  `,
-	`   /          \   |  |‾\  \ | (_) | `,
-	`  / __________ \  |__|  \__\ \___/ .io`,
-}, "\n")
 var BannerColor = color.New(color.FgCyan)
 
 var (
@@ -83,7 +69,7 @@ var (
 var RootCmd = &cobra.Command{
 	Use:           "k6",
 	Short:         "a next-generation load generator",
-	Long:          BannerColor.Sprintf("\n%s", Banner),
+	Long:          BannerColor.Sprintf("\n%s", consts.Banner),
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -173,7 +173,8 @@ a commandline interface for interacting with it.`,
 			conf.Duration = types.NullDuration{}
 		}
 
-		if cerr := validateConfig(conf); cerr != nil {
+		conf, cerr := deriveAndValidateConfig(conf)
+		if cerr != nil {
 			return ExitCode{cerr, invalidConfigErrorCode}
 		}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -42,6 +42,7 @@ import (
 	"github.com/loadimpact/k6/core/local"
 	"github.com/loadimpact/k6/js"
 	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/consts"
 	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/loader"
 	"github.com/loadimpact/k6/ui"
@@ -101,7 +102,7 @@ a commandline interface for interacting with it.`,
 	Args: exactArgsWithMsg(1, "arg should either be \"-\", if reading script from stdin, or a path to a script file"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		//TODO: disable in quiet mode?
-		_, _ = BannerColor.Fprintf(stdout, "\n%s\n\n", Banner)
+		_, _ = BannerColor.Fprintf(stdout, "\n%s\n\n", consts.Banner)
 
 		initBar := ui.ProgressBar{
 			Width: 60,
@@ -304,7 +305,7 @@ a commandline interface for interacting with it.`,
 					stagesEndTSeconds = time.Duration(stagesEndT.Duration).Seconds()
 				}
 				body, err := json.Marshal(map[string]interface{}{
-					"k6_version":  Version,
+					"k6_version":  consts.Version,
 					"vus_max":     engine.Executor.GetVUsMax(),
 					"iterations":  engine.Executor.GetEndIterations(),
 					"duration":    endTSeconds,

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -23,6 +23,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/loadimpact/k6/lib/consts"
 	"github.com/spf13/cobra"
 )
 
@@ -32,7 +33,7 @@ var versionCmd = &cobra.Command{
 	Short: "Show application version",
 	Long:  `Show the application version and exit.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("k6 v" + Version)
+		fmt.Println("k6 v" + consts.Version)
 	},
 }
 

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -25,6 +25,8 @@ import (
 	"encoding/json"
 	"os"
 
+	"github.com/loadimpact/k6/lib/consts"
+
 	"github.com/dop251/goja"
 	"github.com/loadimpact/k6/js/common"
 	"github.com/loadimpact/k6/js/compiler"
@@ -174,13 +176,14 @@ func NewBundleFromArchive(arc *lib.Archive, rtOpts lib.RuntimeOptions) (*Bundle,
 
 func (b *Bundle) makeArchive() *lib.Archive {
 	arc := &lib.Archive{
-		Type:     "js",
-		FS:       afero.NewMemMapFs(),
-		Options:  b.Options,
-		Filename: b.Filename,
-		Data:     []byte(b.Source),
-		Pwd:      b.BaseInitContext.pwd,
-		Env:      make(map[string]string, len(b.Env)),
+		Type:      "js",
+		FS:        afero.NewMemMapFs(),
+		Options:   b.Options,
+		Filename:  b.Filename,
+		Data:      []byte(b.Source),
+		Pwd:       b.BaseInitContext.pwd,
+		Env:       make(map[string]string, len(b.Env)),
+		K6Version: consts.Version,
 	}
 	// Copy env so changes in the archive are not reflected in the source Bundle
 	for k, v := range b.Env {

--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -31,6 +31,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/loadimpact/k6/lib/consts"
+
 	"github.com/dop251/goja"
 	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/lib/types"
@@ -392,6 +394,7 @@ func TestNewBundleFromArchive(t *testing.T) {
 	assert.Equal(t, `export default function(s) { return s + "!" };`, string(arc.Scripts["/path/to/exclaim.js"]))
 	assert.Len(t, arc.Files, 1)
 	assert.Equal(t, `hi`, string(arc.Files["/path/to/file.txt"]))
+	assert.Equal(t, consts.Version, arc.K6Version)
 
 	b2, err := NewBundleFromArchive(arc, lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {

--- a/lib/archive.go
+++ b/lib/archive.go
@@ -90,6 +90,8 @@ type Archive struct {
 
 	// Environment variables
 	Env map[string]string `json:"env"`
+
+	K6Version string `json:"k6version"`
 }
 
 // Reads an archive created by Archive.Write from a reader.

--- a/lib/consts/consts.go
+++ b/lib/consts/consts.go
@@ -1,0 +1,20 @@
+package consts
+
+import (
+	"strings"
+)
+
+// Version contains the current semantic version of k6.
+//nolint:gochecknoglobals
+var Version = "0.24.0"
+
+// Banner contains the ASCII-art banner with the k6 logo and stylized website URL
+//TODO: make these into methods, only the version needs to be a variable
+//nolint:gochecknoglobals
+var Banner = strings.Join([]string{
+	`          /\      |‾‾|  /‾‾/  /‾/   `,
+	`     /\  /  \     |  |_/  /  / /    `,
+	`    /  \/    \    |      |  /  ‾‾\  `,
+	`   /          \   |  |‾\  \ | (_) | `,
+	`  / __________ \  |__|  \__\ \___/ .io`,
+}, "\n")


### PR DESCRIPTION
This includes two minor improvements + refactoring and a bugfix:
- Include the k6 version in the tar archives' metadata.json 
- Do not include the derived execution options in tar archives
  
  Also, since those options were included by k6 v0.24.0, only emit a warning instead of an error if the derived execution options match any `execution` options that are "specified" by the user, since at that level we can't distinguish if we're executing an archive or a script...

-  Allow simultaneous use of `duration` and `iterations` execution shortcuts
  
    This would just produce a shared-iterations scheduler with the specified number of iterations and a `maxDuration` equal to the passed `duration`, similar to how it works in the current k6 execution. This should fix #1058.