### PR TITLE
fix: Always initialize filesystems for all schemes always

### DIFF
--- a/lib/archive.go
+++ b/lib/archive.go
@@ -109,6 +109,9 @@ func (arc *Archive) getFs(name string) afero.Fs {
 func ReadArchive(in io.Reader) (*Archive, error) {
 	r := tar.NewReader(in)
 	arc := &Archive{Filesystems: make(map[string]afero.Fs, 2)}
+	// initialize both fses
+	_ = arc.getFs("https")
+	_ = arc.getFs("file")
 	for {
 		hdr, err := r.Next()
 		if err != nil {

--- a/lib/archive_test.go
+++ b/lib/archive_test.go
@@ -368,6 +368,7 @@ func TestStrangePaths(t *testing.T) {
 
 		assert.Equal(t, arc1, arc2, pathToChange)
 
+		arc1Filesystems["https"] = afero.NewMemMapFs()
 		diffMapFilesystems(t, arc1Filesystems, arc2Filesystems)
 	}
 }


### PR DESCRIPTION
This was always done when running a script, but for archives it was
deemed not needed as if it wasn't needed during the making of the
archive it shouldn't be needed during it's running. The problem arises
when a `require` is in a try block in order (to check if something is
support for example). In that case if it isn't loaded (for example a
nodejs module will not be loaded but will be resolved to an `https` url)
it will not be cached.

So if someone tries to run an archive from such a
script and there were no https imports k6 will panic at runtime.