### PR TITLE
Correctly handle server-initiated WebSocket close

### DIFF
--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -502,6 +502,7 @@ func getMetricCount(collector *dummy.Collector, name string) (result uint) {
 
 const expectedHeaderMaxLength = 500
 
+// FIXME: This test is too brittle, consider simplifying.
 func TestSentReceivedMetrics(t *testing.T) {
 	t.Parallel()
 	tb := httpmultibin.NewHTTPMultiBin(t)
@@ -532,10 +533,14 @@ func TestSentReceivedMetrics(t *testing.T) {
 					file: http.file(data, "test.txt")
 				});
 			}`), 1, 1000, 100},
+		// NOTE(imiric): This needs to keep testing against /ws-echo-invalid because
+		// this test is highly sensitive to metric data, and slightly differing
+		// WS server implementations might introduce flakiness.
+		// See https://github.com/loadimpact/k6/pull/1149
 		{tr(`import ws from "k6/ws";
 			let data = "0123456789".repeat(100);
 			export default function() {
-				ws.connect("WSBIN_URL/ws-echo", null, function (socket) {
+				ws.connect("WSBIN_URL/ws-echo-invalid", null, function (socket) {
 					socket.on('open', function open() {
 						socket.send(data);
 					});

--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -223,6 +223,13 @@ func (*WS) Connect(ctx context.Context, url string, args ...goja.Value) (*WSHTTP
 	// The connection is now open, emit the event
 	socket.handleEvent("open")
 
+	// Make the default close handler a noop to avoid duplicate closes,
+	// since we use custom closing logic to call user's event
+	// handlers and for cleanup. See closeConnection.
+	// closeConnection is not set directly as a handler here to
+	// avoid race conditions when calling the Goja runtime.
+	conn.SetCloseHandler(func(code int, text string) error { return nil })
+
 	// Pass ping/pong events through the main control loop
 	pingChan := make(chan string)
 	pongChan := make(chan string)
@@ -262,9 +269,8 @@ func (*WS) Connect(ctx context.Context, url string, args ...goja.Value) (*WSHTTP
 		case readErr := <-readErrChan:
 			socket.handleEvent("error", rt.ToValue(readErr))
 
-		case readClose := <-readCloseChan:
-			// handle server close
-			socket.handleEvent("close", rt.ToValue(readClose))
+		case code := <-readCloseChan:
+			_ = socket.closeConnection(code)
 
 		case scheduledFn := <-socket.scheduled:
 			if _, err := scheduledFn(goja.Undefined()); err != nil {
@@ -425,7 +431,8 @@ func (s *Socket) Close(args ...goja.Value) {
 	_ = s.closeConnection(code)
 }
 
-// Attempts to close the websocket gracefully
+// closeConnection cleanly closes the WebSocket connection.
+// Returns an error if sending the close control frame fails.
 func (s *Socket) closeConnection(code int) error {
 	var err error
 
@@ -437,15 +444,16 @@ func (s *Socket) closeConnection(code int) error {
 			time.Now().Add(writeWait),
 		)
 		if err != nil {
-			// Just call the handler, we'll try to close the connection anyway
+			// Call the user-defined error handler
 			s.handleEvent("error", rt.ToValue(err))
 		}
 
-		// trigger `close` event when the client closes the connection
+		// Call the user-defined close handler
 		s.handleEvent("close", rt.ToValue(code))
+
 		_ = s.conn.Close()
 
-		// Stops the main control loop
+		// Stop the main control loop
 		close(s.done)
 	})
 
@@ -454,21 +462,19 @@ func (s *Socket) closeConnection(code int) error {
 
 // Wraps conn.ReadMessage in a channel
 func readPump(conn *websocket.Conn, readChan chan []byte, errorChan chan error, closeChan chan int) {
-	defer func() { _ = conn.Close() }()
-
 	for {
 		_, message, err := conn.ReadMessage()
 		if err != nil {
-
-			if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
-				closeChan <- err.(*websocket.CloseError).Code
-			} else if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway) {
-				// Emit the error if it is not CloseNormalClosure
-				// and the error is not  originated from closing the socket ourselves with `CloseGoingAway`
+			if websocket.IsUnexpectedCloseError(
+				err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+				// Report an unexpected closure
 				errorChan <- err
 			}
-
-			//CloseGoingAway errors are ignored
+			code := websocket.CloseGoingAway
+			if e, ok := err.(*websocket.CloseError); ok {
+				code = e.Code
+			}
+			closeChan <- code
 			return
 		}
 

--- a/lib/testutils/httpmultibin/httpmultibin.go
+++ b/lib/testutils/httpmultibin/httpmultibin.go
@@ -100,32 +100,42 @@ type jsonBody struct {
 	Compression string      `json:"compression"`
 }
 
-func websocketEchoHandler(w http.ResponseWriter, req *http.Request) {
-	conn, err := (&websocket.Upgrader{}).Upgrade(w, req, w.Header())
-	if err != nil {
-		return
-	}
-
-	mt, message, err := conn.ReadMessage()
-	if err != nil {
-		return
-	}
-	err = conn.WriteMessage(mt, message)
-	if err != nil {
-		return
-	}
-	err = conn.Close()
-	if err != nil {
-		return
-	}
-}
-
-func websocketCloserHandler(w http.ResponseWriter, req *http.Request) {
-	conn, err := (&websocket.Upgrader{}).Upgrade(w, req, w.Header())
-	if err != nil {
-		return
-	}
-	_ = conn.Close()
+func getWebsocketHandler(echo bool, closePrematurely bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conn, err := (&websocket.Upgrader{}).Upgrade(w, req, w.Header())
+		if err != nil {
+			return
+		}
+		if echo {
+			messageType, r, e := conn.NextReader()
+			if e != nil {
+				return
+			}
+			var wc io.WriteCloser
+			wc, err = conn.NextWriter(messageType)
+			if err != nil {
+				return
+			}
+			if _, err = io.Copy(wc, r); err != nil {
+				return
+			}
+			if err = wc.Close(); err != nil {
+				return
+			}
+		}
+		// closePrematurely=true mimics an invalid WS server that doesn't
+		// send a close control frame before closing the connection.
+		if !closePrematurely {
+			closeMsg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
+			_ = conn.WriteControl(websocket.CloseMessage, closeMsg, time.Now().Add(time.Second))
+			// Wait for response control frame
+			<-time.After(time.Second)
+		}
+		err = conn.Close()
+		if err != nil {
+			return
+		}
+	})
 }
 
 func writeJSON(w io.Writer, v interface{}) error {
@@ -193,8 +203,10 @@ func NewHTTPMultiBin(t testing.TB) *HTTPMultiBin {
 	// Create a http.ServeMux and set the httpbin handler as the default
 	mux := http.NewServeMux()
 	mux.Handle("/brotli", getEncodedHandler(t, httpext.CompressionTypeBr))
-	mux.HandleFunc("/ws-echo", websocketEchoHandler)
-	mux.HandleFunc("/ws-close", websocketCloserHandler)
+	mux.Handle("/ws-echo", getWebsocketHandler(true, false))
+	mux.Handle("/ws-echo-invalid", getWebsocketHandler(true, true))
+	mux.Handle("/ws-close", getWebsocketHandler(false, false))
+	mux.Handle("/ws-close-invalid", getWebsocketHandler(false, true))
 	mux.Handle("/zstd", getEncodedHandler(t, httpext.CompressionTypeZstd))
 	mux.Handle("/zstd-br", getZstdBrHandler(t))
 	mux.Handle("/", httpbin.New().Handler())


### PR DESCRIPTION
This avoids a hanging behavior when the server closes the WS connection, either via a [control close frame](https://tools.ietf.org/html/rfc6455#section-5.5.1) or by closing the connection prematurely without sending the control frame (deviating from the WS protocol).

If the control close frame is not received but the connection is closed, the error (`close 1006 abnormal closure): unexpected EOF`) will be returned to the user's WS error handler, as it indicates an issue with the server.

The user-specified close handler should be called in either case now.

Closes #581