### PR TITLE
fix(js): properly marshal lib.Options values to JS options

### DIFF
--- a/js/bundle.go
+++ b/js/bundle.go
@@ -27,6 +27,7 @@ import (
 	"runtime"
 
 	"github.com/loadimpact/k6/lib/consts"
+	"gopkg.in/guregu/null.v3"
 
 	"github.com/dop251/goja"
 	"github.com/loadimpact/k6/js/common"
@@ -217,6 +218,18 @@ func (b *Bundle) Instantiate() (bi *BundleInstance, instErr error) {
 		jsOptionsObj = jsOptions.ToObject(rt)
 	}
 	b.Options.ForEachSpecified("json", func(key string, val interface{}) {
+		switch v := val.(type) {
+		case null.Bool:
+			val = v.ValueOrZero()
+		case null.Float:
+			val = v.ValueOrZero()
+		case null.Int:
+			val = v.ValueOrZero()
+		case null.String:
+			val = v.ValueOrZero()
+		case null.Time:
+			val = v.ValueOrZero()
+		}
 		if err := jsOptionsObj.Set(key, val); err != nil {
 			instErr = err
 		}

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -27,7 +27,6 @@ import (
 	"runtime"
 
 	"github.com/loadimpact/k6/lib/consts"
-	"gopkg.in/guregu/null.v3"
 
 	"github.com/dop251/goja"
 	"github.com/loadimpact/k6/js/common"
@@ -218,18 +217,6 @@ func (b *Bundle) Instantiate() (bi *BundleInstance, instErr error) {
 		jsOptionsObj = jsOptions.ToObject(rt)
 	}
 	b.Options.ForEachSpecified("json", func(key string, val interface{}) {
-		switch v := val.(type) {
-		case null.Bool:
-			val = v.ValueOrZero()
-		case null.Float:
-			val = v.ValueOrZero()
-		case null.Int:
-			val = v.ValueOrZero()
-		case null.String:
-			val = v.ValueOrZero()
-		case null.Time:
-			val = v.ValueOrZero()
-		}
 		if err := jsOptionsObj.Set(key, val); err != nil {
 			instErr = err
 		}

--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -588,6 +588,9 @@ func TestOpen(t *testing.T) {
 
 func TestBundleInstantiate(t *testing.T) {
 	b, err := getSimpleBundle("/script.js", `
+		export let options = {
+			vus: 5,
+		};
 		let val = true;
 		export default function() { return val; }
 	`)
@@ -613,6 +616,13 @@ func TestBundleInstantiate(t *testing.T) {
 		if assert.NoError(t, err) {
 			assert.Equal(t, false, v.Export())
 		}
+	})
+
+	t.Run("Options", func(t *testing.T) {
+		// Ensure `options` properties are correctly marshalled
+		jsOptions := bi.Runtime.Get("options").ToObject(bi.Runtime)
+		val := jsOptions.Get("vus").Export()
+		assert.Equal(t, int64(5), val)
 	})
 }
 

--- a/lib/types/types.go
+++ b/lib/types/types.go
@@ -180,3 +180,13 @@ func (d NullDuration) MarshalJSON() ([]byte, error) {
 	}
 	return d.Duration.MarshalJSON()
 }
+
+// ValueOrZero returns the underlying Duration value of d if valid or
+// its zero equivalent otherwise. It matches the existing guregu/null API.
+func (d NullDuration) ValueOrZero() Duration {
+	if !d.Valid {
+		return Duration(0)
+	}
+
+	return d.Duration
+}

--- a/lib/types/types.go
+++ b/lib/types/types.go
@@ -30,6 +30,8 @@ import (
 	null "gopkg.in/guregu/null.v3"
 )
 
+// NullDecoder converts data with expected type f to a guregu/null value
+// of equivalent type t. It returns an error if a type mismatch occurs.
 func NullDecoder(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
 	typeFrom := f.String()
 	typeTo := t.String()
@@ -88,6 +90,7 @@ func (d Duration) String() string {
 	return time.Duration(d).String()
 }
 
+// UnmarshalText converts text data to Duration
 func (d *Duration) UnmarshalText(data []byte) error {
 	v, err := time.ParseDuration(string(data))
 	if err != nil {
@@ -97,6 +100,7 @@ func (d *Duration) UnmarshalText(data []byte) error {
 	return nil
 }
 
+// UnmarshalJSON converts JSON data to Duration
 func (d *Duration) UnmarshalJSON(data []byte) error {
 	if len(data) > 0 && data[0] == '"' {
 		var str string
@@ -121,6 +125,7 @@ func (d *Duration) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON returns the JSON representation of d
 func (d Duration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(d.String())
 }
@@ -137,11 +142,12 @@ func NewNullDuration(d time.Duration, valid bool) NullDuration {
 	return NullDuration{Duration(d), valid}
 }
 
-// Creates a valid NullDuration from a time.Duration.
+// NullDurationFrom returns a new valid NullDuration from a time.Duration.
 func NullDurationFrom(d time.Duration) NullDuration {
 	return NullDuration{Duration(d), true}
 }
 
+// UnmarshalText converts text data to a valid NullDuration
 func (d *NullDuration) UnmarshalText(data []byte) error {
 	if len(data) == 0 {
 		*d = NullDuration{}
@@ -154,6 +160,7 @@ func (d *NullDuration) UnmarshalText(data []byte) error {
 	return nil
 }
 
+// UnmarshalJSON converts JSON data to a valid NullDuration
 func (d *NullDuration) UnmarshalJSON(data []byte) error {
 	if bytes.Equal(data, []byte(`null`)) {
 		d.Valid = false
@@ -166,6 +173,7 @@ func (d *NullDuration) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON returns the JSON representation of d
 func (d NullDuration) MarshalJSON() ([]byte, error) {
 	if !d.Valid {
 		return []byte(`null`), nil


### PR DESCRIPTION
This ensures any `guregu/null` values in `lib.Options` are correctly unpacked and saved as JS script options.

Closes #886