### PR TITLE
Add the path to the error when trying to open() a directory

### DIFF
--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -22,6 +22,7 @@ package js
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -208,7 +209,7 @@ func (i *InitContext) Open(filename string, args ...string) (goja.Value, error) 
 	if isDir, err := afero.IsDir(fs, filename); err != nil {
 		return nil, err
 	} else if isDir {
-		return nil, errors.New("open() can't be used with directories")
+		return nil, fmt.Errorf("open() can't be used with directories, path: %q", filename)
 	}
 	data, err := afero.ReadFile(fs, filename)
 	if err != nil {

--- a/js/initcontext_test.go
+++ b/js/initcontext_test.go
@@ -317,6 +317,13 @@ func TestInitContextOpen(t *testing.T) {
 		assert.EqualError(t, err, fmt.Sprintf("GoError: open %s: file does not exist", path))
 	})
 
+	t.Run("Directory", func(t *testing.T) {
+		path := filepath.FromSlash("/some/dir")
+		fs := afero.NewMemMapFs()
+		assert.NoError(t, fs.MkdirAll(path, 0755))
+		_, err := getSimpleBundle("/script.js", `open("/some/dir"); export default function() {}`, fs)
+		assert.EqualError(t, err, fmt.Sprintf("GoError: open() can't be used with directories, path: %q", path))
+	})
 }
 
 func TestRequestWithBinaryFile(t *testing.T) {


### PR DESCRIPTION
closes #1234

proposed release notes in "Bugfixes"(we should have "small changes or miscellaneous"):
```
JS: add the path to the error message when `open()` is used with a directory (#1238)
```