### PR TITLE
feat(lib): remove group separator from main user group

### DIFF
--- a/core/local/local_test.go
+++ b/core/local/local_test.go
@@ -565,9 +565,9 @@ func TestRealTimeAndSetupTeardownMetrics(t *testing.T) {
 	}
 
 	// Initially give a long time (5s) for the executor to start
-	expectIn(0, 5000, getSample(1, testCounter, "group", "::setup", "place", "setupBeforeSleep"))
-	expectIn(900, 1100, getSample(2, testCounter, "group", "::setup", "place", "setupAfterSleep"))
-	expectIn(0, 100, getDummyTrail("::setup"))
+	expectIn(0, 5000, getSample(1, testCounter, "group", "setup", "place", "setupBeforeSleep"))
+	expectIn(900, 1100, getSample(2, testCounter, "group", "setup", "place", "setupAfterSleep"))
+	expectIn(0, 100, getDummyTrail("setup"))
 
 	expectIn(0, 100, getSample(5, testCounter, "group", "", "place", "defaultBeforeSleep"))
 	expectIn(900, 1100, getSample(6, testCounter, "group", "", "place", "defaultAfterSleep"))
@@ -579,9 +579,9 @@ func TestRealTimeAndSetupTeardownMetrics(t *testing.T) {
 	expectIn(0, 100, getDummyTrail(""))
 	expectIn(0, 100, getSample(1, metrics.Iterations))
 
-	expectIn(0, 1000, getSample(3, testCounter, "group", "::teardown", "place", "teardownBeforeSleep"))
-	expectIn(900, 1100, getSample(4, testCounter, "group", "::teardown", "place", "teardownAfterSleep"))
-	expectIn(0, 100, getDummyTrail("::teardown"))
+	expectIn(0, 1000, getSample(3, testCounter, "group", "teardown", "place", "teardownBeforeSleep"))
+	expectIn(900, 1100, getSample(4, testCounter, "group", "teardown", "place", "teardownAfterSleep"))
+	expectIn(0, 100, getDummyTrail("teardown"))
 
 	for {
 		select {

--- a/js/modules/k6/http/response_test.go
+++ b/js/modules/k6/http/response_test.go
@@ -163,7 +163,7 @@ func TestResponse(t *testing.T) {
 				if (res.body.indexOf("Herman Melville - Moby-Dick") == -1) { throw new Error("wrong body: " + res.body); }
 			`))
 			assert.NoError(t, err)
-			assertRequestMetricsEmitted(t, stats.GetBufferedSamples(samples), "GET", sr("HTTPBIN_URL/html"), "", 200, "::my group")
+			assertRequestMetricsEmitted(t, stats.GetBufferedSamples(samples), "GET", sr("HTTPBIN_URL/html"), "", 200, "my group")
 		})
 	})
 	t.Run("Json", func(t *testing.T) {
@@ -196,7 +196,7 @@ func TestResponse(t *testing.T) {
 	        if (value != undefined)
 				{ throw new Error("Expected undefined, but got: " + value); }
 
-			value = res.json("glossary.null") 
+			value = res.json("glossary.null")
 	        if (value != null)
 				{ throw new Error("Expected null, but got: " + value); }
 
@@ -212,8 +212,8 @@ func TestResponse(t *testing.T) {
 	        if (value != true)
 				{ throw new Error("Expected boolean true, but got: " + value); }
 
-			value = res.json("glossary.GlossDiv.GlossList.GlossEntry.GlossDef.title") 
-	        if (value != "example glossary") 
+			value = res.json("glossary.GlossDiv.GlossList.GlossEntry.GlossDef.title")
+	        if (value != "example glossary")
 				{ throw new Error("Expected 'example glossary'', but got: " + value); }
 
 			value =	res.json("glossary.friends.#.first")[0]

--- a/lib/models.go
+++ b/lib/models.go
@@ -125,7 +125,10 @@ func NewGroup(name string, parent *Group) (*Group, error) {
 	}
 
 	path := name
-	if parent != nil {
+	// The top-most user-defined group has the default group as parent,
+	// yet we don't want to prefix it with the group separator.
+	// See https://github.com/loadimpact/k6/issues/948
+	if parent != nil && parent.Path != "" {
 		path = parent.Path + GroupSeparator + path
 	}
 

--- a/lib/models_test.go
+++ b/lib/models_test.go
@@ -88,3 +88,14 @@ func TestDataRaces(t *testing.T) {
 		assert.Equal(t, group1, group2, "Groups are the same")
 	})
 }
+
+func TestNewGroup(t *testing.T) {
+	t.Run("NoGroupSeparatorOnMainUserGroup", func(t *testing.T) {
+		defaultGroup, _ := NewGroup("", nil)
+		assert.Equal(t, "", defaultGroup.Path)
+		mainUserGroup, _ := NewGroup("mainGroup", defaultGroup)
+		assert.Equal(t, "mainGroup", mainUserGroup.Path)
+		nestedUserGroup, _ := NewGroup("nestedGroup", mainUserGroup)
+		assert.Equal(t, "mainGroup::nestedGroup", nestedUserGroup.Path)
+	})
+}


### PR DESCRIPTION
This change now generates group tags according to @ppcano's proposal in #948:

```
{"type":"Point","data":{"time":"2019-08-23T16:00:05.35818107+02:00","value":0.166917,"tags":{"group":"mainGroup","method":"GET","name":"http://httpbin.org/get","proto":"HTTP/1.1","status":"200","url":"http://httpbin.org/get"}},"metric":"http_req_receiving"}
{"type":"Point","data":{"time":"2019-08-23T16:00:05.4684003+02:00","value":1,"tags":{"group":"mainGroup::nestedGroup","method":"GET","name":"http://httpbin.org/get","proto":"HTTP/1.1","status":"200","url":"http://httpbin.org/get"}},"metric":"http_reqs"}
```

This is a small change, but it seems backwards incompatible to me, in the sense that it will break user scripts that depended on the previous tag names. @na-- @MStoykov Thoughts?

Closes #948 