### PR TITLE
Fix handling cli options default value

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -298,8 +298,20 @@ func getConsolidatedConfig(fs afero.Fs, cliConf Config, runner lib.Runner) (conf
 		conf = conf.Apply(Config{Options: runner.GetOptions()})
 	}
 	conf = conf.Apply(envConf).Apply(cliConf)
+	conf = applyDefault(conf)
 
 	return conf, nil
+}
+
+// applyDefault applys default options value if it is not specified by any mechenisms. This happens with types
+// which does not support by "gopkg.in/guregu/null.v3".
+//
+// Note that if you add option default value here, also add it in command line argument help text.
+func applyDefault(conf Config) Config {
+	if conf.Options.SystemTags == nil {
+		conf = conf.Apply(Config{Options: lib.Options{SystemTags: lib.GetTagSet(lib.DefaultSystemTagList...)}})
+	}
+	return conf
 }
 
 func deriveAndValidateConfig(conf Config) (Config, error) {

--- a/cmd/config_consolidation_test.go
+++ b/cmd/config_consolidation_test.go
@@ -389,6 +389,21 @@ func getConfigConsolidationTestCases() []configConsolidationTestCase {
 		},
 		// Just in case, verify that no options will result in the same 1 vu 1 iter config
 		{opts{}, exp{}, verifyOneIterPerOneVU},
+
+		// Test system tags
+		{opts{}, exp{}, func(t *testing.T, c Config) {
+			assert.Equal(t, lib.GetTagSet(lib.DefaultSystemTagList...), c.Options.SystemTags)
+		}},
+		{opts{cli: []string{"--system-tags", `""`}}, exp{}, func(t *testing.T, c Config) {
+			assert.Equal(t, lib.GetTagSet(), c.Options.SystemTags)
+		}},
+		{
+			opts{runner: &lib.Options{SystemTags: lib.GetTagSet([]string{"proto", "url"}...)}},
+			exp{},
+			func(t *testing.T, c Config) {
+				assert.Equal(t, lib.GetTagSet("proto", "url"), c.Options.SystemTags)
+			},
+		},
 		//TODO: test for differences between flagsets
 		//TODO: more tests in general, especially ones not related to execution parameters...
 	}


### PR DESCRIPTION
CLI options have the highest priority, so the cli options which have a
default value will always override options of other mechanisms.

To fix it, we only set default value after consolidated config process.

Close #1010