### PR TITLE
Add output option for csv format

### DIFF
--- a/cmd/collectors.go
+++ b/cmd/collectors.go
@@ -30,6 +30,7 @@ import (
 	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/lib/consts"
 	"github.com/loadimpact/k6/stats/cloud"
+	"github.com/loadimpact/k6/stats/csv"
 	"github.com/loadimpact/k6/stats/datadog"
 	"github.com/loadimpact/k6/stats/influxdb"
 	jsonc "github.com/loadimpact/k6/stats/json"
@@ -47,6 +48,7 @@ const (
 	collectorCloud    = "cloud"
 	collectorStatsD   = "statsd"
 	collectorDatadog  = "datadog"
+	collectorCSV      = "csv"
 )
 
 func parseCollector(s string) (t, arg string) {
@@ -111,6 +113,8 @@ func newCollector(collectorName, arg string, src *lib.SourceData, conf Config) (
 				return nil, err
 			}
 			return datadog.New(config)
+		case collectorCSV:
+			return csv.New(afero.NewOsFs(), arg, conf.SystemTags)
 		default:
 			return nil, errors.Errorf("unknown output type: %s", collectorName)
 		}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -35,6 +35,7 @@ import (
 	"github.com/loadimpact/k6/lib/scheduler"
 	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/stats/cloud"
+	"github.com/loadimpact/k6/stats/csv"
 	"github.com/loadimpact/k6/stats/datadog"
 	"github.com/loadimpact/k6/stats/influxdb"
 	"github.com/loadimpact/k6/stats/kafka"
@@ -72,6 +73,7 @@ type Config struct {
 		Cloud    cloud.Config    `json:"cloud"`
 		StatsD   common.Config   `json:"statsd"`
 		Datadog  datadog.Config  `json:"datadog"`
+		CSV      csv.Config      `json:"csv"`
 	} `json:"collectors"`
 }
 
@@ -97,6 +99,7 @@ func (c Config) Apply(cfg Config) Config {
 	c.Collectors.Kafka = c.Collectors.Kafka.Apply(cfg.Collectors.Kafka)
 	c.Collectors.StatsD = c.Collectors.StatsD.Apply(cfg.Collectors.StatsD)
 	c.Collectors.Datadog = c.Collectors.Datadog.Apply(cfg.Collectors.Datadog)
+	c.Collectors.CSV = c.Collectors.CSV.Apply(cfg.Collectors.CSV)
 	return c
 }
 

--- a/stats/csv/collector.go
+++ b/stats/csv/collector.go
@@ -86,7 +86,7 @@ func New(fs afero.Fs, tags lib.TagSet, config Config) (*Collector, error) {
 			resTags:      resTags,
 			ignoredTags:  ignoredTags,
 			csvWriter:    csv.NewWriter(logfile),
-			row:          make([]string, 3+len(resTags)+1, 3+len(resTags)+1),
+			row:          make([]string, 3+len(resTags)+1),
 			saveInterval: saveInterval,
 		}, nil
 	}
@@ -102,7 +102,7 @@ func New(fs afero.Fs, tags lib.TagSet, config Config) (*Collector, error) {
 		resTags:      resTags,
 		ignoredTags:  ignoredTags,
 		csvWriter:    csv.NewWriter(logfile),
-		row:          make([]string, 3+len(resTags)+1, 3+len(resTags)+1),
+		row:          make([]string, 3+len(resTags)+1),
 		saveInterval: saveInterval,
 	}, nil
 }

--- a/stats/csv/collector.go
+++ b/stats/csv/collector.go
@@ -161,13 +161,11 @@ func (c *Collector) WriteToFile() {
 		for _, sc := range samples {
 			for _, sample := range sc.GetSamples() {
 				sample := sample
-				if &sample != nil {
-					row := c.row[:0]
-					row = SampleToRow(&sample, c.resTags, c.ignoredTags, row)
-					err := c.csvWriter.Write(row)
-					if err != nil {
-						logrus.WithField("filename", c.fname).Error("CSV: Error writing to file")
-					}
+				row := c.row[:0]
+				row = SampleToRow(&sample, c.resTags, c.ignoredTags, row)
+				err := c.csvWriter.Write(row)
+				if err != nil {
+					logrus.WithField("filename", c.fname).Error("CSV: Error writing to file")
 				}
 			}
 		}

--- a/stats/csv/collector.go
+++ b/stats/csv/collector.go
@@ -1,0 +1,145 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2016 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package csv
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/stats"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+)
+
+type Collector struct {
+	outfile io.WriteCloser
+	fname   string
+	restags []string
+	header  bool
+}
+
+// Verify that Collector implements lib.Collector
+var _ lib.Collector = &Collector{}
+
+// Similar to ioutil.NopCloser, but for writers
+type nopCloser struct {
+	io.Writer
+}
+
+func (nopCloser) Close() error { return nil }
+
+func New(fs afero.Fs, fname string, tags lib.TagSet) (*Collector, error) {
+	if fname == "" || fname == "-" {
+		return &Collector{
+			outfile: nopCloser{os.Stdout},
+			fname:   "-",
+		}, nil
+	}
+
+	logfile, err := fs.Create(fname)
+	if err != nil {
+		return nil, err
+	}
+
+	restags := []string{}
+	for tag, flag := range tags {
+		if flag {
+			restags = append(restags, tag)
+		}
+	}
+
+	return &Collector{
+		outfile: logfile,
+		fname:   fname,
+		restags: restags,
+		header:  true,
+	}, nil
+}
+
+func (c *Collector) Init() error {
+	return nil
+}
+
+func (c *Collector) SetRunStatus(status lib.RunStatus) {}
+
+func (c *Collector) Run(ctx context.Context) {
+	log.WithField("filename", c.fname).Debug("CSV: Writing CSV metrics")
+	<-ctx.Done()
+	_ = c.outfile.Close()
+}
+
+func (c *Collector) Collect(scs []stats.SampleContainer) {
+	if c.header {
+		header := MakeHeader(c.restags)
+		c.WriteToCSV(header)
+		c.header = false
+	}
+	for _, sc := range scs {
+		for _, sample := range sc.GetSamples() {
+			row := SampleToRow(&sample, c.restags)
+			c.WriteToCSV(row)
+		}
+	}
+}
+
+func (c *Collector) Link() string {
+	return ""
+}
+
+func (c *Collector) WriteToCSV(row []string) {
+	writer := csv.NewWriter(c.outfile)
+	defer writer.Flush()
+	err := writer.Write(row)
+	if err != nil {
+		log.WithField("filename", c.fname).Error("CSV: Error writing to file")
+	}
+}
+
+func MakeHeader(tags []string) []string {
+	return append([]string{"metric_name", "timestamp", "metric_value"}, tags...)
+}
+
+func SampleToRow(sample *stats.Sample, restags []string) []string {
+	if sample == nil {
+		return nil
+	}
+
+	row := []string{}
+	row = append(row, sample.Metric.Name)
+	row = append(row, fmt.Sprintf("%d", sample.Time.Unix()))
+	row = append(row, fmt.Sprintf("%f", sample.Value))
+	sample_tags := sample.Tags.CloneTags()
+
+	for _, tag := range restags {
+		row = append(row, sample_tags[tag])
+	}
+
+	return row
+}
+
+// GetRequiredSystemTags returns which sample tags are needed by this collector
+func (c *Collector) GetRequiredSystemTags() lib.TagSet {
+	return lib.TagSet{} // There are no required tags for this collector
+}

--- a/stats/csv/collector.go
+++ b/stats/csv/collector.go
@@ -154,12 +154,13 @@ func (c *Collector) WriteToFile() {
 		defer c.csvLock.Unlock()
 		for _, sc := range samples {
 			for _, sample := range sc.GetSamples() {
-				sample := sample
-				row := SampleToRow(&sample, c.resTags, c.ignoredTags)
-				err := c.csvWriter.Write(row)
-				if err != nil {
-					log.WithField("filename", c.fname).Error("CSV: Error writing to file")
-				}
+				func(sample stats.Sample) {
+					row := SampleToRow(&sample, c.resTags, c.ignoredTags)
+					err := c.csvWriter.Write(row)
+					if err != nil {
+						log.WithField("filename", c.fname).Error("CSV: Error writing to file")
+					}
+				}(sample)
 			}
 		}
 		c.csvWriter.Flush()

--- a/stats/csv/collector.go
+++ b/stats/csv/collector.go
@@ -226,16 +226,10 @@ func SampleToRow(sample *stats.Sample, resTags []string, ignoredTags []string, r
 
 // IsStringInSlice returns whether the string is contained within a string slice
 func IsStringInSlice(slice []string, str string) bool {
-	if sort.SearchStrings(slice, str) == len(slice) {
+	if index := sort.SearchStrings(slice, str); index == len(slice) || slice[index] != str {
 		return false
 	}
-
-	for _, item := range slice {
-		if item == str {
-			return true
-		}
-	}
-	return false
+	return true
 }
 
 // GetRequiredSystemTags returns which sample tags are needed by this collector

--- a/stats/csv/collector.go
+++ b/stats/csv/collector.go
@@ -198,23 +198,22 @@ func SampleToRow(sample *stats.Sample, resTags []string, ignoredTags []string, r
 	extraTags := bytes.Buffer{}
 	prev := false
 	for tag, val := range sampleTags {
-		if sort.SearchStrings(resTags, tag) == len(resTags) && sort.SearchStrings(ignoredTags, tag) == len(ignoredTags) {
+		if !IsStringInSlice(resTags, tag) && !IsStringInSlice(ignoredTags, tag) {
 			if prev {
-				_, err := extraTags.WriteString("&")
-				if err != nil {
+				if _, err := extraTags.WriteString("&"); err != nil {
 					break
 				}
 			}
-			_, err := extraTags.WriteString(tag)
-			if err != nil {
+
+			if _, err := extraTags.WriteString(tag); err != nil {
 				break
 			}
-			_, err = extraTags.WriteString("=")
-			if err != nil {
+
+			if _, err := extraTags.WriteString("="); err != nil {
 				break
 			}
-			_, err = extraTags.WriteString(val)
-			if err != nil {
+
+			if _, err := extraTags.WriteString(val); err != nil {
 				break
 			}
 			prev = true
@@ -223,6 +222,20 @@ func SampleToRow(sample *stats.Sample, resTags []string, ignoredTags []string, r
 	row = append(row, extraTags.String())
 
 	return row
+}
+
+// IsStringInSlice returns whether the string is contained within a string slice
+func IsStringInSlice(slice []string, str string) bool {
+	if sort.SearchStrings(slice, str) == len(slice) {
+		return false
+	}
+
+	for _, item := range slice {
+		if item == str {
+			return true
+		}
+	}
+	return false
 }
 
 // GetRequiredSystemTags returns which sample tags are needed by this collector

--- a/stats/csv/collector_test.go
+++ b/stats/csv/collector_test.go
@@ -170,7 +170,7 @@ func TestSampleToRow(t *testing.T) {
 		expectedRow := expected[i]
 
 		t.Run(testname, func(t *testing.T) {
-			row := SampleToRow(sample, resTags, ignoredTags, make([]string, 3+len(resTags)+1, 3+len(resTags)+1))
+			row := SampleToRow(sample, resTags, ignoredTags, make([]string, 3+len(resTags)+1))
 			for ind, cell := range expectedRow.baseRow {
 				assert.Equal(t, cell, row[ind])
 			}

--- a/stats/csv/collector_test.go
+++ b/stats/csv/collector_test.go
@@ -1,0 +1,153 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2016 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package csv
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/loadimpact/k6/stats"
+
+	"github.com/loadimpact/k6/lib"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeHeader(t *testing.T) {
+	testdata := map[string][]string{
+		"One tag": []string{
+			"tag1",
+		},
+		"Two tags": []string{
+			"tag1", "tag2",
+		},
+	}
+
+	for testname, tags := range testdata {
+		t.Run(testname, func(t *testing.T) {
+			header := MakeHeader(tags)
+			assert.Equal(t, len(tags)+4, len(header))
+			assert.Equal(t, "metric_name", header[0])
+			assert.Equal(t, "timestamp", header[1])
+			assert.Equal(t, "metric_value", header[2])
+			assert.Equal(t, "extra_tags", header[len(header)-1])
+		})
+	}
+}
+
+func TestSampleToRow(t *testing.T) {
+	testSamples := []stats.Sample{
+		stats.Sample{
+			Time:   time.Now(),
+			Metric: stats.New("my_metric", stats.Gauge),
+			Value:  1,
+			Tags: stats.NewSampleTags(map[string]string{
+				"tag1": "val1",
+				"tag2": "val2",
+				"tag3": "val3",
+			}),
+		},
+		stats.Sample{
+			Time:   time.Now(),
+			Metric: stats.New("my_metric", stats.Gauge),
+			Value:  1,
+			Tags: stats.NewSampleTags(map[string]string{
+				"tag1": "val1",
+				"tag2": "val2",
+				"tag3": "val3",
+				"tag4": "val4",
+				"tag5": "val5",
+			}),
+		},
+	}
+
+	enabledTags := map[string][][]string{
+		"One tag": [][]string{
+			[]string{"tag1"},
+			[]string{"tag2"},
+		},
+		"Two tags": [][]string{
+			[]string{"tag1", "tag2"},
+			[]string{},
+		},
+		"Two tags, one ignored": [][]string{
+			[]string{"tag1", "tag2"},
+			[]string{"tag3"},
+		},
+	}
+
+	for testname, tags := range enabledTags {
+		for _, sample := range testSamples {
+			t.Run(testname, func(t *testing.T) {
+				row := SampleToRow(&sample, tags[0], tags[1])
+				assert.Equal(t, len(tags[0])+4, len(row))
+				for _, tag := range tags[1] {
+					assert.False(t, strings.Contains(row[len(row)-1], tag))
+				}
+			})
+		}
+	}
+}
+
+func TestCollect(t *testing.T) {
+	testSamples := []stats.SampleContainer{
+		stats.Sample{
+			Time:   time.Unix(1562324643, 0),
+			Metric: stats.New("my_metric", stats.Gauge),
+			Value:  1,
+			Tags: stats.NewSampleTags(map[string]string{
+				"tag1": "val1",
+				"tag2": "val2",
+				"tag3": "val3",
+			}),
+		},
+		stats.Sample{
+			Time:   time.Unix(1562324644, 0),
+			Metric: stats.New("my_metric", stats.Gauge),
+			Value:  1,
+			Tags: stats.NewSampleTags(map[string]string{
+				"tag1": "val1",
+				"tag2": "val2",
+				"tag3": "val3",
+				"tag4": "val4",
+			}),
+		},
+	}
+
+	t.Run("Collect", func(t *testing.T) {
+		mem := afero.NewMemMapFs()
+		collector, err := New(mem, "path", lib.TagSet{"tag1": true, "tag2": false, "tag3": true})
+		assert.NoError(t, err)
+		assert.NotNil(t, collector)
+
+		err = collector.Init()
+		assert.NoError(t, err)
+
+		collector.Collect(testSamples)
+		csvbytes, _ := afero.ReadFile(mem, "path")
+		csvstr := fmt.Sprintf("%s", csvbytes)
+		assert.Equal(t,
+			"metric_name,timestamp,metric_value,tag1,tag3,extra_tags\nmy_metric,1562324643,1.000000,val1,val3,\nmy_metric,1562324644,1.000000,val1,val3,tag4=val4\n",
+			csvstr)
+	})
+}

--- a/stats/csv/collector_test.go
+++ b/stats/csv/collector_test.go
@@ -71,7 +71,7 @@ func TestSampleToRow(t *testing.T) {
 		{
 			testname: "One res tag, one ignored tag, one extra tag",
 			sample: &stats.Sample{
-				Time:   time.Now(),
+				Time:   time.Unix(1562324644, 0),
 				Metric: stats.New("my_metric", stats.Gauge),
 				Value:  1,
 				Tags: stats.NewSampleTags(map[string]string{
@@ -86,7 +86,7 @@ func TestSampleToRow(t *testing.T) {
 		{
 			testname: "Two res tags, three extra tags",
 			sample: &stats.Sample{
-				Time:   time.Now(),
+				Time:   time.Unix(1562324644, 0),
 				Metric: stats.New("my_metric", stats.Gauge),
 				Value:  1,
 				Tags: stats.NewSampleTags(map[string]string{
@@ -103,7 +103,7 @@ func TestSampleToRow(t *testing.T) {
 		{
 			testname: "Two res tags, two ignored",
 			sample: &stats.Sample{
-				Time:   time.Now(),
+				Time:   time.Unix(1562324644, 0),
 				Metric: stats.New("my_metric", stats.Gauge),
 				Value:  1,
 				Tags: stats.NewSampleTags(map[string]string{
@@ -127,7 +127,7 @@ func TestSampleToRow(t *testing.T) {
 		{
 			baseRow: []string{
 				"my_metric",
-				fmt.Sprintf("%d", time.Now().Unix()),
+				"1562324644",
 				"1.000000",
 				"val1",
 			},
@@ -138,7 +138,7 @@ func TestSampleToRow(t *testing.T) {
 		{
 			baseRow: []string{
 				"my_metric",
-				fmt.Sprintf("%d", time.Now().Unix()),
+				"1562324644",
 				"1.000000",
 				"val1",
 				"val2",
@@ -152,7 +152,7 @@ func TestSampleToRow(t *testing.T) {
 		{
 			baseRow: []string{
 				"my_metric",
-				fmt.Sprintf("%d", time.Now().Unix()),
+				"1562324644",
 				"1.000000",
 				"val1",
 				"val3",

--- a/stats/csv/collector_test.go
+++ b/stats/csv/collector_test.go
@@ -46,8 +46,8 @@ func TestMakeHeader(t *testing.T) {
 	}
 
 	for testname, tags := range testdata {
+		tags := tags
 		t.Run(testname, func(t *testing.T) {
-			tags := tags
 			header := MakeHeader(tags)
 			assert.Equal(t, len(tags)+4, len(header))
 			assert.Equal(t, "metric_name", header[0])
@@ -103,8 +103,8 @@ func TestSampleToRow(t *testing.T) {
 		eTags := tags[0]
 		iTags := tags[1]
 		for _, sample := range testSamples {
+			sample := sample
 			t.Run(testname, func(t *testing.T) {
-				sample := sample
 				row := SampleToRow(&sample, eTags, iTags)
 				assert.Equal(t, len(eTags)+4, len(row))
 				for _, tag := range iTags {

--- a/stats/csv/collector_test.go
+++ b/stats/csv/collector_test.go
@@ -104,8 +104,10 @@ func TestSampleToRow(t *testing.T) {
 	}
 
 	for testname, tags := range enabledTags {
+		testname := testname
+		resTags, ignoredTags := tags[0], tags[1]
 		for _, sample := range testSamples {
-			testname, sample, resTags, ignoredTags := testname, sample, tags[0], tags[1]
+			sample := sample
 			t.Run(testname, func(t *testing.T) {
 				row := SampleToRow(sample, resTags, ignoredTags, make([]string, 0, 3+len(resTags)+1))
 				if row != nil {
@@ -147,7 +149,11 @@ func TestCollect(t *testing.T) {
 	}
 
 	mem := afero.NewMemMapFs()
-	collector, err := New(mem, lib.TagSet{"tag1": true, "tag2": false, "tag3": true}, Config{FileName: null.StringFrom("name"), SaveInterval: types.NewNullDuration(time.Duration(1), true)})
+	collector, err := New(
+		mem,
+		lib.TagSet{"tag1": true, "tag2": false, "tag3": true},
+		Config{FileName: null.StringFrom("name"), SaveInterval: types.NewNullDuration(time.Duration(1), true)},
+	)
 	assert.NoError(t, err)
 	assert.NotNil(t, collector)
 
@@ -157,7 +163,11 @@ func TestCollect(t *testing.T) {
 }
 
 func TestRun(t *testing.T) {
-	collector, err := New(afero.NewMemMapFs(), lib.TagSet{"tag1": true, "tag2": false, "tag3": true}, Config{FileName: null.StringFrom("name"), SaveInterval: types.NewNullDuration(time.Duration(1), true)})
+	collector, err := New(
+		afero.NewMemMapFs(),
+		lib.TagSet{"tag1": true, "tag2": false, "tag3": true},
+		Config{FileName: null.StringFrom("name"), SaveInterval: types.NewNullDuration(time.Duration(1), true)},
+	)
 	assert.NoError(t, err)
 	assert.NotNil(t, collector)
 
@@ -200,7 +210,11 @@ func TestRunCollect(t *testing.T) {
 	}
 
 	mem := afero.NewMemMapFs()
-	collector, err := New(mem, lib.TagSet{"tag1": true, "tag2": false, "tag3": true}, Config{FileName: null.StringFrom("path"), SaveInterval: types.NewNullDuration(time.Duration(1), true)})
+	collector, err := New(
+		mem,
+		lib.TagSet{"tag1": true, "tag2": false, "tag3": true},
+		Config{FileName: null.StringFrom("path"), SaveInterval: types.NewNullDuration(time.Duration(1), true)},
+	)
 	assert.NoError(t, err)
 	assert.NotNil(t, collector)
 
@@ -301,14 +315,22 @@ func TestNew(t *testing.T) {
 }
 
 func TestGetRequiredSystemTags(t *testing.T) {
-	collector, err := New(afero.NewMemMapFs(), lib.TagSet{"tag1": true, "tag2": false, "tag3": true}, Config{FileName: null.StringFrom("name"), SaveInterval: types.NewNullDuration(time.Duration(1), true)})
+	collector, err := New(
+		afero.NewMemMapFs(),
+		lib.TagSet{"tag1": true, "tag2": false, "tag3": true},
+		Config{FileName: null.StringFrom("name"), SaveInterval: types.NewNullDuration(time.Duration(1), true)},
+	)
 	assert.NoError(t, err)
 	assert.NotNil(t, collector)
 	assert.Equal(t, lib.TagSet{}, collector.GetRequiredSystemTags())
 }
 
 func TestLink(t *testing.T) {
-	collector, err := New(afero.NewMemMapFs(), lib.TagSet{"tag1": true, "tag2": false, "tag3": true}, Config{FileName: null.StringFrom("path"), SaveInterval: types.NewNullDuration(time.Duration(1), true)})
+	collector, err := New(
+		afero.NewMemMapFs(),
+		lib.TagSet{"tag1": true, "tag2": false, "tag3": true},
+		Config{FileName: null.StringFrom("path"), SaveInterval: types.NewNullDuration(time.Duration(1), true)},
+	)
 	assert.NoError(t, err)
 	assert.NotNil(t, collector)
 	assert.Equal(t, "path", collector.Link())

--- a/stats/csv/collector_test.go
+++ b/stats/csv/collector_test.go
@@ -29,6 +29,9 @@ import (
 	"testing"
 	"time"
 
+	"gopkg.in/guregu/null.v3"
+
+	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/stats"
 
 	"github.com/loadimpact/k6/lib"
@@ -144,7 +147,7 @@ func TestCollect(t *testing.T) {
 	}
 
 	mem := afero.NewMemMapFs()
-	collector, err := New(mem, "path", lib.TagSet{"tag1": true, "tag2": false, "tag3": true})
+	collector, err := New(mem, lib.TagSet{"tag1": true, "tag2": false, "tag3": true}, Config{FileName: null.StringFrom("name"), SaveInterval: types.NewNullDuration(time.Duration(1), true)})
 	assert.NoError(t, err)
 	assert.NotNil(t, collector)
 
@@ -154,7 +157,7 @@ func TestCollect(t *testing.T) {
 }
 
 func TestRun(t *testing.T) {
-	collector, err := New(afero.NewMemMapFs(), "path", lib.TagSet{"tag1": true, "tag2": false, "tag3": true})
+	collector, err := New(afero.NewMemMapFs(), lib.TagSet{"tag1": true, "tag2": false, "tag3": true}, Config{FileName: null.StringFrom("name"), SaveInterval: types.NewNullDuration(time.Duration(1), true)})
 	assert.NoError(t, err)
 	assert.NotNil(t, collector)
 
@@ -197,7 +200,7 @@ func TestRunCollect(t *testing.T) {
 	}
 
 	mem := afero.NewMemMapFs()
-	collector, err := New(mem, "path", lib.TagSet{"tag1": true, "tag2": false, "tag3": true})
+	collector, err := New(mem, lib.TagSet{"tag1": true, "tag2": false, "tag3": true}, Config{FileName: null.StringFrom("path"), SaveInterval: types.NewNullDuration(time.Duration(1), true)})
 	assert.NoError(t, err)
 	assert.NotNil(t, collector)
 
@@ -225,11 +228,11 @@ func TestRunCollect(t *testing.T) {
 
 func TestNew(t *testing.T) {
 	configs := []struct {
-		fname string
-		tags  lib.TagSet
+		cfg  Config
+		tags lib.TagSet
 	}{
 		{
-			fname: "name",
+			cfg: Config{FileName: null.StringFrom("name"), SaveInterval: types.NewNullDuration(time.Duration(1), true)},
 			tags: lib.TagSet{
 				"tag1": true,
 				"tag2": false,
@@ -237,13 +240,13 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
-			fname: "-",
+			cfg: Config{FileName: null.StringFrom("-"), SaveInterval: types.NewNullDuration(time.Duration(1), true)},
 			tags: lib.TagSet{
 				"tag1": true,
 			},
 		},
 		{
-			fname: "",
+			cfg: Config{FileName: null.StringFrom(""), SaveInterval: types.NewNullDuration(time.Duration(1), true)},
 			tags: lib.TagSet{
 				"tag1": false,
 				"tag2": false,
@@ -282,8 +285,8 @@ func TestNew(t *testing.T) {
 
 	for i := range configs {
 		config, expected := configs[i], expected[i]
-		t.Run(config.fname, func(t *testing.T) {
-			collector, err := New(afero.NewMemMapFs(), config.fname, config.tags)
+		t.Run(config.cfg.FileName.String, func(t *testing.T) {
+			collector, err := New(afero.NewMemMapFs(), config.tags, config.cfg)
 			assert.NoError(t, err)
 			assert.NotNil(t, collector)
 			assert.Equal(t, expected.fname, collector.fname)
@@ -298,14 +301,14 @@ func TestNew(t *testing.T) {
 }
 
 func TestGetRequiredSystemTags(t *testing.T) {
-	collector, err := New(afero.NewMemMapFs(), "path", lib.TagSet{"tag1": true, "tag2": false, "tag3": true})
+	collector, err := New(afero.NewMemMapFs(), lib.TagSet{"tag1": true, "tag2": false, "tag3": true}, Config{FileName: null.StringFrom("name"), SaveInterval: types.NewNullDuration(time.Duration(1), true)})
 	assert.NoError(t, err)
 	assert.NotNil(t, collector)
 	assert.Equal(t, lib.TagSet{}, collector.GetRequiredSystemTags())
 }
 
 func TestLink(t *testing.T) {
-	collector, err := New(afero.NewMemMapFs(), "path", lib.TagSet{"tag1": true, "tag2": false, "tag3": true})
+	collector, err := New(afero.NewMemMapFs(), lib.TagSet{"tag1": true, "tag2": false, "tag3": true}, Config{FileName: null.StringFrom("path"), SaveInterval: types.NewNullDuration(time.Duration(1), true)})
 	assert.NoError(t, err)
 	assert.NotNil(t, collector)
 	assert.Equal(t, "path", collector.Link())

--- a/stats/csv/collector_test.go
+++ b/stats/csv/collector_test.go
@@ -217,7 +217,9 @@ func TestRunCollect(t *testing.T) {
 		csvbytes, _ := afero.ReadFile(mem, "path")
 		csvstr := fmt.Sprintf("%s", csvbytes)
 		assert.Equal(t,
-			"metric_name,timestamp,metric_value,tag1,tag3,extra_tags\nmy_metric,1562324643,1.000000,val1,val3,\nmy_metric,1562324644,1.000000,val1,val3,tag4=val4\n",
+			"metric_name,timestamp,metric_value,tag1,tag3,extra_tags\n"+
+				"my_metric,1562324643,1.000000,val1,val3,\n"+
+				"my_metric,1562324644,1.000000,val1,val3,tag4=val4\n",
 			csvstr)
 	})
 }

--- a/stats/csv/collector_test.go
+++ b/stats/csv/collector_test.go
@@ -23,6 +23,7 @@ package csv
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -301,7 +302,11 @@ func TestNew(t *testing.T) {
 				assert.NoError(t, err)
 				assert.NotNil(t, collector)
 				assert.Equal(t, expected.fname, collector.fname)
+				sort.Strings(expected.resTags)
+				sort.Strings(collector.resTags)
 				assert.Equal(t, expected.resTags, collector.resTags)
+				sort.Strings(expected.ignoredTags)
+				sort.Strings(collector.ignoredTags)
 				assert.Equal(t, expected.ignoredTags, collector.ignoredTags)
 			})
 		}(configs[i], expected[i])

--- a/stats/csv/collector_test.go
+++ b/stats/csv/collector_test.go
@@ -170,7 +170,7 @@ func TestSampleToRow(t *testing.T) {
 		expectedRow := expected[i]
 
 		t.Run(testname, func(t *testing.T) {
-			row := SampleToRow(sample, resTags, ignoredTags, make([]string, 0, 3+len(resTags)+1))
+			row := SampleToRow(sample, resTags, ignoredTags, make([]string, 3+len(resTags)+1, 3+len(resTags)+1))
 			for ind, cell := range expectedRow.baseRow {
 				assert.Equal(t, cell, row[ind])
 			}

--- a/stats/csv/collector_test.go
+++ b/stats/csv/collector_test.go
@@ -46,15 +46,16 @@ func TestMakeHeader(t *testing.T) {
 	}
 
 	for testname, tags := range testdata {
-		tags := tags
-		t.Run(testname, func(t *testing.T) {
-			header := MakeHeader(tags)
-			assert.Equal(t, len(tags)+4, len(header))
-			assert.Equal(t, "metric_name", header[0])
-			assert.Equal(t, "timestamp", header[1])
-			assert.Equal(t, "metric_value", header[2])
-			assert.Equal(t, "extra_tags", header[len(header)-1])
-		})
+		func(testname string, tags []string) {
+			t.Run(testname, func(t *testing.T) {
+				header := MakeHeader(tags)
+				assert.Equal(t, len(tags)+4, len(header))
+				assert.Equal(t, "metric_name", header[0])
+				assert.Equal(t, "timestamp", header[1])
+				assert.Equal(t, "metric_value", header[2])
+				assert.Equal(t, "extra_tags", header[len(header)-1])
+			})
+		}(testname, tags)
 	}
 }
 
@@ -100,17 +101,16 @@ func TestSampleToRow(t *testing.T) {
 	}
 
 	for testname, tags := range enabledTags {
-		eTags := tags[0]
-		iTags := tags[1]
 		for _, sample := range testSamples {
-			sample := sample
-			t.Run(testname, func(t *testing.T) {
-				row := SampleToRow(&sample, eTags, iTags)
-				assert.Equal(t, len(eTags)+4, len(row))
-				for _, tag := range iTags {
-					assert.False(t, strings.Contains(row[len(row)-1], tag))
-				}
-			})
+			func(testname string, sample stats.Sample, resTags []string, ignoredTags []string) {
+				t.Run(testname, func(t *testing.T) {
+					row := SampleToRow(&sample, resTags, ignoredTags)
+					assert.Equal(t, len(resTags)+4, len(row))
+					for _, tag := range ignoredTags {
+						assert.False(t, strings.Contains(row[len(row)-1], tag))
+					}
+				})
+			}(testname, sample, tags[0], tags[1])
 		}
 	}
 }

--- a/stats/csv/collector_test.go
+++ b/stats/csv/collector_test.go
@@ -47,6 +47,7 @@ func TestMakeHeader(t *testing.T) {
 
 	for testname, tags := range testdata {
 		t.Run(testname, func(t *testing.T) {
+			tags := tags
 			header := MakeHeader(tags)
 			assert.Equal(t, len(tags)+4, len(header))
 			assert.Equal(t, "metric_name", header[0])
@@ -99,11 +100,14 @@ func TestSampleToRow(t *testing.T) {
 	}
 
 	for testname, tags := range enabledTags {
+		eTags := tags[0]
+		iTags := tags[1]
 		for _, sample := range testSamples {
 			t.Run(testname, func(t *testing.T) {
-				row := SampleToRow(&sample, tags[0], tags[1])
-				assert.Equal(t, len(tags[0])+4, len(row))
-				for _, tag := range tags[1] {
+				sample := sample
+				row := SampleToRow(&sample, eTags, iTags)
+				assert.Equal(t, len(eTags)+4, len(row))
+				for _, tag := range iTags {
 					assert.False(t, strings.Contains(row[len(row)-1], tag))
 				}
 			})
@@ -157,7 +161,8 @@ func TestRun(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			collector.Init()
+			err := collector.Init()
+			assert.NoError(t, err)
 			collector.Run(ctx)
 		}()
 		cancel()
@@ -203,7 +208,8 @@ func TestRunCollect(t *testing.T) {
 			collector.Run(ctx)
 			wg.Done()
 		}()
-		collector.Init()
+		err = collector.Init()
+		assert.NoError(t, err)
 		collector.Collect(testSamples)
 		time.Sleep(1 * time.Second)
 		cancel()

--- a/stats/csv/config.go
+++ b/stats/csv/config.go
@@ -1,0 +1,97 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2016 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package csv
+
+import (
+	"strings"
+	"time"
+
+	"github.com/kubernetes/helm/pkg/strvals"
+	"github.com/loadimpact/k6/lib/types"
+	"github.com/mitchellh/mapstructure"
+	"gopkg.in/guregu/null.v3"
+)
+
+// Config is the config for the csv collector
+type Config struct {
+	// Samples.
+	FileName     null.String        `json:"file_name" envconfig:"CSV_FILENAME"`
+	SaveInterval types.NullDuration `json:"save_interval" envconfig:"CSV_SAVE_INTERVAL"`
+}
+
+// config is a duplicate of ConfigFields as we can not mapstructure.Decode into
+// null types so we duplicate the struct with primitive types to Decode into
+type config struct {
+	FileName     string `json:"file_name" mapstructure:"file_name" envconfig:"CSV_FILENAME"`
+	SaveInterval string `json:"save_interval" mapstructure:"save_interval" envconfig:"CSV_SAVE_INTERVAL"`
+}
+
+// NewConfig creates a new Config instance with default values for some fields.
+func NewConfig() Config {
+	return Config{
+		FileName:     null.StringFrom("file.csv"),
+		SaveInterval: types.NullDurationFrom(1 * time.Second),
+	}
+}
+
+func (c Config) Apply(cfg Config) Config {
+	if cfg.FileName.Valid {
+		c.FileName = cfg.FileName
+	}
+	if cfg.SaveInterval.Valid {
+		c.SaveInterval = cfg.SaveInterval
+	}
+	return c
+}
+
+// ParseArg takes an arg string and converts it to a config
+func ParseArg(arg string) (Config, error) {
+	c := Config{}
+
+	if !strings.Contains(arg, "=") {
+		c.FileName = null.StringFrom(arg)
+		c.SaveInterval = types.NullDurationFrom(1 * time.Second)
+		return c, nil
+	}
+
+	params, err := strvals.Parse(arg)
+
+	if err != nil {
+		return c, err
+	}
+
+	if v, ok := params["save_interval"].(string); ok {
+		err := c.SaveInterval.UnmarshalText([]byte(v))
+		if err != nil {
+			return c, err
+		}
+	}
+
+	var cfg config
+	err = mapstructure.Decode(params, &cfg)
+	if err != nil {
+		return c, err
+	}
+
+	c.FileName = null.StringFrom(cfg.FileName)
+
+	return c, nil
+}

--- a/stats/csv/config.go
+++ b/stats/csv/config.go
@@ -52,6 +52,7 @@ func NewConfig() Config {
 	}
 }
 
+// Apply merges two configs by overwriting properties in the old config
 func (c Config) Apply(cfg Config) Config {
 	if cfg.FileName.Valid {
 		c.FileName = cfg.FileName
@@ -79,7 +80,7 @@ func ParseArg(arg string) (Config, error) {
 	}
 
 	if v, ok := params["save_interval"].(string); ok {
-		err := c.SaveInterval.UnmarshalText([]byte(v))
+		err = c.SaveInterval.UnmarshalText([]byte(v))
 		if err != nil {
 			return c, err
 		}

--- a/stats/csv/config_test.go
+++ b/stats/csv/config_test.go
@@ -1,0 +1,106 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2016 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package csv
+
+import (
+	"testing"
+	"time"
+
+	"gopkg.in/guregu/null.v3"
+
+	"github.com/loadimpact/k6/lib/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewConfig(t *testing.T) {
+	config := NewConfig()
+	assert.Equal(t, "file.csv", config.FileName.String)
+	assert.Equal(t, "1s", config.SaveInterval.String())
+}
+
+func TestApply(t *testing.T) {
+	configs := []Config{
+		Config{
+			FileName:     null.StringFrom(""),
+			SaveInterval: types.NullDurationFrom(2 * time.Second),
+		},
+		Config{
+			FileName:     null.StringFrom("newPath"),
+			SaveInterval: types.NewNullDuration(time.Duration(1), false),
+		},
+	}
+	expected := []struct {
+		FileName     string
+		SaveInterval string
+	}{
+		{
+			FileName:     "",
+			SaveInterval: "2s",
+		},
+		{
+			FileName:     "newPath",
+			SaveInterval: "1s",
+		},
+	}
+
+	for i := range configs {
+		config := configs[i]
+		expected := expected[i]
+		t.Run(expected.FileName+"_"+expected.SaveInterval, func(t *testing.T) {
+			baseConfig := NewConfig()
+			baseConfig = baseConfig.Apply(config)
+
+			assert.Equal(t, expected.FileName, baseConfig.FileName.String)
+			assert.Equal(t, expected.SaveInterval, baseConfig.SaveInterval.String())
+		})
+	}
+}
+
+func TestParseArg(t *testing.T) {
+	args := []string{
+		"test_file.csv",
+		"file_name=test.csv,save_interval=5s",
+	}
+
+	expected := []Config{
+		Config{
+			FileName:     null.StringFrom("test_file.csv"),
+			SaveInterval: types.NullDurationFrom(1 * time.Second),
+		},
+		Config{
+			FileName:     null.StringFrom("test.csv"),
+			SaveInterval: types.NullDurationFrom(5 * time.Second),
+		},
+	}
+
+	for i := range args {
+		arg := args[i]
+		expected := expected[i]
+
+		t.Run(expected.FileName.String+"_"+expected.SaveInterval.String(), func(t *testing.T) {
+			config, err := ParseArg(arg)
+
+			assert.Nil(t, err)
+			assert.Equal(t, expected.FileName.String, config.FileName.String)
+			assert.Equal(t, expected.SaveInterval.String(), config.SaveInterval.String())
+		})
+	}
+}

--- a/stats/csv/config_test.go
+++ b/stats/csv/config_test.go
@@ -38,11 +38,11 @@ func TestNewConfig(t *testing.T) {
 
 func TestApply(t *testing.T) {
 	configs := []Config{
-		Config{
+		{
 			FileName:     null.StringFrom(""),
 			SaveInterval: types.NullDurationFrom(2 * time.Second),
 		},
-		Config{
+		{
 			FileName:     null.StringFrom("newPath"),
 			SaveInterval: types.NewNullDuration(time.Duration(1), false),
 		},
@@ -81,11 +81,11 @@ func TestParseArg(t *testing.T) {
 	}
 
 	expected := []Config{
-		Config{
+		{
 			FileName:     null.StringFrom("test_file.csv"),
 			SaveInterval: types.NullDurationFrom(1 * time.Second),
 		},
-		Config{
+		{
 			FileName:     null.StringFrom("test.csv"),
 			SaveInterval: types.NullDurationFrom(5 * time.Second),
 		},


### PR DESCRIPTION
Hi, I've noticed that json output takes up a lot of disk space for long running tests. I've found this issue #321, the csv output option was discussed there and I've decided to implement it. It works similar to json output, writing one sample per row. It uses twice as less space than json, so I've decided to open a pull request for it.

Maybe someone can suggest a way, how to transform the samples, so it would be one line per http request. Then I will make the changes and reopen the pull request.

I'm new to Go language, so I'm open to criticism. 