### PR TITLE
Fix cookie set, chain redirects

### DIFF
--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -624,7 +624,7 @@ func TestRequestAndBatch(t *testing.T) {
 					`))
 					assert.NoError(t, err)
 
-					redirectURL, err := url.Parse(sr("HTTPSBIN_URL"))
+					redirectURL, err := url.Parse(sr("HTTPSBIN_URL/cookies"))
 					assert.NoError(t, err)
 
 					require.Len(t, cookieJar.Cookies(redirectURL), 1)

--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -290,7 +290,7 @@ func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error
 			// Update active jar with cookies found in "Set-Cookie" header(s) of redirect response
 			if preq.ActiveJar != nil {
 				if respCookies := req.Response.Cookies(); len(respCookies) > 0 {
-					preq.ActiveJar.SetCookies(req.URL, respCookies)
+					preq.ActiveJar.SetCookies(via[len(via)-1].URL, respCookies)
 				}
 				req.Header.Del("Cookie")
 				SetRequestCookies(req, preq.ActiveJar, preq.Cookies)


### PR DESCRIPTION
A problem exists if a series of redirects occurs:

`user -> site A -> site B -> site A`

The current code saves cookies in ActiveJar relative to the redirect URL, and should in the source URL.

Explanation:

1. request to [site A], response cookies [C1]
2. [site A] redirect request to [site B]
3. k6 stores this cookies at activeJar[siteB]
4. [site B] response cookies [C2] redirect request to [site A]
5. k6 stores this cookies at activeJar[siteA]
6. final request to [site A] receives only [C2] cookies.