### PR TITLE
Make cloud API requests idempotent

### DIFF
--- a/stats/cloud/client.go
+++ b/stats/cloud/client.go
@@ -33,11 +33,11 @@ import (
 )
 
 const (
-	// Default request timeout
-	RequestTimeout = 10 * time.Second
-	// Retry interval
+	// RequestTimeout is the default cloud request timeout
+	RequestTimeout = 20 * time.Second
+	// RetryInterval is the default cloud request retry interval
 	RetryInterval = 500 * time.Millisecond
-	// Retry attempts
+	// MaxRetries specifies max retry attempts
 	MaxRetries = 3
 )
 

--- a/stats/cloud/client.go
+++ b/stats/cloud/client.go
@@ -22,10 +22,12 @@ package cloud
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"time"
 
@@ -39,6 +41,8 @@ const (
 	RetryInterval = 500 * time.Millisecond
 	// MaxRetries specifies max retry attempts
 	MaxRetries = 3
+
+	k6IdempotencyKeyHeader = "k6-Idempotency-Key"
 )
 
 // Client handles communication with Load Impact cloud API.
@@ -76,7 +80,16 @@ func (c *Client) NewRequest(method, url string, data interface{}) (*http.Request
 		buf = bytes.NewBuffer(b)
 	}
 
-	return http.NewRequest(method, url, buf)
+	req, err := http.NewRequest(method, url, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	if shouldAddIdempotencyKey(req) {
+		req.Header.Set(k6IdempotencyKeyHeader, randomStrHex())
+	}
+
+	return req, nil
 }
 
 func (c *Client) Do(req *http.Request, v interface{}) error {
@@ -200,4 +213,27 @@ func shouldRetry(resp *http.Response, err error, attempt, maxAttempts int) bool 
 	}
 
 	return false
+}
+
+func shouldAddIdempotencyKey(req *http.Request) bool {
+	switch req.Method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace:
+		return false
+	default:
+		return req.Header.Get(k6IdempotencyKeyHeader) == ""
+	}
+}
+
+// randomStrHex returns a hex string which can be used
+// for session token id or idempotency key.
+//nolint:gosec
+func randomStrHex() string {
+	// 16 hex characters
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
 }


### PR DESCRIPTION
When k6 requests to cloud API timeout, k6 will retry the request a
few times. This can be problematic, because the retrying request can
cause user's test start twice.

This PR tries to fix that problem by using a session token for each POST
request. With this token, cloud API can know that the request is the
retried one, and avoid creating new test, and return the old one.

Speaking in other way, k6 POST request to cloud API becomes idempotent.

Fixes #1205