### PR TITLE
Fix response error handling and slightly improve the digest auth code

### DIFF
--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -1854,6 +1854,7 @@ func TestDigestAuthWithBody(t *testing.T) {
 	defer tb.Cleanup()
 
 	state.Options.Throw = null.BoolFrom(true)
+	state.Options.HttpDebug = null.StringFrom("full")
 
 	tb.Mux.HandleFunc("/digest-auth-with-post/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "POST", r.Method)

--- a/lib/netext/httpext/digest_transport.go
+++ b/lib/netext/httpext/digest_transport.go
@@ -1,0 +1,74 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2019 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package httpext
+
+import (
+	"io/ioutil"
+	"net/http"
+
+	digest "github.com/Soontao/goHttpDigestClient"
+)
+
+type digestTransport struct {
+	originalTransport http.RoundTripper
+}
+
+// RoundTrip is handles digest auth by behaving like an http.RoundTripper
+//
+// TODO: fix - this is a preliminary solution and is somewhat broken! we're
+// always making 2 HTTP requests when digest authentication is enabled... we
+// should cache the nonces and behave more like a browser... or we should
+// ditch the hacky http.RoundTripper approach and write our own client...
+//
+// Github issue: https://github.com/loadimpact/k6/issues/800
+func (t digestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Make an initial request authentication params to compute the
+	// authorization header
+	username := req.URL.User.Username()
+	password, _ := req.URL.User.Password()
+
+	// Removing user from URL to avoid sending the authorization header fo basic auth
+	req.URL.User = nil
+
+	noAuthResponse, err := t.originalTransport.RoundTrip(req)
+	if err != nil || noAuthResponse.StatusCode != http.StatusUnauthorized {
+		return noAuthResponse, err
+	}
+
+	respBody, err := ioutil.ReadAll(noAuthResponse.Body)
+	if err != nil {
+		return nil, err
+	}
+	_ = noAuthResponse.Body.Close()
+
+	challenge := digest.GetChallengeFromHeader(&noAuthResponse.Header)
+	challenge.ComputeResponse(req.Method, req.URL.RequestURI(), string(respBody), username, password)
+	authorization := challenge.ToAuthorizationStr()
+
+	req.Header.Set(digest.KEY_AUTHORIZATION, authorization)
+	if req.GetBody != nil {
+		req.Body, err = req.GetBody()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return t.originalTransport.RoundTrip(req)
+}

--- a/lib/netext/httpext/digest_transport.go
+++ b/lib/netext/httpext/digest_transport.go
@@ -52,7 +52,7 @@ func (t digestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	noAuthResponse, err := t.originalTransport.RoundTrip(req)
 	if err != nil || noAuthResponse.StatusCode != http.StatusUnauthorized {
 		// If there was an error, or if the remote server didn't respond with
-		// status 401, we simply return, so the upsteam code can deal with it.
+		// status 401, we simply return, so the upstream code can deal with it.
 		return noAuthResponse, err
 	}
 
@@ -79,6 +79,6 @@ func (t digestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 	}
 
-	// Actually make the HTTP request with the propper Authorization
+	// Actually make the HTTP request with the proper Authorization
 	return t.originalTransport.RoundTrip(req)
 }

--- a/lib/netext/httpext/digest_transport.go
+++ b/lib/netext/httpext/digest_transport.go
@@ -31,7 +31,7 @@ type digestTransport struct {
 	originalTransport http.RoundTripper
 }
 
-// RoundTrip is handles digest auth by behaving like an http.RoundTripper
+// RoundTrip handles digest auth by behaving like an http.RoundTripper
 //
 // TODO: fix - this is a preliminary solution and is somewhat broken! we're
 // always making 2 HTTP requests when digest authentication is enabled... we

--- a/lib/netext/httpext/error_codes.go
+++ b/lib/netext/httpext/error_codes.go
@@ -35,7 +35,7 @@ import (
 	"golang.org/x/net/http2"
 )
 
-// TODO: mave rename the type errorCode, so we can have errCode variables? and
+// TODO: maybe rename the type errorCode, so we can have errCode variables? and
 // also the constants would probably be better of if `ErrorCode` was a prefix,
 // not a suffix - they would be much easier for auto-autocompletion at least...
 

--- a/lib/netext/httpext/httpdebug_transport.go
+++ b/lib/netext/httpext/httpdebug_transport.go
@@ -1,0 +1,67 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2019 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package httpext
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type httpDebugTransport struct {
+	//TODO: get the state and log to its Logger
+	originalTransport http.RoundTripper
+	httpDebugOption   string
+}
+
+// RoundTrip prints passing HTTP requests and received responses
+//
+// TODO: massively improve this, because the printed information can be wrong:
+//  - https://github.com/loadimpact/k6/issues/986
+//  - https://github.com/loadimpact/k6/issues/1042
+//  - https://github.com/loadimpact/k6/issues/774
+func (t httpDebugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Make an initial reques
+	t.debugRequest(req)
+	resp, err := t.originalTransport.RoundTrip(req)
+	t.debugResponse(resp)
+	return resp, err
+}
+
+func (t httpDebugTransport) debugRequest(req *http.Request) {
+	dump, err := httputil.DumpRequestOut(req, t.httpDebugOption == "full")
+	if err != nil {
+		log.Fatal(err) //TODO: fix...
+	}
+	fmt.Printf("Request:\n%s\n", dump) //TODO: fix...
+}
+
+func (t httpDebugTransport) debugResponse(res *http.Response) {
+	if res != nil {
+		dump, err := httputil.DumpResponse(res, t.httpDebugOption == "full")
+		if err != nil {
+			log.Fatal(err) //TODO: fix...
+		}
+		fmt.Printf("Response:\n%s\n", dump) //TODO: fix...
+	}
+}

--- a/lib/netext/httpext/httpdebug_transport.go
+++ b/lib/netext/httpext/httpdebug_transport.go
@@ -41,7 +41,6 @@ type httpDebugTransport struct {
 //  - https://github.com/loadimpact/k6/issues/1042
 //  - https://github.com/loadimpact/k6/issues/774
 func (t httpDebugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	// Make an initial reques
 	t.debugRequest(req)
 	resp, err := t.originalTransport.RoundTrip(req)
 	t.debugResponse(resp)

--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -433,7 +433,7 @@ func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error
 	tracerTransport := newTransport(state, tags)
 	var transport http.RoundTripper = tracerTransport
 
-	// TODO: if HttpDebug is enabled, inject the debug tranport here? or use
+	// TODO: if HttpDebug is enabled, inject the debug transport here? or use
 	// something like a virtual proxy for more accurate results, so we can catch
 	// things like HTTP/2 and exact headers? Connected issues:
 	// https://github.com/loadimpact/k6/issues/986,

--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -38,7 +38,6 @@ import (
 	"time"
 
 	ntlmssp "github.com/Azure/go-ntlmssp"
-	digest "github.com/Soontao/goHttpDigestClient"
 	"github.com/andybalholm/brotli"
 	"github.com/klauspost/compress/zstd"
 	"github.com/loadimpact/k6/lib"
@@ -193,6 +192,43 @@ func compressBody(algos []CompressionType, body io.ReadCloser) (*bytes.Buffer, s
 	return buf, contentEncoding, body.Close()
 }
 
+//nolint:gochecknoglobals
+var decompressionErrors = [...]error{
+	zlib.ErrChecksum, zlib.ErrDictionary, zlib.ErrHeader,
+	gzip.ErrChecksum, gzip.ErrHeader,
+	//TODO: handle brotli errors - currently unexported
+	zstd.ErrReservedBlockType, zstd.ErrCompressedSizeTooBig, zstd.ErrBlockTooSmall, zstd.ErrMagicMismatch,
+	zstd.ErrWindowSizeExceeded, zstd.ErrWindowSizeTooSmall, zstd.ErrDecoderSizeExceeded, zstd.ErrUnknownDictionary,
+	zstd.ErrFrameSizeExceeded, zstd.ErrCRCMismatch, zstd.ErrDecoderClosed,
+}
+
+func newDecompressionError(originalErr error) K6Error {
+	return NewK6Error(
+		responseDecompressionErrorCode,
+		fmt.Sprintf("error decompressing response body (%s)", originalErr.Error()),
+		originalErr,
+	)
+}
+
+func wrapDecompressionError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// TODO: something more optimized? for example, we won't get zstd errors if
+	// we don't use it... maybe the code that builds the decompression readers
+	// could also add an appropriate error-wrapper layer?
+	for _, decErr := range decompressionErrors {
+		if err == decErr {
+			return newDecompressionError(err)
+		}
+	}
+	if strings.HasPrefix(err.Error(), "brotli: ") { //TODO: submit an upstream patch and fix...
+		return newDecompressionError(err)
+	}
+	return err
+}
+
 func readResponseBody(
 	state *lib.State, respType ResponseType, resp *http.Response, respErr error,
 ) (interface{}, error) {
@@ -220,30 +256,30 @@ func readResponseBody(
 	// Transparently decompress the body if it's has a content-encoding we
 	// support. If not, simply return it as it is.
 	contentEncoding := strings.TrimSpace(resp.Header.Get("Content-Encoding"))
+	//TODO: support stacked compressions, e.g. `deflate, gzip`
 	if compression, err := CompressionTypeString(contentEncoding); err == nil {
-		var decoder io.ReadCloser
+		var decoder io.Reader
+		var err error
 		switch compression {
 		case CompressionTypeDeflate:
-			decoder, respErr = zlib.NewReader(resp.Body)
-			rc = &readCloser{decoder}
+			decoder, err = zlib.NewReader(resp.Body)
 		case CompressionTypeGzip:
-			decoder, respErr = gzip.NewReader(resp.Body)
-			rc = &readCloser{decoder}
+			decoder, err = gzip.NewReader(resp.Body)
 		case CompressionTypeZstd:
-			var zstdecoder *zstd.Decoder
-			zstdecoder, respErr = zstd.NewReader(resp.Body)
-			rc = &readCloser{zstdecoder}
+			decoder, err = zstd.NewReader(resp.Body)
 		case CompressionTypeBr:
-			var brdecoder *brotli.Reader
-			brdecoder = brotli.NewReader(resp.Body)
-			rc = &readCloser{brdecoder}
+			decoder = brotli.NewReader(resp.Body)
 		default:
 			// We have not implemented a compression ... :(
-			respErr = fmt.Errorf(
-				"unsupported compression type %s for decompression - this is a bug in k6, please report it",
+			err = fmt.Errorf(
+				"unsupported compression type %s - this is a bug in k6, please report it",
 				compression,
 			)
 		}
+		if err != nil {
+			return nil, newDecompressionError(err)
+		}
+		rc = &readCloser{decoder}
 	}
 
 	buf := state.BPool.Get()
@@ -251,11 +287,12 @@ func readResponseBody(
 	buf.Reset()
 	_, err := io.Copy(buf, rc.Reader)
 	if err != nil {
-		respErr = err
+		respErr = wrapDecompressionError(err)
 	}
+
 	err = rc.Close()
-	if err != nil {
-		respErr = err
+	if err != nil && respErr == nil { // Don't overwrite previous errors
+		respErr = wrapDecompressionError(err)
 	}
 
 	var result interface{}
@@ -276,6 +313,7 @@ func readResponseBody(
 	return result, respErr
 }
 
+//TODO: move as a response method? or constructor?
 func updateK6Response(k6Response *Response, finishedReq *finishedRequest) {
 	k6Response.ErrorCode = int(finishedReq.errorCode)
 	k6Response.Error = finishedReq.errorMsg
@@ -394,10 +432,17 @@ func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error
 
 	tracerTransport := newTransport(state, tags)
 	var transport http.RoundTripper = tracerTransport
-	if preq.Auth == "ntlm" {
-		transport = ntlmssp.Negotiator{
-			RoundTripper: tracerTransport,
-		}
+
+	// TODO: if HttpDebug is enabled, inject the debug tranport here? or use
+	// something like a virtual proxy for more accurate results, so we can catch
+	// things like HTTP/2 and exact headers? Connected issues:
+	// https://github.com/loadimpact/k6/issues/986,
+	// https://github.com/loadimpact/k6/issues/1042
+
+	if preq.Auth == "digest" {
+		transport = digestTransport{originalTransport: transport}
+	} else if preq.Auth == "ntlm" {
+		transport = ntlmssp.Negotiator{RoundTripper: transport}
 	}
 
 	resp := &Response{ctx: ctx, URL: preq.URL.URL, Request: *respReq}
@@ -434,62 +479,13 @@ func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error
 		},
 	}
 
-	// if digest authentication option is passed, make an initial request
-	// to get the authentication params to compute the authorization header
-	if preq.Auth == "digest" {
-		// TODO: fix - this is very broken! we're always making 2 HTTP requests
-		// when digest authentication is enabled... we should refactor it as a
-		// separate transport, like how NTLM auth works
-		//
-		// Github issue: https://github.com/loadimpact/k6/issues/800
-		username := preq.URL.u.User.Username()
-		password, _ := preq.URL.u.User.Password()
-
-		// removing user from URL to avoid sending the authorization header fo basic auth
-		preq.Req.URL.User = nil
-
-		debugRequest(state, preq.Req, "DigestRequest")
-		res, err := client.Do(preq.Req.WithContext(ctx))
-		debugResponse(state, res, "DigestResponse")
-		body, err := readResponseBody(state, ResponseTypeText, res, err)
-		finishedReq := tracerTransport.processLastSavedRequest()
-		if finishedReq != nil {
-			resp.ErrorCode = int(finishedReq.errorCode)
-			resp.Error = finishedReq.errorMsg
-		}
-
-		if err != nil {
-			// Do *not* log errors about the contex being cancelled.
-			select {
-			case <-ctx.Done():
-			default:
-				state.Logger.WithField("error", err).Warn("Digest request failed")
-			}
-
-			// In case we have an error but resp.Error is not set it means the error is not from
-			// the transport. For all such errors currently we just return them as if throw is true
-			if preq.Throw || resp.Error == "" {
-				return nil, err
-			}
-
-			return resp, nil
-		}
-
-		if res.StatusCode == http.StatusUnauthorized {
-			challenge := digest.GetChallengeFromHeader(&res.Header)
-			challenge.ComputeResponse(preq.Req.Method, preq.Req.URL.RequestURI(), body.(string), username, password)
-			authorization := challenge.ToAuthorizationStr()
-			preq.Req.Header.Set(digest.KEY_AUTHORIZATION, authorization)
-		}
-	}
-
 	debugRequest(state, preq.Req, "Request")
 	mreq := preq.Req.WithContext(ctx)
 	res, resErr := client.Do(mreq)
 	debugResponse(state, res, "Response")
 
 	resp.Body, resErr = readResponseBody(state, preq.ResponseType, res, resErr)
-	finishedReq := tracerTransport.processLastSavedRequest()
+	finishedReq := tracerTransport.processLastSavedRequest(wrapDecompressionError(resErr))
 	if finishedReq != nil {
 		updateK6Response(resp, finishedReq)
 	}
@@ -538,9 +534,7 @@ func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error
 			state.Logger.WithField("error", resErr).Warn("Request Failed")
 		}
 
-		// In case we have an error but resp.Error is not set it means the error is not from
-		// the transport. For all such errors currently we just return them as if throw is true
-		if preq.Throw || resp.Error == "" {
+		if preq.Throw {
 			return nil, resErr
 		}
 	}

--- a/lib/netext/httpext/response.go
+++ b/lib/netext/httpext/response.go
@@ -24,13 +24,9 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
-	"net/http"
-	"net/http/httputil"
 
-	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/lib/netext"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 )
 
@@ -113,16 +109,6 @@ func (res *Response) setTLSInfo(tlsState *tls.ConnectionState) {
 // GetCtx return the response context
 func (res *Response) GetCtx() context.Context {
 	return res.ctx
-}
-
-func debugResponse(state *lib.State, res *http.Response, description string) {
-	if state.Options.HttpDebug.String != "" && res != nil {
-		dump, err := httputil.DumpResponse(res, state.Options.HttpDebug.String == "full")
-		if err != nil {
-			log.Fatal(err)
-		}
-		logDump(description, dump)
-	}
 }
 
 // JSON parses the body of a response as json and returns it to the goja VM


### PR DESCRIPTION
Previously, there was an uncaught error (sometimes leading to panics) in the automatic response body decompression. This patch handles these decompression errors and even assigns a custom error code for them. As a bonus, k6 now also properly handles errors due to improper redirects, or too many redirects, and tags the resulting metric samples accordingly.

By necessity, I had to also move the digest authentication handling to its own `http.RoundTripper` layer. This by no means solves the issues of https://github.com/loadimpact/k6/issues/800, but it hopefully slightly improves the situation. A proper authentication cache and likely a different library still have to be used there eventually...