### PR TITLE
Improve wrap decompress error

### DIFF
--- a/lib/netext/httpext/compression.go
+++ b/lib/netext/httpext/compression.go
@@ -104,7 +104,7 @@ func wrapDecompressionError(err error) error {
 	// TODO: something more optimized? for example, we won't get zstd errors if
 	// we don't use it... maybe the code that builds the decompression readers
 	// could also add an appropriate error-wrapper layer?
-	for _, decErr := range decompressionErrors {
+	for _, decErr := range &decompressionErrors {
 		if err == decErr {
 			return newDecompressionError(err)
 		}

--- a/lib/netext/httpext/request_test.go
+++ b/lib/netext/httpext/request_test.go
@@ -138,3 +138,12 @@ func TestURL(t *testing.T) {
 		}
 	})
 }
+
+func BenchmarkWrapDecompressionError(b *testing.B) {
+	err := errors.New("error")
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = wrapDecompressionError(err)
+	}
+}


### PR DESCRIPTION
Range over array make a copy of all elements in each iteration. Avoiding
this help improving the speed of `wrapDecompressionError` slightly.

```
name                       old time/op    new time/op    delta
WrapDecompressionError-12    14.5ns ± 2%     8.5ns ± 1%  -41.77%  (p=0.008 n=5+5)

name                       old alloc/op   new alloc/op   delta
WrapDecompressionError-12     0.00B          0.00B        ~     (all equal)

name                       old allocs/op  new allocs/op  delta
WrapDecompressionError-12      0.00           0.00        ~     (all equal)
```