### PR TITLE
Fix duplicated error messages

### DIFF
--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -78,7 +78,7 @@ An archive is a fully self-contained test run, and can be executed identically e
 		}
 
 		if _, cerr := deriveAndValidateConfig(conf); cerr != nil {
-			return ExitCode{cerr, invalidConfigErrorCode}
+			return ExitCode{error: cerr, Code: invalidConfigErrorCode}
 		}
 
 		err = r.SetOptions(conf.Options)

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -30,17 +30,23 @@ import (
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
-	"github.com/loadimpact/k6/lib"
-	"github.com/loadimpact/k6/lib/consts"
-	"github.com/loadimpact/k6/loader"
-	"github.com/loadimpact/k6/stats/cloud"
-	"github.com/loadimpact/k6/ui"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/consts"
+	"github.com/loadimpact/k6/loader"
+	"github.com/loadimpact/k6/stats/cloud"
+	"github.com/loadimpact/k6/ui"
+
 	"github.com/sirupsen/logrus"
+)
+
+const (
+	cloudFailedToGetProgressErrorCode = 98
+	cloudTestRunFailedErrorCode       = 99
 )
 
 var (
@@ -99,7 +105,7 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 
 		derivedConf, cerr := deriveAndValidateConfig(conf)
 		if cerr != nil {
-			return ExitCode{cerr, invalidConfigErrorCode}
+			return ExitCode{error: cerr, Code: invalidConfigErrorCode}
 		}
 
 		err = r.SetOptions(conf.Options)
@@ -231,13 +237,15 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 		}
 
 		if testProgress == nil {
-			return ExitCode{errors.New("Test progress error"), 98}
+			//nolint:golint
+			return ExitCode{error: errors.New("Test progress error"), Code: cloudFailedToGetProgressErrorCode}
 		}
 
 		fprintf(stdout, "     test status: %s\n", ui.ValueColor.Sprint(testProgress.RunStatusText))
 
 		if testProgress.ResultStatus == cloud.ResultStatusFailed {
-			return ExitCode{errors.New("The test has failed"), 99}
+			//nolint:golint
+			return ExitCode{error: errors.New("The test has failed"), Code: cloudTestRunFailedErrorCode}
 		}
 
 		return nil

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -45,10 +45,12 @@ func must(err error) {
 	}
 }
 
-// Silently set an exit code.
+// ExitCode wraps the error with an exit code.
+// Hint is used to show details information about underlying error.
 type ExitCode struct {
 	error
 	Code int
+	Hint string
 }
 
 // A writer that syncs writes with a mutex and, if the output is a TTY, clears before newlines.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,11 +86,16 @@ var RootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
-		logrus.Error(err.Error())
+		code := -1
+		var logger logrus.FieldLogger = logrus.StandardLogger()
 		if e, ok := err.(ExitCode); ok {
-			os.Exit(e.Code)
+			code = e.Code
+			if e.Hint != "" {
+				logger = logger.WithField("hint", e.Hint)
+			}
 		}
-		os.Exit(-1)
+		logger.Error(err)
+		os.Exit(code)
 	}
 }
 


### PR DESCRIPTION
If RootCmd.Execute returns any error, we always log that error. So
removing log from child command before returning to prevent duplicated
error message printed.

This PR also adds Hint field to ExitCode, to provide hint/details for
the underlying error. It helps the logger keep the semantic and provide
meaningful error message to user.

Updates #994
Fixes #702