### PR TITLE
Mark "k6 convert" as deprecated

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -47,9 +47,10 @@ var (
 )
 
 var convertCmd = &cobra.Command{
-	Use:   "convert",
-	Short: "Convert a HAR file to a k6 script",
-	Long:  "Convert a HAR (HTTP Archive) file to a k6 script",
+	Use:        "convert",
+	Short:      "Convert a HAR file to a k6 script",
+	Long:       "Convert a HAR (HTTP Archive) file to a k6 script",
+	Deprecated: "please use har-to-k6 (https://github.com/loadimpact/har-to-k6) instead.",
 	Example: `
   # Convert a HAR file to a k6 script.
   k6 convert -O har-session.js session.har


### PR DESCRIPTION
"k6 convert" should emit a warning and point user to https://github.com/loadimpact/har-to-k6

Fixes #1124 