### PR TITLE
Disable the execution mismatch check, but keep the other warnings

### DIFF
--- a/cmd/config_consolidation_test.go
+++ b/cmd/config_consolidation_test.go
@@ -380,30 +380,12 @@ func getConfigConsolidationTestCases() []configConsolidationTestCase {
 								"duration": "60s"
 							}
 						},
-						"vus": 20,
-						"duration": "60s"
-					}`,
-				),
-			},
-			exp{derivationError: true}, nil,
-		},
-		{
-			opts{
-				fs: defaultConfig(`
-					{
-						"execution": {
-							"default": {
-								"type": "constant-looping-vus",
-								"vus": 10,
-								"duration": "60s"
-							}
-						},
 						"vus": 10,
 						"duration": "60s"
 					}`,
 				),
 			},
-			exp{logWarning: true}, verifyConstLoopingVUs(I(10), 60*time.Second),
+			exp{}, verifyConstLoopingVUs(I(10), 60*time.Second),
 		},
 		// Just in case, verify that no options will result in the same 1 vu 1 iter config
 		{opts{}, exp{}, verifyOneIterPerOneVU},


### PR DESCRIPTION
Full description of the issue and rationale for the change can be found here: https://github.com/loadimpact/k6/pull/1007#issuecomment-509586983