### PR TITLE
Upgrade envconfig

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -284,12 +284,12 @@
   revision = "ae77be60afb1dcacde03767a8c37337fad28ac14"
 
 [[projects]]
-  digest = "1:b8870bf2606dca65dc382f4cb8b7a434f17ff36a915451bda12788e9620be368"
+  digest = "1:08c58ac78a8c1f61e9a96350066d30fe194b8779799bd932a79932a5166a173f"
   name = "github.com/kelseyhightower/envconfig"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "f611eb38b3875cc3bd991ca91c51d06446afa14c"
-  version = "v1.3.0"
+  revision = "0b417c4ec4a8a82eecc22a1459a504aa55163d61"
+  version = "v1.4.0"
 
 [[projects]]
   digest = "1:a1eb0245eb436bd1949fdb00f6b2d925874fa0d2c5e709779f3c50fe281b9eee"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -102,3 +102,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/andybalholm/brotli"
+
+[[constraint]]
+  name = "github.com/kelseyhightower/envconfig"
+  version = "^1.4.0"

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -96,7 +96,7 @@ func TestConfigEnv(t *testing.T) {
 			"false": func(c Config) { assert.Equal(t, null.BoolFrom(false), c.NoUsageReport) },
 		},
 		{"Out", "K6_OUT"}: {
-			"":         func(c Config) { assert.Equal(t, []string{""}, c.Out) },
+			"":         func(c Config) { assert.Equal(t, []string{}, c.Out) },
 			"influxdb": func(c Config) { assert.Equal(t, []string{"influxdb"}, c.Out) },
 		},
 	}

--- a/vendor/github.com/kelseyhightower/envconfig/env_os.go
+++ b/vendor/github.com/kelseyhightower/envconfig/env_os.go
@@ -1,4 +1,4 @@
-// +build appengine
+// +build appengine go1.5
 
 package envconfig
 

--- a/vendor/github.com/kelseyhightower/envconfig/env_syscall.go
+++ b/vendor/github.com/kelseyhightower/envconfig/env_syscall.go
@@ -1,4 +1,4 @@
-// +build !appengine
+// +build !appengine,!go1.5
 
 package envconfig
 

--- a/vendor/github.com/kelseyhightower/envconfig/envconfig.go
+++ b/vendor/github.com/kelseyhightower/envconfig/envconfig.go
@@ -8,6 +8,7 @@ import (
 	"encoding"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -17,6 +18,9 @@ import (
 
 // ErrInvalidSpecification indicates that a specification is of the wrong type.
 var ErrInvalidSpecification = errors.New("specification must be a struct pointer")
+
+var gatherRegexp = regexp.MustCompile("([^A-Z]+|[A-Z]+[^A-Z]+|[A-Z]+)")
+var acronymRegexp = regexp.MustCompile("([A-Z]+)([A-Z][^A-Z]+)")
 
 // A ParseError occurs when an environment variable cannot be converted to
 // the type required by a struct field during assignment.
@@ -55,7 +59,6 @@ type varInfo struct {
 
 // GatherInfo gathers information about the specified struct
 func gatherInfo(prefix string, spec interface{}) ([]varInfo, error) {
-	expr := regexp.MustCompile("([^A-Z]+|[A-Z][^A-Z]+|[A-Z]+)")
 	s := reflect.ValueOf(spec)
 
 	if s.Kind() != reflect.Ptr {
@@ -72,7 +75,7 @@ func gatherInfo(prefix string, spec interface{}) ([]varInfo, error) {
 	for i := 0; i < s.NumField(); i++ {
 		f := s.Field(i)
 		ftype := typeOfSpec.Field(i)
-		if !f.CanSet() || ftype.Tag.Get("ignored") == "true" {
+		if !f.CanSet() || isTrue(ftype.Tag.Get("ignored")) {
 			continue
 		}
 
@@ -100,12 +103,16 @@ func gatherInfo(prefix string, spec interface{}) ([]varInfo, error) {
 		info.Key = info.Name
 
 		// Best effort to un-pick camel casing as separate words
-		if ftype.Tag.Get("split_words") == "true" {
-			words := expr.FindAllStringSubmatch(ftype.Name, -1)
+		if isTrue(ftype.Tag.Get("split_words")) {
+			words := gatherRegexp.FindAllStringSubmatch(ftype.Name, -1)
 			if len(words) > 0 {
 				var name []string
 				for _, words := range words {
-					name = append(name, words[0])
+					if m := acronymRegexp.FindStringSubmatch(words[0]); len(m) == 3 {
+						name = append(name, m[1], m[2])
+					} else {
+						name = append(name, words[0])
+					}
 				}
 
 				info.Key = strings.Join(name, "_")
@@ -122,7 +129,7 @@ func gatherInfo(prefix string, spec interface{}) ([]varInfo, error) {
 
 		if f.Kind() == reflect.Struct {
 			// honor Decode if present
-			if decoderFrom(f) == nil && setterFrom(f) == nil && textUnmarshaler(f) == nil {
+			if decoderFrom(f) == nil && setterFrom(f) == nil && textUnmarshaler(f) == nil && binaryUnmarshaler(f) == nil {
 				innerPrefix := prefix
 				if !ftype.Anonymous {
 					innerPrefix = info.Key
@@ -140,6 +147,37 @@ func gatherInfo(prefix string, spec interface{}) ([]varInfo, error) {
 		}
 	}
 	return infos, nil
+}
+
+// CheckDisallowed checks that no environment variables with the prefix are set
+// that we don't know how or want to parse. This is likely only meaningful with
+// a non-empty prefix.
+func CheckDisallowed(prefix string, spec interface{}) error {
+	infos, err := gatherInfo(prefix, spec)
+	if err != nil {
+		return err
+	}
+
+	vars := make(map[string]struct{})
+	for _, info := range infos {
+		vars[info.Key] = struct{}{}
+	}
+
+	if prefix != "" {
+		prefix = strings.ToUpper(prefix) + "_"
+	}
+
+	for _, env := range os.Environ() {
+		if !strings.HasPrefix(env, prefix) {
+			continue
+		}
+		v := strings.SplitN(env, "=", 2)[0]
+		if _, found := vars[v]; !found {
+			return fmt.Errorf("unknown environment variable %s", v)
+		}
+	}
+
+	return nil
 }
 
 // Process populates the specified struct based on environment variables
@@ -164,13 +202,17 @@ func Process(prefix string, spec interface{}) error {
 
 		req := info.Tags.Get("required")
 		if !ok && def == "" {
-			if req == "true" {
-				return fmt.Errorf("required key %s missing value", info.Key)
+			if isTrue(req) {
+				key := info.Key
+				if info.Alt != "" {
+					key = info.Alt
+				}
+				return fmt.Errorf("required key %s missing value", key)
 			}
 			continue
 		}
 
-		err := processField(value, info.Field)
+		err = processField(value, info.Field)
 		if err != nil {
 			return &ParseError{
 				KeyName:   info.Key,
@@ -207,6 +249,10 @@ func processField(value string, field reflect.Value) error {
 
 	if t := textUnmarshaler(field); t != nil {
 		return t.UnmarshalText([]byte(value))
+	}
+
+	if b := binaryUnmarshaler(field); b != nil {
+		return b.UnmarshalBinary([]byte(value))
 	}
 
 	if typ.Kind() == reflect.Ptr {
@@ -256,34 +302,41 @@ func processField(value string, field reflect.Value) error {
 		}
 		field.SetFloat(val)
 	case reflect.Slice:
-		vals := strings.Split(value, ",")
-		sl := reflect.MakeSlice(typ, len(vals), len(vals))
-		for i, val := range vals {
-			err := processField(val, sl.Index(i))
-			if err != nil {
-				return err
+		sl := reflect.MakeSlice(typ, 0, 0)
+		if typ.Elem().Kind() == reflect.Uint8 {
+			sl = reflect.ValueOf([]byte(value))
+		} else if len(strings.TrimSpace(value)) != 0 {
+			vals := strings.Split(value, ",")
+			sl = reflect.MakeSlice(typ, len(vals), len(vals))
+			for i, val := range vals {
+				err := processField(val, sl.Index(i))
+				if err != nil {
+					return err
+				}
 			}
 		}
 		field.Set(sl)
 	case reflect.Map:
-		pairs := strings.Split(value, ",")
 		mp := reflect.MakeMap(typ)
-		for _, pair := range pairs {
-			kvpair := strings.Split(pair, ":")
-			if len(kvpair) != 2 {
-				return fmt.Errorf("invalid map item: %q", pair)
+		if len(strings.TrimSpace(value)) != 0 {
+			pairs := strings.Split(value, ",")
+			for _, pair := range pairs {
+				kvpair := strings.Split(pair, ":")
+				if len(kvpair) != 2 {
+					return fmt.Errorf("invalid map item: %q", pair)
+				}
+				k := reflect.New(typ.Key()).Elem()
+				err := processField(kvpair[0], k)
+				if err != nil {
+					return err
+				}
+				v := reflect.New(typ.Elem()).Elem()
+				err = processField(kvpair[1], v)
+				if err != nil {
+					return err
+				}
+				mp.SetMapIndex(k, v)
 			}
-			k := reflect.New(typ.Key()).Elem()
-			err := processField(kvpair[0], k)
-			if err != nil {
-				return err
-			}
-			v := reflect.New(typ.Elem()).Elem()
-			err = processField(kvpair[1], v)
-			if err != nil {
-				return err
-			}
-			mp.SetMapIndex(k, v)
 		}
 		field.Set(mp)
 	}
@@ -316,4 +369,14 @@ func setterFrom(field reflect.Value) (s Setter) {
 func textUnmarshaler(field reflect.Value) (t encoding.TextUnmarshaler) {
 	interfaceFrom(field, func(v interface{}, ok *bool) { t, *ok = v.(encoding.TextUnmarshaler) })
 	return t
+}
+
+func binaryUnmarshaler(field reflect.Value) (b encoding.BinaryUnmarshaler) {
+	interfaceFrom(field, func(v interface{}, ok *bool) { b, *ok = v.(encoding.BinaryUnmarshaler) })
+	return b
+}
+
+func isTrue(s string) bool {
+	b, _ := strconv.ParseBool(s)
+	return b
 }


### PR DESCRIPTION
We were using a very old version (Jan 2017), and the new one includes fixes like https://github.com/kelseyhightower/envconfig/pull/119 , which would avoid workarounds in PRs like #1143.