### PR TITLE
Fix(?): flaky TestSentReceivedMetrics test

### DIFF
--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -618,10 +618,10 @@ func TestSentReceivedMetrics(t *testing.T) {
 			reuseSent, reuseReceived := runTest(t, ts, tc, false)
 
 			if noReuseSent < reuseSent {
-				t.Errorf("noReuseSent=%f is greater than reuseSent=%f", noReuseSent, reuseSent)
+				t.Errorf("reuseSent=%f is greater than noReuseSent=%f", reuseSent, noReuseSent)
 			}
 			if noReuseReceived < reuseReceived {
-				t.Errorf("noReuseReceived=%f is greater than reuseReceived=%f", noReuseReceived, reuseReceived)
+				t.Errorf("reuseReceived=%f is greater than noReuseReceived=%f", reuseReceived, noReuseReceived)
 			}
 		}
 	}

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -540,7 +540,7 @@ func TestSentReceivedMetrics(t *testing.T) {
 		{tr(`import ws from "k6/ws";
 			let data = "0123456789".repeat(100);
 			export default function() {
-				ws.connect("ws://HTTPBIN_IP:HTTPBIN_PORT/ws-echo", null, function (socket) {
+				ws.connect("WSBIN_URL/ws-echo", null, function (socket) {
 					socket.on('open', function open() {
 						socket.send(data);
 					});
@@ -667,7 +667,7 @@ func TestRunTags(t *testing.T) {
 			})
 
 			group("websockets", function() {
-				var response = ws.connect("wss://HTTPSBIN_IP:HTTPSBIN_PORT/ws-echo", params, function (socket) {
+				var response = ws.connect("WSBIN_URL/ws-echo", params, function (socket) {
 					socket.on('open', function open() {
 						console.log('ws open and say hello');
 						socket.send("hello");

--- a/lib/testutils/httpmultibin/httpmultibin.go
+++ b/lib/testutils/httpmultibin/httpmultibin.go
@@ -106,15 +106,17 @@ func websocketEchoHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	for {
-		mt, message, err := conn.ReadMessage()
-		if err != nil {
-			break
-		}
-		err = conn.WriteMessage(mt, message)
-		if err != nil {
-			break
-		}
+	mt, message, err := conn.ReadMessage()
+	if err != nil {
+		return
+	}
+	err = conn.WriteMessage(mt, message)
+	if err != nil {
+		return
+	}
+	err = conn.Close()
+	if err != nil {
+		return
 	}
 }
 


### PR DESCRIPTION
This _should_ fix flaky test `TestSentReceivedMetrics`.
See https://circleci.com/gh/loadimpact/k6/6474, https://circleci.com/gh/loadimpact/k6/6484 .

This issue was introduced in a63bb586 (PR #1138), where the previous implementation of `getWebsocketEchoHandler()` closed the connection after writing, so this change brings that back.

It seems that closing the connection creates additional metrics which `TestSentReceivedMetrics` takes into account _sometimes_, hence the flakiness.

Please run `go test -count=1 ./core` on this branch a few times on your local machine to ensure it's fixed. :)

There are a few unrelated things to the fix here, but check out the individual commits, and let me know if you prefer another PR for them. I just added them here since they're kind of related.