### PR TITLE
Remove unused testErrorWithString

### DIFF
--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -44,11 +44,6 @@ import (
 	"github.com/loadimpact/k6/stats/dummy"
 )
 
-type testErrorWithString string
-
-func (e testErrorWithString) Error() string  { return string(e) }
-func (e testErrorWithString) String() string { return string(e) }
-
 // Apply a null logger to the engine and return the hook.
 func applyNullLogger(e *Engine) *logtest.Hook {
 	logger, hook := logtest.NewNullLogger()


### PR DESCRIPTION
Usages of `testErrorWithString` was removed in 371b4af8d443dd1eb9717c35d9cdd19d633af40a, it is unused in current code base.