### PR TITLE
Add report summary CLI flag

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -59,7 +59,7 @@ func configFlagSet() *pflag.FlagSet {
 	flags.String(
 		"summary-export",
 		"",
-		"output summary to file in json format, empty string means output is ignored",
+		"output the end-of-test summary report to JSON file",
 	)
 	return flags
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -56,17 +56,23 @@ func configFlagSet() *pflag.FlagSet {
 	flags.Bool("no-usage-report", false, "don't send anonymous stats to the developers")
 	flags.Bool("no-thresholds", false, "don't run thresholds")
 	flags.Bool("no-summary", false, "don't show the summary at the end of the test")
+	flags.String(
+		"summary-export",
+		"",
+		"output summary to file in json format, empty string means output is ignored",
+	)
 	return flags
 }
 
 type Config struct {
 	lib.Options
 
-	Out           []string  `json:"out" envconfig:"K6_OUT"`
-	Linger        null.Bool `json:"linger" envconfig:"K6_LINGER"`
-	NoUsageReport null.Bool `json:"noUsageReport" envconfig:"K6_NO_USAGE_REPORT"`
-	NoThresholds  null.Bool `json:"noThresholds" envconfig:"K6_NO_THRESHOLDS"`
-	NoSummary     null.Bool `json:"noSummary" envconfig:"K6_NO_SUMMARY"`
+	Out           []string    `json:"out" envconfig:"K6_OUT"`
+	Linger        null.Bool   `json:"linger" envconfig:"K6_LINGER"`
+	NoUsageReport null.Bool   `json:"noUsageReport" envconfig:"K6_NO_USAGE_REPORT"`
+	NoThresholds  null.Bool   `json:"noThresholds" envconfig:"K6_NO_THRESHOLDS"`
+	NoSummary     null.Bool   `json:"noSummary" envconfig:"K6_NO_SUMMARY"`
+	SummaryExport null.String `json:"summaryExport" envconfig:"K6_SUMMARY_EXPORT"`
 
 	Collectors struct {
 		InfluxDB influxdb.Config `json:"influxdb"`
@@ -95,6 +101,9 @@ func (c Config) Apply(cfg Config) Config {
 	if cfg.NoSummary.Valid {
 		c.NoSummary = cfg.NoSummary
 	}
+	if cfg.SummaryExport.Valid {
+		c.SummaryExport = cfg.SummaryExport
+	}
 	c.Collectors.InfluxDB = c.Collectors.InfluxDB.Apply(cfg.Collectors.InfluxDB)
 	c.Collectors.Cloud = c.Collectors.Cloud.Apply(cfg.Collectors.Cloud)
 	c.Collectors.Kafka = c.Collectors.Kafka.Apply(cfg.Collectors.Kafka)
@@ -121,6 +130,7 @@ func getConfig(flags *pflag.FlagSet) (Config, error) {
 		NoUsageReport: getNullBool(flags, "no-usage-report"),
 		NoThresholds:  getNullBool(flags, "no-thresholds"),
 		NoSummary:     getNullBool(flags, "no-summary"),
+		SummaryExport: getNullString(flags, "summary-export"),
 	}, nil
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -456,19 +456,19 @@ a commandline interface for interacting with it.`,
 			fprintf(stdout, "\n")
 		}
 
-		if conf.SummaryExport.Valid && conf.SummaryExport.String != "" {
+		if conf.SummaryExport.ValueOrZero() != "" {
 			f, err := os.Create(conf.SummaryExport.String)
 			if err != nil {
-				logrus.Error("failed to create summary export file")
+				logrus.WithError(err).Error("failed to create summary export file")
 			} else {
 				defer func() {
 					if err := f.Close(); err != nil {
-						logrus.WithError(err).Fatal("failed to close summary output file")
+						logrus.WithError(err).Fatal("failed to close summary export file")
 					}
 				}()
 				s := ui.NewSummary(conf.SummaryTrendStats)
 				if err := s.SummarizeMetricsJSON(f, data); err != nil {
-					logrus.WithError(err).Fatal("failed to make summary export")
+					logrus.WithError(err).Fatal("failed to make json summary export file")
 				}
 			}
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -205,6 +205,9 @@ a commandline interface for interacting with it.`,
 		if conf.NoSummary.Valid {
 			engine.NoSummary = conf.NoSummary.Bool
 		}
+		if conf.SummaryExport.Valid {
+			engine.SummaryExport = conf.SummaryExport.String != ""
+		}
 
 		// Create a collector and assign it to the engine if requested.
 		fprintf(stdout, "%s   collector\r", initBar.String())
@@ -437,19 +440,37 @@ a commandline interface for interacting with it.`,
 			logrus.Warn("No data generated, because no script iterations finished, consider making the test duration longer")
 		}
 
+		data := ui.SummaryData{
+			Metrics:   engine.Metrics,
+			RootGroup: engine.Executor.GetRunner().GetDefaultGroup(),
+			Time:      engine.Executor.GetTime(),
+			TimeUnit:  conf.Options.SummaryTimeUnit.String,
+		}
 		// Print the end-of-test summary.
 		if !conf.NoSummary.Bool {
 			fprintf(stdout, "\n")
 
 			s := ui.NewSummary(conf.SummaryTrendStats)
-			s.SummarizeMetrics(stdout, "", ui.SummaryData{
-				Metrics:   engine.Metrics,
-				RootGroup: engine.Executor.GetRunner().GetDefaultGroup(),
-				Time:      engine.Executor.GetTime(),
-				TimeUnit:  conf.Options.SummaryTimeUnit.String,
-			})
+			s.SummarizeMetrics(stdout, "", data)
 
 			fprintf(stdout, "\n")
+		}
+
+		if conf.SummaryExport.Valid && conf.SummaryExport.String != "" {
+			f, err := os.Create(conf.SummaryExport.String)
+			if err != nil {
+				logrus.Error("failed to create summary export file")
+			} else {
+				defer func() {
+					if err := f.Close(); err != nil {
+						logrus.WithError(err).Fatal("failed to close summary output file")
+					}
+				}()
+				s := ui.NewSummary(conf.SummaryTrendStats)
+				if err := s.SummarizeMetricsJSON(f, data); err != nil {
+					logrus.WithError(err).Fatal("failed to make summary export")
+				}
+			}
 		}
 
 		if conf.Linger.Bool {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -463,12 +463,12 @@ a commandline interface for interacting with it.`,
 			} else {
 				defer func() {
 					if err := f.Close(); err != nil {
-						logrus.WithError(err).Fatal("failed to close summary export file")
+						logrus.WithError(err).Error("failed to close summary export file")
 					}
 				}()
 				s := ui.NewSummary(conf.SummaryTrendStats)
 				if err := s.SummarizeMetricsJSON(f, data); err != nil {
-					logrus.WithError(err).Fatal("failed to make json summary export file")
+					logrus.WithError(err).Error("failed to make summary export file")
 				}
 			}
 		}

--- a/core/engine.go
+++ b/core/engine.go
@@ -50,11 +50,12 @@ const (
 type Engine struct {
 	runLock sync.Mutex
 
-	Executor     lib.Executor
-	Options      lib.Options
-	Collectors   []lib.Collector
-	NoThresholds bool
-	NoSummary    bool
+	Executor      lib.Executor
+	Options       lib.Options
+	Collectors    []lib.Collector
+	NoThresholds  bool
+	NoSummary     bool
+	SummaryExport bool
 
 	logger *logrus.Logger
 
@@ -386,7 +387,7 @@ func (e *Engine) processSamples(sampleContainers []stats.SampleContainer) {
 	defer e.MetricsLock.Unlock()
 
 	// TODO: run this and the below code in goroutines?
-	if !(e.NoSummary && e.NoThresholds) {
+	if !(e.NoSummary && e.NoThresholds && !e.SummaryExport) {
 		e.processSamplesForMetrics(sampleContainers)
 	}
 

--- a/ui/summary.go
+++ b/ui/summary.go
@@ -21,6 +21,7 @@
 package ui
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
@@ -383,4 +384,45 @@ func (s *Summary) SummarizeMetrics(w io.Writer, indent string, data SummaryData)
 	}
 
 	s.summarizeMetrics(w, indent+"  ", data.Time, data.TimeUnit, data.Metrics)
+}
+
+func newJSONEncoder(w io.Writer) *json.Encoder {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "    ")
+	return encoder
+}
+
+func summarizeGroupJSON(w io.Writer, group *lib.Group) error {
+	return newJSONEncoder(w).Encode(group)
+}
+
+func summarizeMetricsJSON(w io.Writer, t time.Duration, timeUnit string, metrics map[string]*stats.Metric) error {
+	data := make(map[string]interface{})
+	for name, m := range metrics {
+		m.Sink.Calc()
+		if sink, ok := m.Sink.(*stats.TrendSink); ok {
+			data[name] = sink.Format(t)
+			continue
+		}
+		data[name] = m.Sink.Format(t)
+		_, extra := nonTrendMetricValueForSum(t, timeUnit, m)
+		if len(extra) > 1 {
+			extraData := make(map[string]interface{})
+			extraData["value"] = m.Sink.Format(t)["value"]
+			extraData["extra"] = extra
+			data[name] = extraData
+		}
+	}
+
+	return newJSONEncoder(w).Encode(data)
+}
+
+// SummarizeMetricsJSON summarizes a dataset in JSON format.
+func (s *Summary) SummarizeMetricsJSON(w io.Writer, data SummaryData) error {
+	if data.RootGroup != nil {
+		if err := summarizeGroupJSON(w, data.RootGroup); err != nil {
+			return err
+		}
+	}
+	return summarizeMetricsJSON(w, data.Time, data.TimeUnit, data.Metrics)
 }

--- a/ui/summary_test.go
+++ b/ui/summary_test.go
@@ -26,10 +26,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/guregu/null.v3"
+
 	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/stats"
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/guregu/null.v3"
 )
 
 func TestSummary(t *testing.T) {
@@ -163,4 +165,81 @@ func createTestMetrics() map[string]*stats.Metric {
 	metrics["my_trend"] = &stats.Metric{Name: "my_trend", Type: stats.Trend, Contains: stats.Time, Sink: sink}
 
 	return metrics
+}
+
+func TestSummarizeMetricsJSON(t *testing.T) {
+	metrics := createTestMetrics()
+	expected := `{
+    "root_group": {
+        "name": "",
+        "path": "",
+        "id": "d41d8cd98f00b204e9800998ecf8427e",
+        "groups": {
+            "child": {
+            "name": "child",
+            "path": "::child",
+            "id": "f41cbb53a398ec1c9fb3d33e20c9b040",
+            "groups": {},
+            "checks": {
+                "check1": {
+                    "name": "check1",
+                    "path": "::child::check1",
+                    "id": "6289a7a06253a1c3f6137dfb25695563",
+                    "passes": 5,
+                    "fails": 10
+                    }
+                }
+            }
+        },
+        "checks": {}
+    },
+    "metrics": {
+        "checks": {
+            "extra": [
+                "✓ 3",
+                "✗ 0"
+            ],
+            "value": 0
+        },
+        "http_reqs": {
+            "count": 3,
+            "rate": 3
+        },
+        "my_trend": {
+            "avg": 15,
+            "max": 20,
+            "med": 15,
+            "min": 10,
+            "p(90)": 19,
+            "p(95)": 19.5
+        },
+        "vus": {
+            "extra": [
+                "min=1",
+                "max=1"
+            ],
+            "value": 1
+        }
+    }
+}
+`
+	rootG, _ := lib.NewGroup("", nil)
+	childG, _ := rootG.Group("child")
+	check, _ := lib.NewCheck("check1", childG)
+	check.Passes = 5
+	check.Fails = 10
+	childG.Checks["check1"] = check
+
+	s := NewSummary([]string{"avg", "min", "med", "max", "p(90)", "p(95)", "p(99.9)"})
+	data := SummaryData{
+		Metrics:   metrics,
+		RootGroup: rootG,
+		Time:      time.Second,
+		TimeUnit:  "",
+	}
+
+	var w bytes.Buffer
+	err := s.SummarizeMetricsJSON(&w, data)
+	require.Nil(t, err)
+	require.JSONEq(t, expected, w.String())
 }

--- a/ui/summary_test.go
+++ b/ui/summary_test.go
@@ -41,7 +41,7 @@ func TestSummary(t *testing.T) {
 				"   ✓ checks......: 100.00% ✓ 3   ✗ 0  \n"
 			countOut = "   ✗ http_reqs...: 3       3/s\n"
 			gaugeOut = "     vus.........: 1       min=1 max=1\n"
-			trendOut = "     my_trend....: avg=15ms min=10ms med=15ms max=20ms p(90)=19ms " +
+			trendOut = "   ✗ my_trend....: avg=15ms min=10ms med=15ms max=20ms p(90)=19ms " +
 				"p(95)=19.5ms p(99.9)=19.99ms\n"
 		)
 
@@ -52,8 +52,8 @@ func TestSummary(t *testing.T) {
 		}{
 			{[]string{"avg", "min", "med", "max", "p(90)", "p(95)", "p(99.9)"},
 				checksOut + countOut + trendOut + gaugeOut},
-			{[]string{"count"}, checksOut + countOut + "     my_trend....: count=3\n" + gaugeOut},
-			{[]string{"avg", "count"}, checksOut + countOut + "     my_trend....: avg=15ms count=3\n" + gaugeOut},
+			{[]string{"count"}, checksOut + countOut + "   ✗ my_trend....: count=3\n" + gaugeOut},
+			{[]string{"avg", "count"}, checksOut + countOut + "   ✗ my_trend....: avg=15ms count=3\n" + gaugeOut},
 		}
 
 		rootG, _ := lib.NewGroup("", nil)


### PR DESCRIPTION
Add --summary-export flag for "k6 run", the parameter is output file to
write report summary in JSON format.

Empty string means output is ignored.

Close #355