### PR TITLE
cmd: make stats/status always output result

### DIFF
--- a/cmd/command_test.go
+++ b/cmd/command_test.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func executeCommand(root *cobra.Command, args ...string) (output string, err error) {
+	_, output, err = executeCommandC(root, args...)
+	return output, err
+}
+
+func executeCommandC(root *cobra.Command, args ...string) (c *cobra.Command, output string, err error) {
+	buf := new(bytes.Buffer)
+	root.SetOutput(buf)
+	root.SetArgs(args)
+	c, err = root.ExecuteC()
+	return c, buf.String(), err
+}
+
+func TestCommandReturnErrorWhenServerNotRunning(t *testing.T) {
+	tests := []struct {
+		command *cobra.Command
+		name    string
+	}{
+		{statusCmd, "status"},
+		{statsCmd, "stats"},
+	}
+
+	for _, tc := range tests {
+		RootCmd.AddCommand(tc.command)
+		_, err := executeCommand(RootCmd, tc.name)
+		if err == nil {
+			t.Errorf("Command %s expected error, got nil", tc.name)
+		}
+		RootCmd.RemoveCommand(tc.command)
+	}
+}

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/loadimpact/k6/api/v1/client"
 	"github.com/loadimpact/k6/ui"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -42,7 +43,8 @@ var statsCmd = &cobra.Command{
 		}
 		metrics, err := c.Metrics(context.Background())
 		if err != nil {
-			return err
+			logrus.WithError(err).Debug("failed to get metrics")
+			return errNoTestRunning
 		}
 		ui.Dump(stdout, metrics)
 		return nil

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -25,8 +25,12 @@ import (
 
 	"github.com/loadimpact/k6/api/v1/client"
 	"github.com/loadimpact/k6/ui"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
+
+var errNoTestRunning = errors.New("no test running")
 
 // statusCmd represents the status command
 var statusCmd = &cobra.Command{
@@ -42,7 +46,8 @@ var statusCmd = &cobra.Command{
 		}
 		status, err := c.Status(context.Background())
 		if err != nil {
-			return err
+			logrus.WithError(err).Debug("failed to get status")
+			return errNoTestRunning
 		}
 		ui.Dump(stdout, status)
 		return nil


### PR DESCRIPTION
Currently, if no test is running, stats/status reports the error which
indicate that client can not connect to api server. From user
perspective, this message is not friendly.
