### PR TITLE
Ignore minIterationDuration in setup/teardown stage

### DIFF
--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -581,15 +581,14 @@ func TestSentReceivedMetrics(t *testing.T) {
 		engine.Collectors = []lib.Collector{collector}
 
 		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		errC := make(chan error)
 		go func() { errC <- engine.Run(ctx) }()
 
 		select {
 		case <-time.After(10 * time.Second):
-			cancel()
 			t.Fatal("Test timed out")
 		case err := <-errC:
-			cancel()
 			require.NoError(t, err)
 		}
 
@@ -723,15 +722,14 @@ func TestRunTags(t *testing.T) {
 	engine.Collectors = []lib.Collector{collector}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	errC := make(chan error)
 	go func() { errC <- engine.Run(ctx) }()
 
 	select {
 	case <-time.After(10 * time.Second):
-		cancel()
 		t.Fatal("Test timed out")
 	case err := <-errC:
-		cancel()
 		require.NoError(t, err)
 	}
 
@@ -816,15 +814,14 @@ func TestSetupTeardownThresholds(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	errC := make(chan error)
 	go func() { errC <- engine.Run(ctx) }()
 
 	select {
 	case <-time.After(10 * time.Second):
-		cancel()
 		t.Fatal("Test timed out")
 	case err := <-errC:
-		cancel()
 		require.NoError(t, err)
 		require.False(t, engine.IsTainted())
 	}
@@ -875,15 +872,14 @@ func TestEmittedMetricsWhenScalingDown(t *testing.T) {
 	engine.Collectors = []lib.Collector{collector}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	errC := make(chan error)
 	go func() { errC <- engine.Run(ctx) }()
 
 	select {
 	case <-time.After(10 * time.Second):
-		cancel()
 		t.Fatal("Test timed out")
 	case err := <-errC:
-		cancel()
 		require.NoError(t, err)
 		require.False(t, engine.IsTainted())
 	}
@@ -949,15 +945,14 @@ func TestMinIterationDuration(t *testing.T) {
 	engine.Collectors = []lib.Collector{collector}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	errC := make(chan error)
 	go func() { errC <- engine.Run(ctx) }()
 
 	select {
 	case <-time.After(10 * time.Second):
-		cancel()
 		t.Fatal("Test timed out")
 	case err := <-errC:
-		cancel()
 		require.NoError(t, err)
 		require.False(t, engine.IsTainted())
 	}
@@ -967,4 +962,71 @@ func TestMinIterationDuration(t *testing.T) {
 
 	// But we expect the custom counter to be added to 4 times
 	assert.Equal(t, 4.0, getMetricSum(collector, "testcounter"))
+}
+
+//nolint: funlen
+func TestMinIterationDurationInSetupTeardownStage(t *testing.T) {
+	t.Parallel()
+	setupScript := `
+		import { sleep } from "k6";
+
+		export function setup() {
+			sleep(1);
+		}
+
+		export let options = {
+			minIterationDuration: "2s",
+			duration: "2s",
+			setupTimeout: "2s",
+		};
+
+		export default function () {
+		};`
+	teardownScript := `
+		import { sleep } from "k6";
+
+		export let options = {
+			minIterationDuration: "2s",
+			duration: "2s",
+			teardownTimeout: "2s",
+		};
+
+		export default function () {
+		};
+
+		export function teardown() {
+			sleep(1);
+		}
+`
+	tests := []struct {
+		name, script string
+	}{
+		{"Test setup", setupScript},
+		{"Test teardown", teardownScript},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			runner, err := js.New(
+				&loader.SourceData{URL: &url.URL{Path: "/script.js"}, Data: []byte(tc.script)},
+				nil,
+				lib.RuntimeOptions{},
+			)
+			require.NoError(t, err)
+			engine, err := NewEngine(local.New(runner), runner.GetOptions())
+			require.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			errC := make(chan error)
+			go func() { errC <- engine.Run(ctx) }()
+			select {
+			case <-time.After(10 * time.Second):
+				t.Fatal("Test timed out")
+			case err := <-errC:
+				require.NoError(t, err)
+				require.False(t, engine.IsTainted())
+			}
+		})
+	}
 }

--- a/js/runner.go
+++ b/js/runner.go
@@ -423,7 +423,10 @@ func (u *VU) RunOnce(ctx context.Context) error {
 	// If MinIterationDuration is specified and the iteration wasn't cancelled
 	// and was less than it, sleep for the remainder
 	if isFullIteration && u.Runner.Bundle.Options.MinIterationDuration.Valid {
-		time.Sleep(time.Duration(u.Runner.Bundle.Options.MinIterationDuration.Duration) - totalTime)
+		durationDiff := time.Duration(u.Runner.Bundle.Options.MinIterationDuration.Duration) - totalTime
+		if durationDiff > 0 {
+			time.Sleep(durationDiff)
+		}
 	}
 
 	return err

--- a/js/runner.go
+++ b/js/runner.go
@@ -319,7 +319,7 @@ func (r *Runner) runPart(ctx context.Context, out chan<- stats.SampleContainer, 
 		return goja.Undefined(), err
 	}
 
-	v, _, err := vu.runFn(ctx, group, fn, vu.Runtime.ToValue(arg))
+	v, _, _, err := vu.runFn(ctx, group, fn, vu.Runtime.ToValue(arg))
 
 	// deadline is reached so we have timeouted but this might've not been registered correctly
 	if deadline, ok := ctx.Deadline(); ok && time.Now().After(deadline) {
@@ -418,16 +418,23 @@ func (u *VU) RunOnce(ctx context.Context) error {
 	}
 
 	// Call the default function.
-	_, _, err := u.runFn(ctx, u.Runner.defaultGroup, u.Default, u.setupData)
+	_, isFullIteration, totalTime, err := u.runFn(ctx, u.Runner.defaultGroup, u.Default, u.setupData)
+
+	// If MinIterationDuration is specified and the iteration wasn't cancelled
+	// and was less than it, sleep for the remainder
+	if isFullIteration && u.Runner.Bundle.Options.MinIterationDuration.Valid {
+		time.Sleep(time.Duration(u.Runner.Bundle.Options.MinIterationDuration.Duration) - totalTime)
+	}
+
 	return err
 }
 
 func (u *VU) runFn(
 	ctx context.Context, group *lib.Group, fn goja.Callable, args ...goja.Value,
-) (goja.Value, *lib.State, error) {
+) (goja.Value, bool, time.Duration, error) {
 	cookieJar, err := cookiejar.New(nil)
 	if err != nil {
-		return goja.Undefined(), nil, err
+		return goja.Undefined(), false, time.Duration(0), err
 	}
 
 	if u.Runner.Bundle.Options.NoCookiesReset.Valid && u.Runner.Bundle.Options.NoCookiesReset.Bool {
@@ -486,14 +493,5 @@ func (u *VU) runFn(
 
 	state.Samples <- u.Dialer.GetTrail(startTime, endTime, isFullIteration, stats.IntoSampleTags(&tags))
 
-	// If MinIterationDuration is specified and the iteration wasn't cancelled
-	// and was less than it, sleep for the remainder
-	if isFullIteration && state.Options.MinIterationDuration.Valid {
-		durationDiff := time.Duration(state.Options.MinIterationDuration.Duration) - endTime.Sub(startTime)
-		if durationDiff > 0 {
-			time.Sleep(durationDiff)
-		}
-	}
-
-	return v, state, err
+	return v, isFullIteration, endTime.Sub(startTime), err
 }


### PR DESCRIPTION
`minIterrationDuration` is affecting setup/teardown stages. That should not be the case, and must only affect normal iteration only.

So ignore `minterationDuration` when in setup/teardown stage.

Close #1003