### PR TITLE
Correctly set the "name" of scripts ran through the shortcut urls

### DIFF
--- a/stats/cloud/collector.go
+++ b/stats/cloud/collector.go
@@ -110,7 +110,7 @@ func New(conf Config, src *loader.SourceData, opts lib.Options, version string) 
 	}
 
 	if !conf.Name.Valid || conf.Name.String == "" {
-		conf.Name = null.StringFrom(filepath.Base(src.URL.Path))
+		conf.Name = null.StringFrom(filepath.Base(src.URL.String()))
 	}
 	if conf.Name.String == "-" {
 		conf.Name = null.StringFrom(TestName)


### PR DESCRIPTION
fixes #1236

Text for release notes in bugfix section:
```
Cloud output: correctly set the "name" for scripts being ran through the shortcut urls (github.com,cdnjs.com), instead of returning an error. Thanks @Menda for reporting! (#1237)
```