### PR TITLE
chore: bump golangci-lint version, ignore _gen.go files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,7 @@ issues:
      linters:
        - gocyclo
        - dupl
-       #TODO - gocognit
+       - gocognit
        - funlen
        - lll
 
@@ -53,7 +53,7 @@ linters:
   disable:
   - gochecknoinits
   - godox
-  #TODO - wsl
+  - wsl
   fast: false
 
 service:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,7 @@ issues:
   exclude-rules:
    # Exclude duplicate code and function length and complexity checking in test
    # files (due to common repeats and long functions in test code)
-   - path: _test\.go #TODO: also exclude all go-generated files by giving them common names? *_gen.go?
+   - path: _(test|gen)\.go
      linters:
        - gocyclo
        - dupl
@@ -57,4 +57,4 @@ linters:
   fast: false
 
 service:
-  golangci-lint-version: 1.19.x  #TODO: upgrade to 1.20
+  golangci-lint-version: 1.20.x


### PR DESCRIPTION
[1.19 has issues on the GolangCI service](https://golangci.com/r/github.com/loadimpact/k6/pulls/1143), which is fixed by upgrading. Or it was a temporary hiccup, but regardless it works OK on 1.20 now and we should probably upgrade.

The `_gen.go` excludes were suggested by @na--.