### PR TITLE
Fix a bunch of minor release issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             go version
             export PATH="$GOPATH/bin:$PATH"
             mkdir -p "$GOPATH/bin"
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            curl --fail https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
             dep version
             dep status
             dep ensure -update -dry-run
@@ -40,7 +40,7 @@ jobs:
             done
             grep -h -v "^mode:" *.coverage >> coverage.txt
             rm -f *.coverage
-            bash <(curl -s https://codecov.io/bash)
+            bash <(curl --fail -s https://codecov.io/bash)
 
 
   test-prev-golang:
@@ -143,9 +143,9 @@ jobs:
           command: |
             export VERSION=${CIRCLE_TAG:1}
             # Publishing deb
-            curl -H "X-GPG-PASSPHRASE: $GPG_PASSPHRASE" -T dist/k6-v$VERSION-amd64.deb "https://$BINTRAY_USER:$BINTRAY_KEY@api.bintray.com/content/loadimpact/deb/k6/$VERSION/k6-v$VERSION-amd64.deb;deb_distribution=stable;deb_component=main;deb_architecture=amd64;publish=1;override=1"
+            curl --fail -H "X-GPG-PASSPHRASE: $GPG_PASSPHRASE" -T dist/k6-v$VERSION-amd64.deb "https://$BINTRAY_USER:$BINTRAY_KEY@api.bintray.com/content/loadimpact/deb/k6/$VERSION/k6-v$VERSION-amd64.deb;deb_distribution=stable;deb_component=main;deb_architecture=amd64;publish=1;override=1"
             # Publishing rpm
-            curl -H "X-GPG-PASSPHRASE: $GPG_PASSPHRASE" -T dist/k6-v$VERSION-amd64.rpm "https://$BINTRAY_USER:$BINTRAY_KEY@api.bintray.com/content/loadimpact/rpm/k6/$VERSION/k6-v$VERSION-amd64.rpm?publish=1&override=1"
+            curl --fail -H "X-GPG-PASSPHRASE: $GPG_PASSPHRASE" -T dist/k6-v$VERSION-amd64.rpm "https://$BINTRAY_USER:$BINTRAY_KEY@api.bintray.com/content/loadimpact/rpm/k6/$VERSION/k6-v$VERSION-amd64.rpm?publish=1&override=1"
 workflows:
   version: 2
   test_and_build:

--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ Install
 Install with [Homebrew](https://brew.sh/) by running:
 
 ```bash
-brew install loadimpact/k6/k6
+brew install k6
 ```
 
 ### Windows
 
-You can manually download and install the [latest `.msi` installation package](https://dl.bintray.com/loadimpact/windows/k6-latest-amd64.msi) or, if you use the [chocolatey package manager](https://chocolatey.org/), follow [these instructions](https://bintray.com/repo/buildSettings?repoPath=%2Floadimpact%2Fchoco) to set up the k6 repository.
+You can manually download and install the [official `.msi` installation package](https://dl.bintray.com/loadimpact/windows/k6-v0.25.0-amd64.msi) or, if you use the [chocolatey package manager](https://chocolatey.org/), follow [these instructions](https://bintray.com/repo/buildSettings?repoPath=%2Floadimpact%2Fchoco) to set up the k6 repository.
 
 ### Linux
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,8 +68,8 @@ deploy_script:
   - ps: |
       if ( $env:APPVEYOR_REPO_TAG -eq "false" ) { Exit-AppveyorBuild }
   # Publishing the msi
-  - 'curl -H "X-GPG-PASSPHRASE: %GPG_PASSPHRASE%" -T k6.msi "https://%BINTRAY_USER%:%BINTRAY_KEY%@api.bintray.com/content/loadimpact/windows/k6/%VERSION%/k6-v%VERSION%-amd64.msi?publish=1&override=1"'
-  - 'curl -H "X-GPG-PASSPHRASE: %GPG_PASSPHRASE%" -T k6.msi "https://%BINTRAY_USER%:%BINTRAY_KEY%@api.bintray.com/content/loadimpact/windows/k6/latest/k6-latest-amd64.msi?publish=1&override=1"'
+  - 'curl --fail -H "X-GPG-PASSPHRASE: %GPG_PASSPHRASE%" -T k6.msi "https://%BINTRAY_USER%:%BINTRAY_KEY%@api.bintray.com/content/loadimpact/windows/k6/%VERSION%/k6-v%VERSION%-amd64.msi?publish=1&override=1"'
+  - 'curl --fail -H "X-GPG-PASSPHRASE: %GPG_PASSPHRASE%" -T k6.msi "https://%BINTRAY_USER%:%BINTRAY_KEY%@api.bintray.com/content/loadimpact/windows/k6/latest/k6-latest-amd64.msi?publish=1&override=1"'
   - ps: |
       # Create Chocolately Package
       mkdir .\k6.portable
@@ -81,4 +81,4 @@ deploy_script:
       (Get-Content '.\k6.portable.nuspec' -Raw).Replace("<version>__REPLACE__</version>", "<version>$($env:APPVEYOR_REPO_TAG_NAME.substring(1))</version>") | Out-File '.\k6.portable.nuspec'
       choco pack
   # Publising the chocolatey package
-  - 'curl -H "X-GPG-PASSPHRASE: %GPG_PASSPHRASE%" -T .\k6.portable.%VERSION%.nupkg "https://%BINTRAY_USER%:%BINTRAY_KEY%@api.bintray.com/content/loadimpact/choco/k6.portable/%VERSION%/k6.portable.%VERSION%.nupkg?publish=1&override=1"'
+  - 'curl --fail -H "X-GPG-PASSPHRASE: %GPG_PASSPHRASE%" -T .\k6.portable.%VERSION%.nupkg "https://%BINTRAY_USER%:%BINTRAY_KEY%@api.bintray.com/content/loadimpact/choco/k6.portable/%VERSION%/k6.portable.%VERSION%.nupkg?publish=1&override=1"'

--- a/lib/consts/consts.go
+++ b/lib/consts/consts.go
@@ -6,7 +6,7 @@ import (
 
 // Version contains the current semantic version of k6.
 //nolint:gochecknoglobals
-var Version = "0.25.0"
+var Version = "0.25.1-dev"
 
 // Banner contains the ASCII-art banner with the k6 logo and stylized website URL
 //TODO: make these into methods, only the version needs to be a variable

--- a/release notes/v0.25.0.md
+++ b/release notes/v0.25.0.md
@@ -98,7 +98,6 @@ Also, all [cipher suites supported by Go](https://golang.org/pkg/crypto/tls/#pkg
 * HTTP: Correctly detect connection refused errors on dial. (#998)
 * JS: Run imports once per VU. (#975, #1040)
 * Config: Fix blacklistIPs JS configuration. Thanks, @THoelzel! (#1004)
-* JS: Correctly handle exports when `module.exports` gets redefined. (#1015)
 * HTTP: Fix a bunch of HTTP measurement and handling issues (#1047)
   - the `http_req_receiving` metric was measured incorrectly (#1041)
   - binary response bodies could get mangled in an `http.batch()` call (#1044)


### PR DESCRIPTION
This commit contains a few different things:
- Add `--fail` to all curl calls, so CI runs will fail when we don't receive a 200 response from some remote system.
- Switch the homebrew installation instructions to use the [new formula from `homebrew-core`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/k6.rb) (still have to figure out how to update the formula in homebrew-code, but this closes https://github.com/loadimpact/k6/issues/380 - I forgot to do it earlier).
- Stop pointing to the `latest` .msi package on BinTray - it's stuck on v0.24.0 and we can't update it to v0.25.0 or delete it, since apparently BinTray doesn't allow us to modify or delete "versions" that are older than a year... :|
- Remove a wrong line from the `v0.25.0` release notes, referencing a pull request that fixed an unreleased bug.
- Change the k6 `Version` constant to `0.25.1-dev`, to distinguish the recently officially released k6 version and any custom builds from the current master.