### PR TITLE
Remove configdir from Gopkg.toml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
             curl --fail https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
             dep version
             dep status
-            dep ensure -update -dry-run
+            case $(dep ensure 2>&1 | head -n 1) in Warning*) false ;; esac
             dep check
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
             dep version
             dep status
             dep ensure -update -dry-run
+            dep check
 
 
   test:

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,10 +29,6 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/shibukawa/configdir"
-
-[[constraint]]
-  branch = "master"
   name = "github.com/sirupsen/logrus"
 
 [[constraint]]


### PR DESCRIPTION
Usages of `configdir` library were removed in https://github.com/loadimpact/k6/pull/1162, but we forget to remove it from Gopkg.toml.

This PR removes its entry from Gopkg.toml, now `dep ensure` run without warnings.