### PR TITLE
Use go1.13 for CI again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine as builder
+FROM golang:1.13-alpine as builder
 WORKDIR $GOPATH/src/github.com/loadimpact/k6
 ADD . .
 RUN apk --no-cache add --virtual .build-deps git make build-base && \


### PR DESCRIPTION
PR #1157 used go1.12 temporary for Dockerfile, to mitigate https://github.com/golang/go/issues/34282. The backport issue was merged https://github.com/golang/go/issues/34285 and ~~go1.13.1~~ go1.13.3 is now released. so we can use go1.13 again.

Close #1153