### PR TITLE
Fix js map causes wrong return type

### DIFF
--- a/js/modules/k6/html/html.go
+++ b/js/modules/k6/html/html.go
@@ -381,7 +381,8 @@ func (s Selection) Map(v goja.Value) []string {
 	}
 
 	fn := func(idx int, sel *goquery.Selection) string {
-		if fnRes, fnErr := gojaFn(v, s.rt.ToValue(idx), s.rt.ToValue(&Selection{sel: sel, URL: s.URL, rt: s.rt})); fnErr == nil {
+		selection := &Selection{sel: sel, URL: s.URL, rt: s.rt}
+		if fnRes, fnErr := gojaFn(v, s.rt.ToValue(idx), s.rt.ToValue(selection)); fnErr == nil {
 			return fnRes.String()
 		}
 		return ""

--- a/js/modules/k6/html/html.go
+++ b/js/modules/k6/html/html.go
@@ -373,28 +373,21 @@ func (s Selection) Is(v goja.Value) bool {
 	}
 }
 
+// Map implements ES5 Array.prototype.map
 func (s Selection) Map(v goja.Value) []string {
 	gojaFn, isFn := goja.AssertFunction(v)
 	if !isFn {
 		common.Throw(s.rt, errors.New("Argument to map() must be a function"))
 	}
 
-	fn := func(idx int, sel *Selection) string {
-		if fnRes, fnErr := gojaFn(v, s.rt.ToValue(idx), s.rt.ToValue(sel)); fnErr == nil {
+	fn := func(idx int, sel *goquery.Selection) string {
+		if fnRes, fnErr := gojaFn(v, s.rt.ToValue(idx), s.rt.ToValue(&Selection{sel: sel, URL: s.URL, rt: s.rt})); fnErr == nil {
 			return fnRes.String()
 		}
 		return ""
 	}
 
-	// Mimics goquery.Selector.Map function.
-	// We can not use s.sel.Map directly, otherwise, goja will see the function body elements as type
-	// *gohtml.Selection instead of our *Selection wrapper, so goja runtime will call wrong methods.
-	// See issue #1195
-	result := make([]string, len(s.sel.Nodes))
-	for i, n := range s.sel.Nodes {
-		result[i] = fn(i, &Selection{rt: s.rt, sel: &goquery.Selection{Nodes: []*gohtml.Node{n}}})
-	}
-	return result
+	return s.sel.Map(fn)
 }
 
 func (s Selection) Slice(start int, def ...int) Selection {

--- a/js/modules/k6/html/html_test.go
+++ b/js/modules/k6/html/html_test.go
@@ -328,6 +328,14 @@ func TestParseHTML(t *testing.T) {
 				assert.Contains(t, err.Error(), "must be a function")
 			}
 		})
+		t.Run("Map with attr must return string", func(t *testing.T) {
+			v, err := common.RunString(rt, `doc.find("#select_multi").map(function(idx, val) { return val.attr("name") })`)
+			if assert.NoError(t, err) {
+				mapped := v.Export().([]string)
+				assert.Equal(t, 1, len(mapped))
+				assert.Equal(t, []string{"select_multi"}, mapped)
+			}
+		})
 	})
 	t.Run("Next", func(t *testing.T) {
 		t.Run("No arg", func(t *testing.T) {


### PR DESCRIPTION
Selection.map currently calls the underlying goquery.Selection Map. It
causes problem when running inside goja runtime, all the nodes inside
the function body is treated as goquery.Selection instead of our wrapper
Selection, thus lead to wrong calling methods.

To fix it, we wrap goquery.Selection to Selection before passing to goja.

Fixes #1195