### PR TITLE
fix(ws): return error before running setup fn if WS is not connectable

### DIFF
--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -192,16 +192,16 @@ func (*WS) Connect(ctx context.Context, url string, args ...goja.Value) (*WSHTTP
 		}
 	}
 
-	// Run the user-provided set up function
-	if _, err := setupFn(goja.Undefined(), rt.ToValue(&socket)); err != nil {
-		return nil, err
-	}
-
 	if connErr != nil {
 		// Pass the error to the user script before exiting immediately
 		socket.handleEvent("error", rt.ToValue(connErr))
 
 		return nil, connErr
+	}
+
+	// Run the user-provided set up function
+	if _, err := setupFn(goja.Undefined(), rt.ToValue(&socket)); err != nil {
+		return nil, err
 	}
 
 	wsResponse, wsRespErr := wrapHTTPResponse(httpResponse)

--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -324,6 +324,25 @@ func TestErrors(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("invalid_url_message_panic", func(t *testing.T) {
+		// Attempting to send a message to a non-existent socket shouldn't panic
+		_, err := common.RunString(rt, `
+		let res = ws.connect("INVALID", function(socket){
+			socket.send("new message");
+		});
+		`)
+		assert.Error(t, err)
+	})
+
+	t.Run("error_in_setup", func(t *testing.T) {
+		_, err := common.RunString(rt, `
+		let res = ws.connect("ws://demos.kaazing.com/echo", function(socket){
+			throw new Error("error in setup");
+		});
+		`)
+		assert.Error(t, err)
+	})
+
 	t.Run("send_after_close", func(t *testing.T) {
 		_, err := common.RunString(rt, `
 		let hasError = false;


### PR DESCRIPTION
This is a very naive fix for #1116: it ensures the WS connection is established before running the setup function.

This avoids the panic and running the test script provided by @MStoykov now outputs:

```
ERRO[0011] GoError: lookup nonexistant on 172.16.1.1:53: no such host
        at native
        at file:///home/ivan/.local/go/src/github.com/loadimpact/k6/test-ws.js:5:61(14)
```

Closes #1116