### PR TITLE
Emit more detailed k6 version information

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,6 +79,7 @@ var RootCmd = &cobra.Command{
 			stderr.Writer = colorable.NewNonColorable(os.Stderr)
 		}
 		log.SetOutput(logrus.StandardLogger().Writer())
+		logrus.Debugf("k6 version: v%s", consts.FullVersion())
 	},
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -33,7 +33,7 @@ var versionCmd = &cobra.Command{
 	Short: "Show application version",
 	Long:  `Show the application version and exit.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("k6 v" + consts.Version)
+		fmt.Println("k6 v" + consts.FullVersion())
 	},
 }
 

--- a/lib/consts/consts.go
+++ b/lib/consts/consts.go
@@ -1,12 +1,32 @@
 package consts
 
 import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
 	"strings"
 )
 
 // Version contains the current semantic version of k6.
-//nolint:gochecknoglobals
-var Version = "0.26.0-dev"
+var Version = "0.26.0-dev" //nolint:gochecknoglobals
+
+// VersionDetails can be set externally as part of the build process
+var VersionDetails = "" // nolint:gochecknoglobals
+
+// FullVersion returns the maximully full version and build information for
+// the currently running k6 executable.
+func FullVersion() string {
+	goVersionArch := fmt.Sprintf("%s, %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	if VersionDetails != "" {
+		return fmt.Sprintf("%s (%s, %s)", Version, VersionDetails, goVersionArch)
+	}
+
+	if buildInfo, ok := debug.ReadBuildInfo(); ok {
+		return fmt.Sprintf("%s (%s, %s)", Version, buildInfo.Main.Version, goVersionArch)
+	}
+
+	return fmt.Sprintf("%s (dev build, %s)", Version, goVersionArch)
+}
 
 // Banner contains the ASCII-art banner with the k6 logo and stylized website URL
 //TODO: make these into methods, only the version needs to be a variable


### PR DESCRIPTION
Not sure if this is the best way to format and present everything, and whether we can add some more information, but something like this should greatly help with debugging of various issues. And it's worth investigating the details of https://github.com/loadimpact/k6/issues/1070#issuecomment-552507335... Also, not sure if we should build our official images with something like `go build -ldflags "-X github.com/loadimpact/k6/lib/consts.VersionDetails=$(date --iso-8601=seconds)/$(git describe --always --long --dirty)"`...