### PR TITLE
Add optional 'count' column to CLI summary output

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -328,10 +328,10 @@ func getConsolidatedConfig(fs afero.Fs, cliConf Config, runner lib.Runner) (conf
 // Note that if you add option default value here, also add it in command line argument help text.
 func applyDefault(conf Config) Config {
 	if conf.Options.SystemTags == nil {
-		conf = conf.Apply(Config{Options: lib.Options{SystemTags: &stats.DefaultSystemTagSet}})
+		conf.Options.SystemTags = &stats.DefaultSystemTagSet
 	}
 	if conf.Options.SummaryTrendStats == nil {
-		conf = conf.Apply(Config{Options: lib.Options{SummaryTrendStats: lib.DefaultSummaryTrendStats}})
+		conf.Options.SummaryTrendStats = lib.DefaultSummaryTrendStats
 	}
 	return conf
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -330,7 +330,7 @@ func applyDefault(conf Config) Config {
 	if conf.Options.SystemTags == nil {
 		conf = conf.Apply(Config{Options: lib.Options{SystemTags: &stats.DefaultSystemTagSet}})
 	}
-	if len(conf.Options.SummaryTrendStats) == 0 {
+	if conf.Options.SummaryTrendStats == nil {
 		conf = conf.Apply(Config{Options: lib.Options{SummaryTrendStats: lib.DefaultSummaryTrendStats}})
 	}
 	return conf

--- a/cmd/config_consolidation_test.go
+++ b/cmd/config_consolidation_test.go
@@ -417,7 +417,7 @@ func getConfigConsolidationTestCases() []configConsolidationTestCase {
 			assert.Equal(t, lib.DefaultSummaryTrendStats, c.Options.SummaryTrendStats)
 		}},
 		{opts{cli: []string{"--summary-trend-stats", `""`}}, exp{}, func(t *testing.T, c Config) {
-			assert.Equal(t, lib.DefaultSummaryTrendStats, c.Options.SummaryTrendStats)
+			assert.Equal(t, []string{}, c.Options.SummaryTrendStats)
 		}},
 		{
 			opts{runner: &lib.Options{SummaryTrendStats: []string{"avg", "p(90)", "count"}}},

--- a/cmd/config_consolidation_test.go
+++ b/cmd/config_consolidation_test.go
@@ -412,6 +412,20 @@ func getConfigConsolidationTestCases() []configConsolidationTestCase {
 				)
 			},
 		},
+		// Test summary trend stats
+		{opts{}, exp{}, func(t *testing.T, c Config) {
+			assert.Equal(t, lib.DefaultSummaryTrendStats, c.Options.SummaryTrendStats)
+		}},
+		{opts{cli: []string{"--summary-trend-stats", `""`}}, exp{}, func(t *testing.T, c Config) {
+			assert.Equal(t, lib.DefaultSummaryTrendStats, c.Options.SummaryTrendStats)
+		}},
+		{
+			opts{runner: &lib.Options{SummaryTrendStats: []string{"avg", "p(90)", "count"}}},
+			exp{},
+			func(t *testing.T, c Config) {
+				assert.Equal(t, []string{"avg", "p(90)", "count"}, c.Options.SummaryTrendStats)
+			},
+		},
 		//TODO: test for differences between flagsets
 		//TODO: more tests in general, especially ones not related to execution parameters...
 	}

--- a/cmd/config_consolidation_test.go
+++ b/cmd/config_consolidation_test.go
@@ -416,8 +416,15 @@ func getConfigConsolidationTestCases() []configConsolidationTestCase {
 		{opts{}, exp{}, func(t *testing.T, c Config) {
 			assert.Equal(t, lib.DefaultSummaryTrendStats, c.Options.SummaryTrendStats)
 		}},
-		{opts{cli: []string{"--summary-trend-stats", `""`}}, exp{}, func(t *testing.T, c Config) {
+		{opts{cli: []string{"--summary-trend-stats", ""}}, exp{}, func(t *testing.T, c Config) {
 			assert.Equal(t, []string{}, c.Options.SummaryTrendStats)
+		}},
+		{opts{cli: []string{"--summary-trend-stats", "coun"}}, exp{consolidationError: true}, nil},
+		{opts{cli: []string{"--summary-trend-stats", "med,avg,p("}}, exp{consolidationError: true}, nil},
+		{opts{cli: []string{"--summary-trend-stats", "med,avg,p(-1)"}}, exp{consolidationError: true}, nil},
+		{opts{cli: []string{"--summary-trend-stats", "med,avg,p(101)"}}, exp{consolidationError: true}, nil},
+		{opts{cli: []string{"--summary-trend-stats", "med,avg,p(99.999)"}}, exp{}, func(t *testing.T, c Config) {
+			assert.Equal(t, []string{"med", "avg", "p(99.999)"}, c.Options.SummaryTrendStats)
 		}},
 		{
 			opts{runner: &lib.Options{SummaryTrendStats: []string{"avg", "p(90)", "count"}}},

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -63,7 +63,14 @@ func optionFlagSet() *pflag.FlagSet {
 	flags.Duration("min-iteration-duration", 0, "minimum amount of time k6 will take executing a single iteration")
 	flags.BoolP("throw", "w", false, "throw warnings (like failed http requests) as errors")
 	flags.StringSlice("blacklist-ip", nil, "blacklist an `ip range` from being called")
-	flags.StringSlice("summary-trend-stats", nil, "define `stats` for trend metrics (response times), one or more as 'avg,p(95),...'")
+
+	// The comment about system-tags also applies for summary-trend-stats. The default values
+	// are set in applyDefault().
+	sumTrendStatsHelp := fmt.Sprintf(
+		"define `stats` for trend metrics (response times), one or more as 'avg,p(95),...' (default '%s')",
+		strings.Join(lib.DefaultSummaryTrendStats, ","),
+	)
+	flags.StringSlice("summary-trend-stats", nil, sumTrendStatsHelp)
 	flags.String("summary-time-unit", "", "define the time unit used to display the trend stats. Possible units are: 's', 'ms' and 'us'")
 	// system-tags must have a default value, but we can't specify it here, otherwiese, it will always override others.
 	// set it to nil here, and add the default in applyDefault() instead.
@@ -143,16 +150,15 @@ func getOptions(flags *pflag.FlagSet) (lib.Options, error) {
 		opts.BlacklistIPs = append(opts.BlacklistIPs, net)
 	}
 
-	trendStatStrings, err := flags.GetStringSlice("summary-trend-stats")
-	if err != nil {
-		return opts, err
-	}
-	for _, s := range trendStatStrings {
-		if err := ui.VerifyTrendColumnStat(s); err != nil {
-			return opts, errors.Wrapf(err, "stat '%s'", s)
+	if flags.Changed("summary-trend-stats") {
+		trendStats, errSts := flags.GetStringSlice("summary-trend-stats")
+		if errSts != nil {
+			return opts, errSts
 		}
-
-		opts.SummaryTrendStats = append(opts.SummaryTrendStats, s)
+		if errSts = ui.ValidateSummary(trendStats); err != nil {
+			return opts, errSts
+		}
+		opts.SummaryTrendStats = trendStats
 	}
 
 	summaryTimeUnit, err := flags.GetString("summary-time-unit")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -176,11 +176,6 @@ a commandline interface for interacting with it.`,
 			return ExitCode{cerr, invalidConfigErrorCode}
 		}
 
-		// If summary trend stats are defined, update the UI to reflect them
-		if len(conf.SummaryTrendStats) > 0 {
-			ui.UpdateTrendColumns(conf.SummaryTrendStats)
-		}
-
 		// Write options back to the runner too.
 		if err = r.SetOptions(conf.Options); err != nil {
 			return err
@@ -448,12 +443,15 @@ a commandline interface for interacting with it.`,
 		// Print the end-of-test summary.
 		if !conf.NoSummary.Bool {
 			fprintf(stdout, "\n")
-			ui.Summarize(stdout, "", ui.SummaryData{
-				Opts:    conf.Options,
-				Root:    engine.Executor.GetRunner().GetDefaultGroup(),
-				Metrics: engine.Metrics,
-				Time:    engine.Executor.GetTime(),
+
+			s := ui.NewSummary(conf.SummaryTrendStats)
+			s.SummarizeMetrics(stdout, "", ui.SummaryData{
+				Metrics:   engine.Metrics,
+				RootGroup: engine.Executor.GetRunner().GetDefaultGroup(),
+				Time:      engine.Executor.GetTime(),
+				TimeUnit:  conf.Options.SummaryTimeUnit.String,
 			})
+
 			fprintf(stdout, "\n")
 		}
 

--- a/lib/options.go
+++ b/lib/options.go
@@ -39,6 +39,10 @@ import (
 // iterations+vus, or stages)
 const DefaultSchedulerName = "default"
 
+// DefaultSummaryTrendStats are the default trend columns shown in the test summary output
+// nolint: gochecknoglobals
+var DefaultSummaryTrendStats = []string{"avg", "min", "med", "max", "p(90)", "p(95)"}
+
 // Describes a TLS version. Serialised to/from JSON as a string, eg. "tls1.2".
 type TLSVersion int
 

--- a/ui/summary.go
+++ b/ui/summary.go
@@ -46,8 +46,9 @@ const (
 var (
 	errStatEmptyString            = errors.New("invalid stat, empty string")
 	errStatUnknownFormat          = errors.New("invalid stat, unknown format")
-	errPercentileStatInvalidValue = errors.New("invalid percentile stat value, accepts a number")
-	staticResolvers               = map[string]func(s *stats.TrendSink) interface{}{
+	errPercentileStatInvalidValue = errors.New(
+		"invalid percentile stat value, accepts a number between 0 and 100")
+	staticResolvers = map[string]func(s *stats.TrendSink) interface{}{
 		"avg":   func(s *stats.TrendSink) interface{} { return s.Avg },
 		"min":   func(s *stats.TrendSink) interface{} { return s.Min },
 		"med":   func(s *stats.TrendSink) interface{} { return s.Med },
@@ -127,7 +128,7 @@ func validatePercentile(stat string) (float64, error) {
 
 	percentile, err := strconv.ParseFloat(stat[2:len(stat)-1], 64)
 
-	if err != nil {
+	if err != nil || ((0 > percentile) || (percentile > 100)) {
 		return 0, errPercentileStatInvalidValue
 	}
 

--- a/ui/summary_test.go
+++ b/ui/summary_test.go
@@ -21,33 +21,113 @@
 package ui
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/stats"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/guregu/null.v3"
 )
 
-var verifyTests = []struct {
-	in  string
-	out error
-}{
-	{"avg", nil},
-	{"min", nil},
-	{"med", nil},
-	{"max", nil},
-	{"p(0)", nil},
-	{"p(90)", nil},
-	{"p(95)", nil},
-	{"p(99)", nil},
-	{"p(99.9)", nil},
-	{"p(99.9999)", nil},
-	{"nil", ErrStatUnknownFormat},
-	{" avg", ErrStatUnknownFormat},
-	{"avg ", ErrStatUnknownFormat},
-	{"", ErrStatEmptyString},
+func TestSummary(t *testing.T) {
+	t.Run("SummarizeMetrics", func(t *testing.T) {
+		var (
+			checksOut = "     █ child\n\n       ✗ check1\n        ↳  33% — ✓ 5 / ✗ 10\n\n" +
+				"   ✓ checks......: 100.00% ✓ 3   ✗ 0  \n"
+			countOut = "   ✗ http_reqs...: 3       3/s\n"
+			gaugeOut = "     vus.........: 1       min=1 max=1\n"
+			trendOut = "     my_trend....: avg=15ms min=10ms med=15ms max=20ms p(90)=19ms " +
+				"p(95)=19.5ms p(99.9)=19.99ms\n"
+		)
+
+		metrics := createTestMetrics()
+		testCases := []struct {
+			stats    []string
+			expected string
+		}{
+			{[]string{"avg", "min", "med", "max", "p(90)", "p(95)", "p(99.9)"},
+				checksOut + countOut + trendOut + gaugeOut},
+			{[]string{"count"}, checksOut + countOut + "     my_trend....: count=3\n" + gaugeOut},
+			{[]string{"avg", "count"}, checksOut + countOut + "     my_trend....: avg=15ms count=3\n" + gaugeOut},
+		}
+
+		rootG, _ := lib.NewGroup("", nil)
+		childG, _ := rootG.Group("child")
+		check, _ := lib.NewCheck("check1", childG)
+		check.Passes = 5
+		check.Fails = 10
+		childG.Checks["check1"] = check
+		for _, tc := range testCases {
+			tc := tc
+			t.Run(fmt.Sprintf("%v", tc.stats), func(t *testing.T) {
+				var w bytes.Buffer
+				s := NewSummary(tc.stats)
+
+				s.SummarizeMetrics(&w, " ", SummaryData{
+					Metrics:   metrics,
+					RootGroup: rootG,
+					Time:      time.Second,
+					TimeUnit:  "",
+				})
+				assert.Equal(t, tc.expected, w.String())
+			})
+		}
+	})
+
+	t.Run("generateCustomTrendValueResolvers", func(t *testing.T) {
+		var customResolversTests = []struct {
+			stats      []string
+			percentile float64
+		}{
+			{[]string{"p(99)", "p(err)"}, 0.99},
+			{[]string{"p(none", "p(99.9)"}, 0.9990000000000001},
+			{[]string{"p(none", "p(99.99)"}, 0.9998999999999999},
+			{[]string{"p(none", "p(99.999)"}, 0.9999899999999999},
+		}
+
+		sink := createTestTrendSink(100)
+
+		for _, tc := range customResolversTests {
+			tc := tc
+			t.Run(fmt.Sprintf("%v", tc.stats), func(t *testing.T) {
+				s := Summary{trendColumns: tc.stats}
+				res := s.generateCustomTrendValueResolvers(tc.stats)
+				assert.Len(t, res, 1)
+				for k := range res {
+					assert.Equal(t, sink.P(tc.percentile), res[k](sink))
+				}
+			})
+		}
+	})
 }
 
-var defaultTrendColumns = TrendColumns
+func TestValidateSummary(t *testing.T) {
+	var validateTests = []struct {
+		stats  []string
+		expErr error
+	}{
+		{[]string{}, nil},
+		{[]string{"avg", "min", "med", "max", "p(0)", "p(99)", "p(99.999)", "count"}, nil},
+		{[]string{"avg", "p(err)"}, ErrInvalidStat{"p(err)", errPercentileStatInvalidValue}},
+		{[]string{"nil", "p(err)"}, ErrInvalidStat{"nil", errStatUnknownFormat}},
+		{[]string{"p90"}, ErrInvalidStat{"p90", errStatUnknownFormat}},
+		{[]string{"p(90"}, ErrInvalidStat{"p(90", errStatUnknownFormat}},
+		{[]string{" avg"}, ErrInvalidStat{" avg", errStatUnknownFormat}},
+		{[]string{"avg "}, ErrInvalidStat{"avg ", errStatUnknownFormat}},
+		{[]string{"", "avg "}, ErrInvalidStat{"", errStatEmptyString}},
+	}
+
+	for _, tc := range validateTests {
+		tc := tc
+		t.Run(fmt.Sprintf("%v", tc.stats), func(t *testing.T) {
+			err := ValidateSummary(tc.stats)
+			assert.Equal(t, tc.expErr, err)
+		})
+	}
+}
 
 func createTestTrendSink(count int) *stats.TrendSink {
 	sink := stats.TrendSink{}
@@ -59,102 +139,28 @@ func createTestTrendSink(count int) *stats.TrendSink {
 	return &sink
 }
 
-func TestVerifyTrendColumnStat(t *testing.T) {
-	for _, testCase := range verifyTests {
-		err := VerifyTrendColumnStat(testCase.in)
-		assert.Equal(t, testCase.out, err)
+func createTestMetrics() map[string]*stats.Metric {
+	metrics := make(map[string]*stats.Metric)
+	gaugeMetric := stats.New("vus", stats.Gauge)
+	gaugeMetric.Sink.Add(stats.Sample{Value: 1})
+
+	countMetric := stats.New("http_reqs", stats.Counter)
+	countMetric.Tainted = null.BoolFrom(true)
+	checksMetric := stats.New("checks", stats.Rate)
+	checksMetric.Tainted = null.BoolFrom(false)
+	sink := &stats.TrendSink{}
+
+	samples := []float64{10.0, 15.0, 20.0}
+	for _, s := range samples {
+		sink.Add(stats.Sample{Value: s})
+		checksMetric.Sink.Add(stats.Sample{Value: 1})
+		countMetric.Sink.Add(stats.Sample{Value: 1})
 	}
-}
 
-func TestUpdateTrendColumns(t *testing.T) {
-	sink := createTestTrendSink(100)
+	metrics["vus"] = gaugeMetric
+	metrics["http_reqs"] = countMetric
+	metrics["checks"] = checksMetric
+	metrics["my_trend"] = &stats.Metric{Name: "my_trend", Type: stats.Trend, Contains: stats.Time, Sink: sink}
 
-	t.Run("No stats", func(t *testing.T) {
-		TrendColumns = defaultTrendColumns
-
-		UpdateTrendColumns(make([]string, 0))
-
-		assert.Equal(t, defaultTrendColumns, TrendColumns)
-	})
-
-	t.Run("One stat", func(t *testing.T) {
-		TrendColumns = defaultTrendColumns
-
-		UpdateTrendColumns([]string{"avg"})
-
-		assert.Exactly(t, 1, len(TrendColumns))
-		assert.Exactly(t,
-			sink.Avg,
-			TrendColumns[0].Get(sink))
-	})
-
-	t.Run("Multiple stats", func(t *testing.T) {
-		TrendColumns = defaultTrendColumns
-
-		UpdateTrendColumns([]string{"med", "max"})
-
-		assert.Exactly(t, 2, len(TrendColumns))
-		assert.Exactly(t, sink.Med, TrendColumns[0].Get(sink))
-		assert.Exactly(t, sink.Max, TrendColumns[1].Get(sink))
-	})
-
-	t.Run("Ignore invalid stats", func(t *testing.T) {
-		TrendColumns = defaultTrendColumns
-
-		UpdateTrendColumns([]string{"med", "max", "invalid"})
-
-		assert.Exactly(t, 2, len(TrendColumns))
-		assert.Exactly(t, sink.Med, TrendColumns[0].Get(sink))
-		assert.Exactly(t, sink.Max, TrendColumns[1].Get(sink))
-	})
-
-	t.Run("Percentile stats", func(t *testing.T) {
-		TrendColumns = defaultTrendColumns
-
-		UpdateTrendColumns([]string{"p(99.9999)"})
-
-		assert.Exactly(t, 1, len(TrendColumns))
-		assert.Exactly(t, sink.P(0.999999), TrendColumns[0].Get(sink))
-	})
-}
-
-func TestGeneratePercentileTrendColumn(t *testing.T) {
-	sink := createTestTrendSink(100)
-
-	t.Run("Happy path", func(t *testing.T) {
-		colFunc, err := generatePercentileTrendColumn("p(99)")
-		assert.Nil(t, err)
-		assert.NotNil(t, colFunc)
-		assert.Exactly(t, sink.P(0.99), colFunc(sink))
-		assert.NotEqual(t, sink.P(0.98), colFunc(sink))
-		assert.Nil(t, err)
-	})
-
-	t.Run("Empty stat", func(t *testing.T) {
-		colFunc, err := generatePercentileTrendColumn("")
-
-		assert.Nil(t, colFunc)
-		assert.Exactly(t, err, ErrStatEmptyString)
-	})
-
-	t.Run("Invalid format", func(t *testing.T) {
-		colFunc, err := generatePercentileTrendColumn("p90")
-
-		assert.Nil(t, colFunc)
-		assert.Exactly(t, err, ErrStatUnknownFormat)
-	})
-
-	t.Run("Invalid format 2", func(t *testing.T) {
-		colFunc, err := generatePercentileTrendColumn("p(90")
-
-		assert.Nil(t, colFunc)
-		assert.Exactly(t, err, ErrStatUnknownFormat)
-	})
-
-	t.Run("Invalid float", func(t *testing.T) {
-		colFunc, err := generatePercentileTrendColumn("p(a)")
-
-		assert.Nil(t, colFunc)
-		assert.Exactly(t, err, ErrPercentileStatInvalidValue)
-	})
+	return metrics
 }


### PR DESCRIPTION
This adds an optional `count` column for Trend metrics in the CLI summary output, while refactoring parts of `ui/summary.go` for code style (avoiding globals, explicit validation, etc.) and negligible performance improvements (using a map for column lookups).

To enable it run e.g. `k6 run --summary-trend-stats 'avg,p(99.99),count' test.js`.

This essentially makes the existing default Count metrics like "http_reqs" and "iterations" obsolete, so we might want to consider making `count` a default column after all and removing these two metrics from the output.

I added a test for `SummarizeMetrics`, so our coverage should improve a bit. :)

Closes #1087