### PR TITLE
Factor out header preparation from do

### DIFF
--- a/stats/cloud/client.go
+++ b/stats/cloud/client.go
@@ -107,6 +107,8 @@ func (c *Client) Do(req *http.Request, v interface{}) error {
 		}
 	}
 
+	c.prepareHeader(req)
+
 	for i := 1; i <= c.retries; i++ {
 		if len(originalBody) > 0 {
 			req.Body = ioutil.NopCloser(bytes.NewBuffer(originalBody))
@@ -125,7 +127,7 @@ func (c *Client) Do(req *http.Request, v interface{}) error {
 	return err
 }
 
-func (c *Client) do(req *http.Request, v interface{}, attempt int) (retry bool, err error) {
+func (c *Client) prepareHeader(req *http.Request) {
 	if req.Header.Get("Content-Type") == "" {
 		req.Header.Set("Content-Type", "application/json")
 	}
@@ -133,6 +135,9 @@ func (c *Client) do(req *http.Request, v interface{}, attempt int) (retry bool, 
 		req.Header.Set("Authorization", fmt.Sprintf("Token %s", c.token))
 	}
 	req.Header.Set("User-Agent", "k6cloud/"+c.version)
+}
+
+func (c *Client) do(req *http.Request, v interface{}, attempt int) (retry bool, err error) {
 	resp, err := c.client.Do(req)
 
 	defer func() {

--- a/stats/cloud/client.go
+++ b/stats/cloud/client.go
@@ -85,9 +85,7 @@ func (c *Client) NewRequest(method, url string, data interface{}) (*http.Request
 		return nil, err
 	}
 
-	if shouldAddIdempotencyKey(req) {
-		req.Header.Set(k6IdempotencyKeyHeader, randomStrHex())
-	}
+	c.prepareHeaders(req)
 
 	return req, nil
 }
@@ -106,8 +104,6 @@ func (c *Client) Do(req *http.Request, v interface{}) error {
 			err = cerr
 		}
 	}
-
-	c.prepareHeaders(req)
 
 	for i := 1; i <= c.retries; i++ {
 		if len(originalBody) > 0 {
@@ -131,9 +127,15 @@ func (c *Client) prepareHeaders(req *http.Request) {
 	if req.Header.Get("Content-Type") == "" {
 		req.Header.Set("Content-Type", "application/json")
 	}
+
 	if c.token != "" {
 		req.Header.Set("Authorization", fmt.Sprintf("Token %s", c.token))
 	}
+
+	if shouldAddIdempotencyKey(req) {
+		req.Header.Set(k6IdempotencyKeyHeader, randomStrHex())
+	}
+
 	req.Header.Set("User-Agent", "k6cloud/"+c.version)
 }
 

--- a/stats/cloud/client.go
+++ b/stats/cloud/client.go
@@ -107,7 +107,7 @@ func (c *Client) Do(req *http.Request, v interface{}) error {
 		}
 	}
 
-	c.prepareHeader(req)
+	c.prepareHeaders(req)
 
 	for i := 1; i <= c.retries; i++ {
 		if len(originalBody) > 0 {
@@ -127,7 +127,7 @@ func (c *Client) Do(req *http.Request, v interface{}) error {
 	return err
 }
 
-func (c *Client) prepareHeader(req *http.Request) {
+func (c *Client) prepareHeaders(req *http.Request) {
 	if req.Header.Get("Content-Type") == "" {
 		req.Header.Set("Content-Type", "application/json")
 	}


### PR DESCRIPTION
Currently, we do header preparation in Client.do. It's a little verbose, and also done for every retried requests.

We can make it slightly better by factor out header preparation to its own function, and calling it once before retry loop.