### PR TITLE
Cleanup some warnings emitted by nilness check

### DIFF
--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -79,6 +79,7 @@ func TestNewBundle(t *testing.T) {
 	})
 	t.Run("Invalid", func(t *testing.T) {
 		_, err := getSimpleBundle("/script.js", "\x00")
+		assert.NotNil(t, err)
 		assert.Contains(t, err.Error(), "SyntaxError: file:///script.js: Unexpected character '\x00' (1:0)\n> 1 | \x00\n")
 	})
 	t.Run("Error", func(t *testing.T) {

--- a/js/common/util_test.go
+++ b/js/common/util_test.go
@@ -35,6 +35,7 @@ func TestRunString(t *testing.T) {
 	})
 	t.Run("Invalid", func(t *testing.T) {
 		_, err := RunString(goja.New(), `let a = #;`)
+		assert.NotNil(t, err)
 		assert.Contains(t, err.Error(), "SyntaxError: __string__: Unexpected character '#' (1:8)\n> 1 | let a = #;\n")
 	})
 }

--- a/js/initcontext_test.go
+++ b/js/initcontext_test.go
@@ -113,6 +113,7 @@ func TestInitContextRequire(t *testing.T) {
 		t.Run("Nonexistent", func(t *testing.T) {
 			path := filepath.FromSlash("/nonexistent.js")
 			_, err := getSimpleBundle("/script.js", `import "/nonexistent.js"; export default function() {}`)
+			assert.NotNil(t, err)
 			assert.Contains(t, err.Error(), fmt.Sprintf(`"file://%s" couldn't be found on local disk`, filepath.ToSlash(path)))
 		})
 		t.Run("Invalid", func(t *testing.T) {

--- a/lib/testutils/httpmultibin/httpmultibin.go
+++ b/lib/testutils/httpmultibin/httpmultibin.go
@@ -158,7 +158,9 @@ func getEncodedHandler(t testing.TB, compressionType httpext.CompressionType) ht
 			Compression: encoding,
 		}
 		err = writeJSON(encw, data)
-		_ = encw.Close()
+		if encw != nil {
+			_ = encw.Close()
+		}
 		if !assert.NoError(t, err) {
 			return
 		}

--- a/stats/cloud/client.go
+++ b/stats/cloud/client.go
@@ -89,7 +89,7 @@ func (c *Client) Do(req *http.Request, v interface{}) error {
 			return err
 		}
 
-		if cerr := req.Body.Close(); cerr != nil && err == nil {
+		if cerr := req.Body.Close(); cerr != nil {
 			err = cerr
 		}
 	}

--- a/stats/thresholds_test.go
+++ b/stats/thresholds_test.go
@@ -163,6 +163,7 @@ func TestThresholdsRunAll(t *testing.T) {
 	for name, data := range testdata {
 		t.Run(name, func(t *testing.T) {
 			ts, err := NewThresholds(data.srcs)
+			assert.Nil(t, err)
 			ts.Thresholds[0].AbortOnFail = data.abort
 			ts.Thresholds[0].AbortGracePeriod = data.grace
 

--- a/ui/summary_test.go
+++ b/ui/summary_test.go
@@ -123,7 +123,7 @@ func TestGeneratePercentileTrendColumn(t *testing.T) {
 
 	t.Run("Happy path", func(t *testing.T) {
 		colFunc, err := generatePercentileTrendColumn("p(99)")
-
+		assert.Nil(t, err)
 		assert.NotNil(t, colFunc)
 		assert.Exactly(t, sink.P(0.99), colFunc(sink))
 		assert.NotEqual(t, sink.P(0.98), colFunc(sink))


### PR DESCRIPTION
This cleanup most warnings emitted by nilness check, including
potentinal accessing field of nil object in tests, or condition which is
always true.

Passes all current tests.