### PR TITLE
Improve cloud aggregation for different URLs

### DIFF
--- a/stats/cloud/collector_test.go
+++ b/stats/cloud/collector_test.go
@@ -51,6 +51,10 @@ func tagEqual(expected, got *stats.SampleTags) bool {
 	expectedMap := expected.CloneTags()
 	gotMap := got.CloneTags()
 
+	if len(expectedMap) != len(gotMap) {
+		return false
+	}
+
 	for k, v := range gotMap {
 		if k == "url" {
 			if expectedMap["name"] != v {


### PR DESCRIPTION
For cloud output, we currently don't aggregate HTTP metrics with
different url tag, but with the same name tag.

This PR improves aggregation by setting url tag to be the same as name
tag. It's not ideal, but seems like the least bad option in term of UX.

Fixes #1166