### PR TITLE
Remove another useless len check before for loop

### DIFF
--- a/cmd/runtime_options.go
+++ b/cmd/runtime_options.go
@@ -72,15 +72,14 @@ func getRuntimeOptions(flags *pflag.FlagSet) (lib.RuntimeOptions, error) {
 	if err != nil {
 		return opts, err
 	}
-	if len(envVars) > 0 {
-		for _, kv := range envVars {
-			k, v := parseEnvKeyValue(kv)
-			// Allow only alphanumeric ASCII variable names for now
-			if !userEnvVarName.MatchString(k) {
-				return opts, errors.Errorf("Invalid environment variable name '%s'", k)
-			}
-			opts.Env[k] = v
+
+	for _, kv := range envVars {
+		k, v := parseEnvKeyValue(kv)
+		// Allow only alphanumeric ASCII variable names for now
+		if !userEnvVarName.MatchString(k) {
+			return opts, errors.Errorf("Invalid environment variable name '%s'", k)
 		}
+		opts.Env[k] = v
 	}
 
 	return opts, nil

--- a/js/common/bridge.go
+++ b/js/common/bridge.go
@@ -107,7 +107,9 @@ type FieldNameMapper struct{}
 
 // FieldName is part of the goja.FieldNameMapper interface
 // https://godoc.org/github.com/dop251/goja#FieldNameMapper
-func (FieldNameMapper) FieldName(t reflect.Type, f reflect.StructField) string { return FieldName(t, f) }
+func (FieldNameMapper) FieldName(t reflect.Type, f reflect.StructField) string {
+	return FieldName(t, f)
+}
 
 // MethodName is part of the goja.FieldNameMapper interface
 // https://godoc.org/github.com/dop251/goja#FieldNameMapper


### PR DESCRIPTION
In #1188, I removed some useless `len` check before `for` loop. But there is one place in `cmd/` is not removed.

This PR removed it.

While at it, also run gofmt -s -w.