### PR TITLE
Use default config directory value instead of panic

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -115,7 +115,8 @@ func rootCmdPersistentFlagSet() *pflag.FlagSet {
 func init() {
 	confDir, err := configDir()
 	if err != nil {
-		panic(err)
+		logrus.WithError(err).Warn("could not get config directory")
+		confDir = ".config"
 	}
 	defaultConfigFilePath = filepath.Join(
 		confDir,


### PR DESCRIPTION
In #1162, we use new os.UserConfigDir to get user's config directory, and it will
panic when encounter an error. This is a backward in-compatible behavior and
can lead to bad UX.

This PR restore previous #1162 behavior. Instead of panic, we return a
default value for config dir if we can figure out user config directory.

Close #1176