### PR TITLE
Always set the correct content-length for requests

### DIFF
--- a/cmd/testdata/example.js
+++ b/cmd/testdata/example.js
@@ -52,8 +52,7 @@ export default function() {
 					"Accept": "application/json; charset=utf-8",
 					"Content-Type": "application/json",
 					"Accept-Encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-					"Host": "some-host.example.com",
-					"Content-Length": "2042"
+					"Host": "some-host.example.com"
 				}
 			}
 		)
@@ -178,8 +177,7 @@ export default function() {
 					"Content-Type": "application/vnd.checkout.client-order-v1+json",
 					"Accept": "application/vnd.checkout.server-order-v1+json",
 					"Accept-Encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-					"Host": "some-other-host.example.com",
-					"Content-Length": "4351"
+					"Host": "some-other-host.example.com"
 				}
 			}
 		)
@@ -284,8 +282,7 @@ export default function() {
 					"Content-Type": "application/vnd.checkout.client-order-v1+json",
 					"Accept": "application/vnd.checkout.server-order-v1+json",
 					"Accept-Encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-					"Host": "some-other-host.example.com",
-					"Content-Length": "5003"
+					"Host": "some-other-host.example.com"
 				}
 			}
 		)
@@ -388,8 +385,7 @@ export default function() {
 					"Content-Type": "application/vnd.checkout.client-order-v1+json",
 					"Accept": "application/vnd.checkout.server-order-v1+json",
 					"Accept-Encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-					"Host": "some-other-host.example.com",
-					"Content-Length": "4774"
+					"Host": "some-other-host.example.com"
 				}
 			}
 		)

--- a/converter/har/converter.go
+++ b/converter/har/converter.go
@@ -390,13 +390,13 @@ func buildK6RequestObject(req *Request) (string, error) {
 func buildK6Headers(headers []Header) []string {
 	var h []string
 	if len(headers) > 0 {
-		m := make(map[string]Header)
+		ignored := map[string]bool{"cookie": true, "content-length": true}
 		for _, header := range headers {
 			name := strings.ToLower(header.Name)
-			_, exists := m[name]
-			// Avoid SPDY's, duplicated or cookie headers
-			if !exists && name[0] != ':' && name != "cookie" {
-				m[strings.ToLower(header.Name)] = header
+			_, isIgnored := ignored[name]
+			// Avoid SPDY's, duplicated or ignored headers
+			if !isIgnored && name[0] != ':' {
+				ignored[name] = true
 				h = append(h, fmt.Sprintf("%q: %q", header.Name, header.Value))
 			}
 		}

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -1395,9 +1395,8 @@ func TestRequestCompression(t *testing.T) {
 					}
 				);
 			`))
-			require.Error(t, err)
-			// TODO: This probably shouldn't be like this
-			require.Contains(t, err.Error(), "http: ContentLength=12 with Body length 211")
+			require.NoError(t, err)
+			// TODO: test for warnings with the log hook
 		})
 	})
 }

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -1255,6 +1255,9 @@ func TestRequestCompression(t *testing.T) {
 	tb, state, _, rt, _ := newRuntime(t)
 	defer tb.Cleanup()
 
+	logHook := testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.WarnLevel}}
+	state.Logger.AddHook(&logHook)
+
 	// We don't expect any failed requests
 	state.Options.Throw = null.BoolFrom(true)
 
@@ -1374,6 +1377,8 @@ func TestRequestCompression(t *testing.T) {
 	t.Run("custom set header", func(t *testing.T) {
 		expectedEncoding = "not, valid"
 		actualEncoding = "gzip, deflate"
+
+		logHook.Drain()
 		t.Run("encoding", func(t *testing.T) {
 			_, err := common.RunString(rt, tb.Replacer.Replace(`
 				http.post("HTTPBIN_URL/compressed-text", `+"`"+text+"`"+`,
@@ -1383,7 +1388,7 @@ func TestRequestCompression(t *testing.T) {
 				);
 			`))
 			require.NoError(t, err)
-
+			require.NotEmpty(t, logHook.Drain())
 		})
 
 		t.Run("encoding and length", func(t *testing.T) {
@@ -1396,7 +1401,40 @@ func TestRequestCompression(t *testing.T) {
 				);
 			`))
 			require.NoError(t, err)
-			// TODO: test for warnings with the log hook
+			require.NotEmpty(t, logHook.Drain())
+		})
+
+		expectedEncoding = actualEncoding
+		t.Run("correct encoding", func(t *testing.T) {
+			_, err := common.RunString(rt, tb.Replacer.Replace(`
+				http.post("HTTPBIN_URL/compressed-text", `+"`"+text+"`"+`,
+					{"compression": "`+actualEncoding+`",
+					 "headers": {"Content-Encoding": "`+actualEncoding+`"}
+					}
+				);
+			`))
+			require.NoError(t, err)
+			require.Empty(t, logHook.Drain())
+		})
+
+		//TODO: move to some other test?
+		t.Run("correct length", func(t *testing.T) {
+			_, err := common.RunString(rt, tb.Replacer.Replace(
+				`http.post("HTTPBIN_URL/post", "0123456789", { "headers": {"Content-Length": "10"}});`,
+			))
+			require.NoError(t, err)
+			require.Empty(t, logHook.Drain())
+		})
+
+		t.Run("content-length is set", func(t *testing.T) {
+			_, err := common.RunString(rt, tb.Replacer.Replace(`
+				let resp = http.post("HTTPBIN_URL/post", "0123456789");
+				if (resp.json().headers["Content-Length"][0] != "10") {
+					throw new Error("content-length not set: " + JSON.stringify(resp.json().headers));
+				}
+			`))
+			require.NoError(t, err)
+			require.Empty(t, logHook.Drain())
 		})
 	})
 }

--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -45,10 +45,6 @@ import (
 	null "gopkg.in/guregu/null.v3"
 )
 
-const compressionHeaderOverwriteMessage = "Both compression and the `%s` header were specified " +
-	"in the %s request for '%s', the custom header has precedence and won't be overwritten. " +
-	"This will likely result in invalid data being sent to the server."
-
 // HTTPRequestCookie is a representation of a cookie used for request objects
 type HTTPRequestCookie struct {
 	Name, Value string
@@ -346,47 +342,31 @@ func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error
 		Headers: preq.Req.Header,
 	}
 
-	if contentLength := preq.Req.Header.Get("Content-Length"); contentLength != "" {
-		length, err := strconv.Atoi(contentLength)
-		if err == nil {
-			preq.Req.ContentLength = int64(length)
-		}
-		// TODO: maybe do something in the other case ... but no error
-	}
-
 	if preq.Body != nil {
-
 		// TODO: maybe hide this behind of flag in order for this to not happen for big post/puts?
 		// should we set this after the compression? what will be the point ?
 		respReq.Body = preq.Body.String()
 
-		switch {
-		case len(preq.Compressions) > 0:
-			var (
-				contentEncoding string
-				err             error
-			)
-			preq.Body, contentEncoding, err = compressBody(preq.Compressions, ioutil.NopCloser(preq.Body))
+		if len(preq.Compressions) > 0 {
+			compressedBody, contentEncoding, err := compressBody(preq.Compressions, ioutil.NopCloser(preq.Body))
 			if err != nil {
 				return nil, err
 			}
+			preq.Body = compressedBody
 
-			if preq.Req.Header.Get("Content-Length") == "" {
-				preq.Req.ContentLength = int64(preq.Body.Len())
-			} else {
-				state.Logger.Warningf(compressionHeaderOverwriteMessage, "Content-Length", preq.Req.Method, preq.Req.URL)
-			}
-			if preq.Req.Header.Get("Content-Encoding") == "" {
+			currentContentEncoding := preq.Req.Header.Get("Content-Encoding")
+			if currentContentEncoding == "" {
 				preq.Req.Header.Set("Content-Encoding", contentEncoding)
-			} else {
-				state.Logger.Warningf(compressionHeaderOverwriteMessage, "Content-Encoding", preq.Req.Method, preq.Req.URL)
+			} else if currentContentEncoding != contentEncoding {
+				state.Logger.Warningf(
+					"There's a mismatch between the desired `compression` the manually set `Content-Encoding` header "+
+						"in the %s request for '%s', the custom header has precedence and won't be overwritten. "+
+						"This may result in invalid data being sent to the server.", preq.Req.Method, preq.Req.URL,
+				)
 			}
-		case preq.Req.Header.Get("Content-Length") == "":
-			preq.Req.ContentLength = int64(preq.Body.Len())
 		}
-		// TODO: print some message in case we have Content-Length set so that we can warn users
-		// that setting it manually can lead to bad requests
 
+		preq.Req.ContentLength = int64(preq.Body.Len()) // This will make Go set the content-length header
 		preq.Req.GetBody = func() (io.ReadCloser, error) {
 			//  using `Bytes()` should reuse the same buffer and as such help with the memory usage. We
 			//  should not be writing to it any way so there shouldn't be way to corrupt it (?)
@@ -394,6 +374,20 @@ func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error
 		}
 		// as per the documentation using GetBody still requires setting the Body.
 		preq.Req.Body, _ = preq.Req.GetBody()
+	}
+
+	if contentLengthHeader := preq.Req.Header.Get("Content-Length"); contentLengthHeader != "" {
+		// The content-length header was set by the user, delete it (since Go
+		// will set it automatically) and warn if there were differences
+		preq.Req.Header.Del("Content-Length")
+		length, err := strconv.Atoi(contentLengthHeader)
+		if err != nil || preq.Req.ContentLength != int64(length) {
+			state.Logger.Warnf(
+				"The specified Content-Length header %q in the %s request for %s "+
+					"doesn't match the actual request body length of %d, so it will be ignored!",
+				contentLengthHeader, preq.Req.Method, preq.Req.URL, length,
+			)
+		}
 	}
 
 	tags := state.Options.RunTags.CloneTags()

--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -385,7 +385,7 @@ func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error
 			state.Logger.Warnf(
 				"The specified Content-Length header %q in the %s request for %s "+
 					"doesn't match the actual request body length of %d, so it will be ignored!",
-				contentLengthHeader, preq.Req.Method, preq.Req.URL, length,
+				contentLengthHeader, preq.Req.Method, preq.Req.URL, preq.Req.ContentLength,
 			)
 		}
 	}


### PR DESCRIPTION
This would restore the behavior pre-#989, so that any content-length header values manually specified by users would be overwritten by k6. Only, this time it won't be done silently, a warning would be shown every time there was a mismatch.

The HAR converter is also modified to not include the content-length header in the generated sources. While that header isn't going to be a problem if its values matches the actual body content length, some HAR files are broken and include the header without any body data, and other times users may modify the body but forget the header. So, since k6 would automatically send it, we shouldn't include it in the script.

This will close https://github.com/loadimpact/k6/issues/1094