### PR TITLE
move HTTPMultiBin to it's own package

### DIFF
--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/loadimpact/k6/js"
 	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/lib/metrics"
-	"github.com/loadimpact/k6/lib/testutils"
+	"github.com/loadimpact/k6/lib/testutils/httpmultibin"
 	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/loader"
 	"github.com/loadimpact/k6/stats"
@@ -509,7 +509,7 @@ const expectedHeaderMaxLength = 500
 
 func TestSentReceivedMetrics(t *testing.T) {
 	t.Parallel()
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 	tr := tb.Replacer.Replace
 
@@ -641,7 +641,7 @@ func TestSentReceivedMetrics(t *testing.T) {
 
 func TestRunTags(t *testing.T) {
 	t.Parallel()
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 
 	runTagsMap := map[string]string{"foo": "bar", "test": "mest", "over": "written"}
@@ -765,7 +765,7 @@ func TestRunTags(t *testing.T) {
 
 func TestSetupTeardownThresholds(t *testing.T) {
 	t.Parallel()
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 
 	script := []byte(tb.Replacer.Replace(`
@@ -832,7 +832,7 @@ func TestSetupTeardownThresholds(t *testing.T) {
 
 func TestEmittedMetricsWhenScalingDown(t *testing.T) {
 	t.Parallel()
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 
 	script := []byte(tb.Replacer.Replace(`

--- a/js/http_bench_test.go
+++ b/js/http_bench_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/loadimpact/k6/lib"
-	"github.com/loadimpact/k6/lib/testutils"
+	"github.com/loadimpact/k6/lib/testutils/httpmultibin"
 	"github.com/loadimpact/k6/stats"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/guregu/null.v3"
@@ -13,7 +13,7 @@ import (
 
 func BenchmarkHTTPRequests(b *testing.B) {
 	b.StopTimer()
-	tb := testutils.NewHTTPMultiBin(b)
+	tb := httpmultibin.NewHTTPMultiBin(b)
 	defer tb.Cleanup()
 
 	r, err := getSimpleRunner("/script.js", tb.Replacer.Replace(`

--- a/js/module_loading_test.go
+++ b/js/module_loading_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 
 	"github.com/loadimpact/k6/lib"
-	"github.com/loadimpact/k6/lib/testutils"
+	"github.com/loadimpact/k6/lib/testutils/httpmultibin"
 	"github.com/loadimpact/k6/stats"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
@@ -168,7 +168,7 @@ func TestLoadDoesntBreakHTTPGet(t *testing.T) {
 	// This test that functions such as http.get which require context still work if they are called
 	// inside script that is imported
 
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 	fs := afero.NewMemMapFs()
 	require.NoError(t, afero.WriteFile(fs, "/A.js", []byte(tb.Replacer.Replace(`

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/lib/metrics"
 	"github.com/loadimpact/k6/lib/testutils"
+	"github.com/loadimpact/k6/lib/testutils/httpmultibin"
 	"github.com/loadimpact/k6/stats"
 	"github.com/mccutchen/go-httpbin/httpbin"
 	"github.com/oxtoacart/bpool"
@@ -105,8 +106,8 @@ func assertRequestMetricsEmitted(t *testing.T, sampleContainers []stats.SampleCo
 
 func newRuntime(
 	t testing.TB,
-) (*testutils.HTTPMultiBin, *lib.State, chan stats.SampleContainer, *goja.Runtime, *context.Context) {
-	tb := testutils.NewHTTPMultiBin(t)
+) (*httpmultibin.HTTPMultiBin, *lib.State, chan stats.SampleContainer, *goja.Runtime, *context.Context) {
+	tb := httpmultibin.NewHTTPMultiBin(t)
 
 	root, err := lib.NewGroup("", nil)
 	require.NoError(t, err)

--- a/js/modules/k6/marshalling_test.go
+++ b/js/modules/k6/marshalling_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/loadimpact/k6/js"
 	"github.com/loadimpact/k6/lib"
-	"github.com/loadimpact/k6/lib/testutils"
+	"github.com/loadimpact/k6/lib/testutils/httpmultibin"
 	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/loader"
 	"github.com/loadimpact/k6/stats"
@@ -37,7 +37,7 @@ import (
 )
 
 func TestSetupDataMarshalling(t *testing.T) {
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 
 	script := []byte(tb.Replacer.Replace(`

--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/loadimpact/k6/js/common"
 	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/lib/metrics"
-	"github.com/loadimpact/k6/lib/testutils"
+	"github.com/loadimpact/k6/lib/testutils/httpmultibin"
 	"github.com/loadimpact/k6/stats"
 	"github.com/stretchr/testify/assert"
 )
@@ -83,7 +83,7 @@ func assertMetricEmitted(t *testing.T, metric *stats.Metric, sampleContainers []
 func TestSession(t *testing.T) {
 	//TODO: split and paralelize tests
 	t.Parallel()
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 	sr := tb.Replacer.Replace
 
@@ -279,7 +279,7 @@ func TestSession(t *testing.T) {
 
 func TestErrors(t *testing.T) {
 	t.Parallel()
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 	sr := tb.Replacer.Replace
 
@@ -357,7 +357,7 @@ func TestErrors(t *testing.T) {
 }
 
 func TestSystemTags(t *testing.T) {
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 
 	sr := tb.Replacer.Replace
@@ -422,7 +422,7 @@ func TestTLSConfig(t *testing.T) {
 	root, err := lib.NewGroup("", nil)
 	assert.NoError(t, err)
 
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 
 	sr := tb.Replacer.Replace

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -45,7 +45,7 @@ import (
 	"github.com/loadimpact/k6/js/modules/k6/ws"
 	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/lib/metrics"
-	"github.com/loadimpact/k6/lib/testutils"
+	"github.com/loadimpact/k6/lib/testutils/httpmultibin"
 	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/stats"
 	"github.com/loadimpact/k6/stats/dummy"
@@ -211,7 +211,7 @@ func TestOptionsPropagationToScript(t *testing.T) {
 }
 
 func TestMetricName(t *testing.T) {
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 
 	script := tb.Replacer.Replace(`
@@ -229,7 +229,7 @@ func TestMetricName(t *testing.T) {
 }
 
 func TestSetupDataIsolation(t *testing.T) {
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 
 	script := tb.Replacer.Replace(`
@@ -759,7 +759,7 @@ func TestVUIntegrationBlacklistScript(t *testing.T) {
 }
 
 func TestVUIntegrationHosts(t *testing.T) {
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 
 	r1, err := getSimpleRunner("/script.js",
@@ -940,7 +940,7 @@ func TestVUIntegrationOpenFunctionError(t *testing.T) {
 
 func TestVUIntegrationCookiesReset(t *testing.T) {
 
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 
 	r1, err := getSimpleRunner("/script.js", tb.Replacer.Replace(`
@@ -990,7 +990,7 @@ func TestVUIntegrationCookiesReset(t *testing.T) {
 }
 
 func TestVUIntegrationCookiesNoReset(t *testing.T) {
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 
 	r1, err := getSimpleRunner("/script.js", tb.Replacer.Replace(`
@@ -1217,7 +1217,7 @@ func TestVUIntegrationClientCerts(t *testing.T) {
 }
 
 func TestHTTPRequestInInitContext(t *testing.T) {
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 
 	_, err := getSimpleRunner("/script.js", tb.Replacer.Replace(`
@@ -1296,7 +1296,7 @@ func TestInitContextForbidden(t *testing.T) {
 			k6metrics.ErrMetricsAddInInitContext.Error(),
 		},
 	}
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 
 	for _, test := range table {
@@ -1314,7 +1314,7 @@ func TestInitContextForbidden(t *testing.T) {
 }
 
 func TestArchiveRunningIntegraty(t *testing.T) {
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 
 	fs := afero.NewMemMapFs()
@@ -1358,7 +1358,7 @@ func TestArchiveRunningIntegraty(t *testing.T) {
 }
 
 func TestArchiveNotPanicking(t *testing.T) {
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 
 	fs := afero.NewMemMapFs()
@@ -1380,7 +1380,7 @@ func TestArchiveNotPanicking(t *testing.T) {
 }
 
 func TestStuffNotPanicking(t *testing.T) {
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 
 	r, err := getSimpleRunner("/script.js", tb.Replacer.Replace(`

--- a/lib/testutils/httpmultibin/httpmultibin.go
+++ b/lib/testutils/httpmultibin/httpmultibin.go
@@ -18,8 +18,8 @@
  *
  */
 
-// Package testutils is indended only for use in tests, do not import in production code!
-package testutils
+// Package httpmultibin is indended only for use in tests, do not import in production code!
+package httpmultibin
 
 import (
 	"context"

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -27,7 +27,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/loadimpact/k6/lib/testutils"
+	"github.com/loadimpact/k6/lib/testutils/httpmultibin"
 	"github.com/loadimpact/k6/loader"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -100,7 +100,7 @@ func TestResolve(t *testing.T) {
 
 }
 func TestLoad(t *testing.T) {
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	sr := tb.Replacer.Replace
 
 	oldHTTPTransport := http.DefaultTransport

--- a/stats/cloud/collector_test.go
+++ b/stats/cloud/collector_test.go
@@ -41,7 +41,7 @@ import (
 	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/lib/metrics"
 	"github.com/loadimpact/k6/lib/netext/httpext"
-	"github.com/loadimpact/k6/lib/testutils"
+	"github.com/loadimpact/k6/lib/testutils/httpmultibin"
 	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/loader"
 	"github.com/loadimpact/k6/stats"
@@ -121,7 +121,7 @@ func skewTrail(t httpext.Trail, minCoef, maxCoef float64) httpext.Trail {
 
 func TestCloudCollector(t *testing.T) {
 	t.Parallel()
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	tb.Mux.HandleFunc("/v1/tests", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := fmt.Fprintf(w, `{
 			"reference_id": "123",
@@ -265,7 +265,7 @@ func TestCloudCollector(t *testing.T) {
 
 func TestCloudCollectorMaxPerPacket(t *testing.T) {
 	t.Parallel()
-	tb := testutils.NewHTTPMultiBin(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	var maxMetricSamplesPerPackage = 20
 	tb.Mux.HandleFunc("/v1/tests", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := fmt.Fprintf(w, `{


### PR DESCRIPTION
This is done because it gets in the way of using the `testutils` package
inside lib