### PR TITLE
Emit iterations metric as part of netext.NetTrail

### DIFF
--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -957,10 +957,10 @@ func TestMinIterationDuration(t *testing.T) {
 		require.False(t, engine.IsTainted())
 	}
 
-	// Only 2 full iterations are expected to be completed due to the 1 second minIterationDuration
-	assert.Equal(t, 2.0, getMetricSum(collector, metrics.Iterations.Name))
+	// 4 full iterations are expected to be completed
+	assert.Equal(t, 4.0, getMetricSum(collector, metrics.Iterations.Name))
 
-	// But we expect the custom counter to be added to 4 times
+	// The custom counter should be added to 4 times
 	assert.Equal(t, 4.0, getMetricSum(collector, "testcounter"))
 }
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -924,10 +924,10 @@ func TestMinIterationDuration(t *testing.T) {
 		let testCounter = new Counter("testcounter");
 
 		export let options = {
-			minIterationDuration: "1s",
-			vus: 2,
-			vusMax: 2,
-			duration: "1.9s",
+			minIterationDuration: "150ms",
+			vus: 4,
+			vusMax: 4,
+			duration: "500ms",
 		};
 
 		export default function () {
@@ -957,11 +957,11 @@ func TestMinIterationDuration(t *testing.T) {
 		require.False(t, engine.IsTainted())
 	}
 
-	// 4 full iterations are expected to be completed
-	assert.Equal(t, 4.0, getMetricSum(collector, metrics.Iterations.Name))
+	// 16 full iterations are expected to be completed
+	assert.Equal(t, 16.0, getMetricSum(collector, metrics.Iterations.Name))
 
-	// The custom counter should be added to 4 times
-	assert.Equal(t, 4.0, getMetricSum(collector, "testcounter"))
+	// The custom counter should be added to 16 times
+	assert.Equal(t, 16.0, getMetricSum(collector, "testcounter"))
 }
 
 //nolint: funlen

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -914,54 +914,77 @@ func TestEmittedMetricsWhenScalingDown(t *testing.T) {
 	assert.InDelta(t, 3.35, durationSum/(1000*durationCount), 0.25)
 }
 
-func TestMinIterationDuration(t *testing.T) {
+func TestMetricsEmission(t *testing.T) {
 	t.Parallel()
 
-	runner, err := js.New(
-		&loader.SourceData{URL: &url.URL{Path: "/script.js"}, Data: []byte(`
-		import { Counter } from "k6/metrics";
-
-		let testCounter = new Counter("testcounter");
-
-		export let options = {
-			minIterationDuration: "150ms",
-			vus: 4,
-			vusMax: 4,
-			duration: "500ms",
-		};
-
-		export default function () {
-			testCounter.add(1);
-		};`)},
-		nil,
-		lib.RuntimeOptions{},
-	)
-	require.NoError(t, err)
-
-	engine, err := NewEngine(local.New(runner), runner.GetOptions())
-	require.NoError(t, err)
-
-	collector := &dummy.Collector{}
-	engine.Collectors = []lib.Collector{collector}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	errC := make(chan error)
-	go func() { errC <- engine.Run(ctx) }()
-
-	select {
-	case <-time.After(10 * time.Second):
-		t.Fatal("Test timed out")
-	case err := <-errC:
-		require.NoError(t, err)
-		require.False(t, engine.IsTainted())
+	testCases := []struct {
+		method             string
+		minIterDuration    string
+		defaultBody        string
+		expCount, expIters float64
+	}{
+		// Since emission of Iterations happens before the minIterationDuration
+		// sleep is done, we expect to receive metrics for all executions of
+		// the `default` function, despite of the lower overall duration setting.
+		{"minIterationDuration", `"150ms"`, "testCounter.add(1);", 16.0, 16.0},
+		// With the manual sleep method and no minIterationDuration, the last
+		// `default` execution will be cutoff by the duration setting, so only
+		// 3 sets of metrics are expected.
+		{"sleepBeforeCounterAdd", "null", "sleep(0.15); testCounter.add(1); ", 12.0, 12.0},
+		// The counter should be sent, but the last iteration will be incomplete
+		{"sleepAfterCounterAdd", "null", "testCounter.add(1); sleep(0.15); ", 16.0, 12.0},
 	}
 
-	// 16 full iterations are expected to be completed
-	assert.Equal(t, 16.0, getMetricSum(collector, metrics.Iterations.Name))
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.method, func(t *testing.T) {
+			t.Parallel()
+			runner, err := js.New(
+				&loader.SourceData{URL: &url.URL{Path: "/script.js"}, Data: []byte(fmt.Sprintf(`
+				import { sleep } from "k6";
+				import { Counter } from "k6/metrics";
 
-	// The custom counter should be added to 16 times
-	assert.Equal(t, 16.0, getMetricSum(collector, "testcounter"))
+				let testCounter = new Counter("testcounter");
+
+				export let options = {
+					vus: 4,
+					vusMax: 4,
+					duration: "500ms",
+					minIterationDuration: %s,
+				};
+
+				export default function() {
+					%s
+				}
+				`, tc.minIterDuration, tc.defaultBody))},
+				nil,
+				lib.RuntimeOptions{},
+			)
+			require.NoError(t, err)
+
+			engine, err := NewEngine(local.New(runner), runner.GetOptions())
+			require.NoError(t, err)
+
+			collector := &dummy.Collector{}
+			engine.Collectors = []lib.Collector{collector}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			errC := make(chan error)
+			go func() { errC <- engine.Run(ctx) }()
+
+			select {
+			case <-time.After(10 * time.Second):
+				t.Fatal("Test timed out")
+			case err := <-errC:
+				require.NoError(t, err)
+				require.False(t, engine.IsTainted())
+			}
+
+			assert.Equal(t, tc.expIters, getMetricSum(collector, metrics.Iterations.Name))
+			assert.Equal(t, tc.expCount, getMetricSum(collector, "testcounter"))
+		})
+	}
 }
 
 //nolint: funlen

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"runtime"
 	"testing"
 	"time"
 
@@ -43,6 +44,8 @@ import (
 	"github.com/loadimpact/k6/stats"
 	"github.com/loadimpact/k6/stats/dummy"
 )
+
+const isWindows = runtime.GOOS == "windows"
 
 // Apply a null logger to the engine and return the hook.
 func applyNullLogger(e *Engine) *logtest.Hook {
@@ -915,7 +918,9 @@ func TestEmittedMetricsWhenScalingDown(t *testing.T) {
 }
 
 func TestMetricsEmission(t *testing.T) {
-	t.Parallel()
+	if !isWindows {
+		t.Parallel()
+	}
 
 	testCases := []struct {
 		method             string
@@ -938,7 +943,9 @@ func TestMetricsEmission(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.method, func(t *testing.T) {
-			t.Parallel()
+			if !isWindows {
+				t.Parallel()
+			}
 			runner, err := js.New(
 				&loader.SourceData{URL: &url.URL{Path: "/script.js"}, Data: []byte(fmt.Sprintf(`
 				import { sleep } from "k6";

--- a/core/local/local.go
+++ b/core/local/local.go
@@ -32,7 +32,6 @@ import (
 	null "gopkg.in/guregu/null.v3"
 
 	"github.com/loadimpact/k6/lib"
-	"github.com/loadimpact/k6/lib/metrics"
 	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/stats"
 )
@@ -298,17 +297,6 @@ func (e *Executor) Run(parent context.Context, engineOut chan<- stats.SampleCont
 		case <-iterDone:
 			// Every iteration ends with a write to iterDone. Check if we've hit the end point.
 			// If not, make sure to include an Iterations bump in the list!
-			var tags *stats.SampleTags
-			if e.Runner != nil {
-				tags = e.Runner.GetOptions().RunTags
-			}
-			engineOut <- stats.Sample{
-				Time:   time.Now(),
-				Metric: metrics.Iterations,
-				Value:  1,
-				Tags:   tags,
-			}
-
 			end := atomic.LoadInt64(&e.endIters)
 			at := atomic.AddInt64(&e.iters, 1)
 			if end >= 0 && at >= end {

--- a/js/runner.go
+++ b/js/runner.go
@@ -319,7 +319,7 @@ func (r *Runner) runPart(ctx context.Context, out chan<- stats.SampleContainer, 
 		return goja.Undefined(), err
 	}
 
-	v, _, _, err := vu.runFn(ctx, group, fn, vu.Runtime.ToValue(arg))
+	v, _, _, err := vu.runFn(ctx, group, false, fn, vu.Runtime.ToValue(arg))
 
 	// deadline is reached so we have timeouted but this might've not been registered correctly
 	if deadline, ok := ctx.Deadline(); ok && time.Now().After(deadline) {
@@ -418,7 +418,7 @@ func (u *VU) RunOnce(ctx context.Context) error {
 	}
 
 	// Call the default function.
-	_, isFullIteration, totalTime, err := u.runFn(ctx, u.Runner.defaultGroup, u.Default, u.setupData)
+	_, isFullIteration, totalTime, err := u.runFn(ctx, u.Runner.defaultGroup, true, u.Default, u.setupData)
 
 	// If MinIterationDuration is specified and the iteration wasn't cancelled
 	// and was less than it, sleep for the remainder
@@ -433,7 +433,7 @@ func (u *VU) RunOnce(ctx context.Context) error {
 }
 
 func (u *VU) runFn(
-	ctx context.Context, group *lib.Group, fn goja.Callable, args ...goja.Value,
+	ctx context.Context, group *lib.Group, isDefault bool, fn goja.Callable, args ...goja.Value,
 ) (goja.Value, bool, time.Duration, error) {
 	cookieJar, err := cookiejar.New(nil)
 	if err != nil {
@@ -494,7 +494,7 @@ func (u *VU) runFn(
 		u.Transport.CloseIdleConnections()
 	}
 
-	state.Samples <- u.Dialer.GetTrail(startTime, endTime, isFullIteration, stats.IntoSampleTags(&tags))
+	state.Samples <- u.Dialer.GetTrail(startTime, endTime, isFullIteration, isDefault, stats.IntoSampleTags(&tags))
 
 	return v, isFullIteration, endTime.Sub(startTime), err
 }

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -630,10 +630,13 @@ func TestVUIntegrationMetrics(t *testing.T) {
 						assert.Equal(t, metrics.DataReceived, s.Metric, "`data_received` sample is after `data_received`")
 					case 3:
 						assert.Equal(t, metrics.IterationDuration, s.Metric, "`iteration-duration` sample is after `data_received`")
+					case 4:
+						assert.Equal(t, metrics.Iterations, s.Metric, "`iterations` sample is after `iteration_duration`")
+						assert.Equal(t, float64(1), s.Value)
 					}
 				}
 			}
-			assert.Equal(t, sampleCount, 4)
+			assert.Equal(t, sampleCount, 5)
 		})
 	}
 }

--- a/lib/netext/dialer.go
+++ b/lib/netext/dialer.go
@@ -100,7 +100,11 @@ func (d *Dialer) DialContext(ctx context.Context, proto, addr string) (net.Conn,
 
 // GetTrail creates a new NetTrail instance with the Dialer
 // sent and received data metrics and the supplied times and tags.
-func (d *Dialer) GetTrail(startTime, endTime time.Time, fullIteration bool, tags *stats.SampleTags) *NetTrail {
+// TODO: Refactor this according to
+// https://github.com/loadimpact/k6/pull/1203#discussion_r337938370
+func (d *Dialer) GetTrail(
+	startTime, endTime time.Time, fullIteration bool, emitIterations bool, tags *stats.SampleTags,
+) *NetTrail {
 	bytesWritten := atomic.SwapInt64(&d.BytesWritten, 0)
 	bytesRead := atomic.SwapInt64(&d.BytesRead, 0)
 	samples := []stats.Sample{
@@ -116,12 +120,6 @@ func (d *Dialer) GetTrail(startTime, endTime time.Time, fullIteration bool, tags
 			Value:  float64(bytesRead),
 			Tags:   tags,
 		},
-		{
-			Time:   endTime,
-			Metric: metrics.Iterations,
-			Value:  1,
-			Tags:   tags,
-		},
 	}
 	if fullIteration {
 		samples = append(samples, stats.Sample{
@@ -130,6 +128,14 @@ func (d *Dialer) GetTrail(startTime, endTime time.Time, fullIteration bool, tags
 			Value:  stats.D(endTime.Sub(startTime)),
 			Tags:   tags,
 		})
+		if emitIterations {
+			samples = append(samples, stats.Sample{
+				Time:   endTime,
+				Metric: metrics.Iterations,
+				Value:  1,
+				Tags:   tags,
+			})
+		}
 	}
 
 	return &NetTrail{

--- a/lib/netext/dialer.go
+++ b/lib/netext/dialer.go
@@ -116,6 +116,12 @@ func (d *Dialer) GetTrail(startTime, endTime time.Time, fullIteration bool, tags
 			Value:  float64(bytesRead),
 			Tags:   tags,
 		},
+		{
+			Time:   endTime,
+			Metric: metrics.Iterations,
+			Value:  1,
+			Tags:   tags,
+		},
 	}
 	if fullIteration {
 		samples = append(samples, stats.Sample{

--- a/stats/cloud/collector.go
+++ b/stats/cloud/collector.go
@@ -303,6 +303,7 @@ func (c *Collector) Collect(sampleContainers []stats.SampleContainer) {
 
 			if sc.FullIteration {
 				values[metrics.IterationDuration.Name] = stats.D(sc.EndTime.Sub(sc.StartTime))
+				values[metrics.Iterations.Name] = 1
 			}
 
 			newSamples = append(newSamples, &Sample{


### PR DESCRIPTION
This removes emission of `metrics.Iterations` as a standalone metric, and instead bundles it as part of `netext.NetTrail`, and only for `default` functions.

This is done to reduce the amount of individual metrics, and thus traffic, sent to backends, and has minor user-facing impact mentioned in #1189.

Closes: #1189