### PR TITLE
fix(httpext): remove user credentials from metric tags

### DIFF
--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -751,7 +751,7 @@ func TestRequestAndBatch(t *testing.T) {
 		t.Run("auth", func(t *testing.T) {
 			t.Run("basic", func(t *testing.T) {
 				url := sr("http://bob:pass@HTTPBIN_IP:HTTPBIN_PORT/basic-auth/bob/pass")
-				urlExpected := sr("http://HTTPBIN_IP:HTTPBIN_PORT/basic-auth/bob/pass")
+				urlExpected := sr("http://****:****@HTTPBIN_IP:HTTPBIN_PORT/basic-auth/bob/pass")
 
 				_, err := common.RunString(rt, fmt.Sprintf(`
 				let res = http.request("GET", "%s", null, {});
@@ -763,7 +763,7 @@ func TestRequestAndBatch(t *testing.T) {
 			t.Run("digest", func(t *testing.T) {
 				t.Run("success", func(t *testing.T) {
 					url := sr("http://bob:pass@HTTPBIN_IP:HTTPBIN_PORT/digest-auth/auth/bob/pass")
-					urlExpected := sr("http://HTTPBIN_IP:HTTPBIN_PORT/digest-auth/auth/bob/pass")
+					urlExpected := sr("http://****:****@HTTPBIN_IP:HTTPBIN_PORT/digest-auth/auth/bob/pass")
 
 					_, err := common.RunString(rt, fmt.Sprintf(`
 					let res = http.request("GET", "%s", null, { auth: "digest" });
@@ -1926,8 +1926,12 @@ func TestDigestAuthWithBody(t *testing.T) {
 	`, urlWithCreds))
 	require.NoError(t, err)
 
-	expectedURL := tb.Replacer.Replace("http://HTTPBIN_IP:HTTPBIN_PORT/digest-auth-with-post/auth/testuser/testpwd")
+	expectedURL := tb.Replacer.Replace(
+		"http://HTTPBIN_IP:HTTPBIN_PORT/digest-auth-with-post/auth/testuser/testpwd")
+	expectedName := tb.Replacer.Replace(
+		"http://****:****@HTTPBIN_IP:HTTPBIN_PORT/digest-auth-with-post/auth/testuser/testpwd")
+
 	sampleContainers := stats.GetBufferedSamples(samples)
-	assertRequestMetricsEmitted(t, sampleContainers[0:1], "POST", expectedURL, expectedURL, 401, "")
-	assertRequestMetricsEmitted(t, sampleContainers[1:2], "POST", expectedURL, expectedURL, 200, "")
+	assertRequestMetricsEmitted(t, sampleContainers[0:1], "POST", expectedURL, expectedName, 401, "")
+	assertRequestMetricsEmitted(t, sampleContainers[1:2], "POST", expectedURL, expectedName, 200, "")
 }

--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -50,34 +50,49 @@ type HTTPRequestCookie struct {
 
 // A URL wraps net.URL, and preserves the template (if any) the URL was constructed from.
 type URL struct {
-	u    *url.URL
-	Name string // http://example.com/thing/${}/
-	URL  string // http://example.com/thing/1234/
+	u        *url.URL
+	Name     string // http://example.com/thing/${}/
+	URL      string // http://example.com/thing/1234/
+	CleanURL string // URL with masked user credentials, used for output
 }
 
 // NewURL returns a new URL for the provided url and name. The error is returned if the url provided
 // can't be parsed
 func NewURL(urlString, name string) (URL, error) {
 	u, err := url.Parse(urlString)
-	return URL{u: u, Name: name, URL: urlString}, err
+	newURL := URL{u: u, Name: name, URL: urlString}
+	newURL.CleanURL = newURL.Clean()
+	if urlString == name {
+		newURL.Name = newURL.CleanURL
+	}
+	return newURL, err
+}
+
+// Clean returns an output-safe representation of URL
+func (u URL) Clean() string {
+	if u.CleanURL != "" {
+		return u.CleanURL
+	}
+
+	out := u.URL
+
+	if u.u != nil && u.u.User != nil {
+		// mask user credentials
+		creds := fmt.Sprintf("%s@", u.u.User.String())
+		mask := "****@"
+		_, passSet := u.u.User.Password()
+		if passSet {
+			mask = fmt.Sprintf("****:%s", mask)
+		}
+		return strings.Replace(out, creds, mask, 1)
+	}
+
+	return out
 }
 
 // GetURL returns the internal url.URL
 func (u URL) GetURL() *url.URL {
 	return u.u
-}
-
-// Return a sanitized URL, clean of e.g. user credentials
-func cleanURL(urlString string) string {
-	idxEnd := strings.Index(urlString, "@")
-	if idxEnd == -1 {
-		return urlString
-	}
-	idxStart := strings.Index(urlString[:idxEnd], "/")
-	if idxStart != -1 {
-		return fmt.Sprintf("%s%s", urlString[0:idxStart+2], urlString[idxEnd+1:])
-	}
-	return urlString
 }
 
 // Request represent an http request
@@ -226,12 +241,12 @@ func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error
 		tags["method"] = preq.Req.Method
 	}
 	if state.Options.SystemTags["url"] {
-		tags["url"] = cleanURL(preq.URL.URL)
+		tags["url"] = preq.URL.Clean()
 	}
 
 	// Only set the name system tag if the user didn't explicitly set it beforehand
 	if _, ok := tags["name"]; !ok && state.Options.SystemTags["name"] {
-		tags["name"] = cleanURL(preq.URL.Name)
+		tags["name"] = preq.URL.Name
 	}
 	if state.Options.SystemTags["group"] {
 		tags["group"] = state.Group.Path

--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -23,7 +23,6 @@ package httpext
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
@@ -77,14 +76,13 @@ func (u URL) Clean() string {
 	out := u.URL
 
 	if u.u != nil && u.u.User != nil {
-		// mask user credentials
-		creds := fmt.Sprintf("%s@", u.u.User.String())
-		mask := "****@"
-		_, passSet := u.u.User.Password()
-		if passSet {
-			mask = fmt.Sprintf("****:%s", mask)
+		schemeIndex := strings.Index(out, "://")
+		atIndex := strings.Index(out, "@")
+		if _, passwordOk := u.u.User.Password(); passwordOk {
+			out = out[:schemeIndex+3] + "****:****" + out[atIndex:]
+		} else {
+			out = out[:schemeIndex+3] + "****" + out[atIndex:]
 		}
-		return strings.Replace(out, creds, mask, 1)
 	}
 
 	return out

--- a/lib/netext/httpext/request_test.go
+++ b/lib/netext/httpext/request_test.go
@@ -82,3 +82,26 @@ func TestMakeRequestError(t *testing.T) {
 		require.Equal(t, err.Error(), "unknown compressionType CompressionType(13)")
 	})
 }
+
+func TestCleanURL(t *testing.T) {
+	testCases := []struct {
+		url      string
+		expected string
+	}{
+		{"https://example.com/", "https://example.com/"},
+		{"https://example.com/${}", "https://example.com/${}"},
+		{"https://user:pass@example.com/", "https://example.com/"},
+		{"https://user:pass@example.com/path?a=1&b=2", "https://example.com/path?a=1&b=2"},
+		{"https://user:pass@example.com/${}", "https://example.com/${}"},
+		{"@malformed/url", "@malformed/url"},
+		{"not a url", "not a url"},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.url, func(t *testing.T) {
+			res := cleanURL(tc.url)
+			require.Equal(t, tc.expected, res)
+		})
+	}
+}

--- a/lib/netext/httpext/transport.go
+++ b/lib/netext/httpext/transport.go
@@ -113,7 +113,7 @@ func (t *transport) measureAndEmitMetrics(unfReq *unfinishedRequest) *finishedRe
 		}
 	} else {
 		if enabledTags["url"] {
-			tags["url"] = unfReq.request.URL.String()
+			tags["url"] = cleanURL(unfReq.request.URL.String())
 		}
 		if enabledTags["status"] {
 			tags["status"] = strconv.Itoa(unfReq.response.StatusCode)

--- a/lib/netext/httpext/transport.go
+++ b/lib/netext/httpext/transport.go
@@ -113,7 +113,8 @@ func (t *transport) measureAndEmitMetrics(unfReq *unfinishedRequest) *finishedRe
 		}
 	} else {
 		if enabledTags["url"] {
-			tags["url"] = cleanURL(unfReq.request.URL.String())
+			u := URL{u: unfReq.request.URL, URL: unfReq.request.URL.String()}
+			tags["url"] = u.Clean()
 		}
 		if enabledTags["status"] {
 			tags["status"] = strconv.Itoa(unfReq.response.StatusCode)


### PR DESCRIPTION
This fixes the credential leak in HTTP metric tags.

Closes #1103