### PR TITLE
Fix memory leak after stop sending metrics to cloud

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -237,17 +237,16 @@ a commandline interface for interacting with it.`,
 		{
 			out := "-"
 			link := ""
-			if engine.Collectors != nil {
-				for idx, collector := range engine.Collectors {
-					if out != "-" {
-						out = out + "; " + conf.Out[idx]
-					} else {
-						out = conf.Out[idx]
-					}
 
-					if l := collector.Link(); l != "" {
-						link = link + " (" + l + ")"
-					}
+			for idx, collector := range engine.Collectors {
+				if out != "-" {
+					out = out + "; " + conf.Out[idx]
+				} else {
+					out = conf.Out[idx]
+				}
+
+				if l := collector.Link(); l != "" {
+					link = link + " (" + l + ")"
 				}
 			}
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -220,8 +220,10 @@ func (e *Engine) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-ticker.C:
-			e.processSamples(sampleContainers)
-			sampleContainers = []stats.SampleContainer{}
+			if len(sampleContainers) > 0 {
+				e.processSamples(sampleContainers)
+				sampleContainers = []stats.SampleContainer{}
+			}
 		case sc := <-e.Samples:
 			sampleContainers = append(sampleContainers, sc)
 		case err := <-errC:

--- a/stats/cloud/collector.go
+++ b/stats/cloud/collector.go
@@ -253,6 +253,12 @@ func (c *Collector) Run(ctx context.Context) {
 // Collect receives a set of samples. This method is never called concurrently, and only while
 // the context for Run() is valid, but should defer as much work as possible to Run().
 func (c *Collector) Collect(sampleContainers []stats.SampleContainer) {
+	select {
+	case <-c.stopSendingMetricsCh:
+		return
+	default:
+	}
+
 	if c.referenceID == "" {
 		return
 	}

--- a/stats/cloud/collector_test.go
+++ b/stats/cloud/collector_test.go
@@ -459,6 +459,18 @@ func TestCloudCollectorStopSendingMetric(t *testing.T) {
 	_, ok := <-collector.stopSendingMetricsCh
 	require.False(t, ok)
 	require.Equal(t, max, count)
+
+	nBufferSamples := len(collector.bufferSamples)
+	nBufferHTTPTrails := len(collector.bufferHTTPTrails)
+	collector.Collect([]stats.SampleContainer{stats.Sample{
+		Time:   now,
+		Metric: metrics.VUs,
+		Tags:   stats.NewSampleTags(tags.CloneTags()),
+		Value:  1.0,
+	}})
+	if nBufferSamples != len(collector.bufferSamples) || nBufferHTTPTrails != len(collector.bufferHTTPTrails) {
+		t.Errorf("Collector still collects data after stop sending metrics")
+	}
 }
 
 func TestCloudCollectorAggregationPeriodZeroNoBlock(t *testing.T) {


### PR DESCRIPTION
In #1130, we stop sending metrics to cloud when limit reached. However,
after stop sending metrics, collector still collects data, causing the
memory usage quickly increase.

To fix it, do not collect data if stop sending metrics triggered.

While at it, also remove some useless condition checking that slice
length is greater than 0 before looping.

Fixes #1187