### PR TITLE
Remove un-necessary type conversion

### DIFF
--- a/cmd/convert_test.go
+++ b/cmd/convert_test.go
@@ -138,7 +138,7 @@ func TestIntegrationConvertCmd(t *testing.T) {
 
 		defaultFs = afero.NewMemMapFs()
 
-		err = afero.WriteFile(defaultFs, harFile, []byte(har), 0644)
+		err = afero.WriteFile(defaultFs, harFile, har, 0644)
 		assert.NoError(t, err)
 
 		buf := &bytes.Buffer{}

--- a/js/initcontext_test.go
+++ b/js/initcontext_test.go
@@ -238,9 +238,8 @@ func TestInitContextRequire(t *testing.T) {
 func createAndReadFile(t *testing.T, file string, content []byte, expectedLength int, binary bool) (*BundleInstance, error) {
 	fs := afero.NewMemMapFs()
 	assert.NoError(t, fs.MkdirAll("/path/to", 0755))
-	assert.NoError(t, afero.WriteFile(fs, "/path/to/"+file, []byte(content), 0644))
+	assert.NoError(t, afero.WriteFile(fs, "/path/to/"+file, content, 0644))
 
-	afero.WriteFile(fs, "/path/to/"+file, []byte(content), 0644)
 	binaryArg := ""
 	if binary {
 		binaryArg = ",\"b\""


### PR DESCRIPTION
Discover this while I have been working on marking "k6 convert" as deprecated.