### PR TITLE
temporary use go1.12 for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1-alpine as builder
+FROM golang:1.12-alpine as builder
 WORKDIR $GOPATH/src/github.com/loadimpact/k6
 ADD . .
 RUN apk --no-cache add --virtual .build-deps git make build-base && \


### PR DESCRIPTION
Until https://github.com/golang/go/issues/34066 is fixed.

Update #1153