### PR TITLE
fix(httpext): return error on unsupported 101 response

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,4 +45,5 @@ linters:
   enable-all: true
   disable:
   - gochecknoinits
+  - godox
   fast: false


### PR DESCRIPTION
Raise an error on a `101 Switching Protocols` response, since k6 doesn't support protocol upgrades in the current HTTP API. This avoids the hanging behavior described in #971.

See the commit description for details (I want to avoid GH's reference link spam).