### PR TITLE
Improve the cloud aggregation bucketing performance

### DIFF
--- a/stats/cloud/collector.go
+++ b/stats/cloud/collector.go
@@ -347,6 +347,7 @@ func (c *Collector) aggregateHTTPTrails(waitPeriod time.Duration) {
 				if trailTags.IsEqual(sbTags) {
 					subBucketKey = sbTags
 					subBucket = sb
+					break
 				}
 			}
 		}


### PR DESCRIPTION
This causes a native comparison loop to abort as soon as a match is found, potentially improving performance a lot when there are many different sub-buckets.

@MStoykov pointed out the missing `break` :blush:  Its lack wasn't causing any bugs, it was just making an already inefficient code even more so...  :man_facepalming: 