### PR TITLE
Move prepareHeaders inside Do

### DIFF
--- a/stats/cloud/client.go
+++ b/stats/cloud/client.go
@@ -68,6 +68,10 @@ func NewClient(token, host, version string) *Client {
 	return c
 }
 
+// NewRequest creates new HTTP request.
+//
+// This is the same as http.NewRequest, except that data if not nil
+// will be serialized in json format.
 func (c *Client) NewRequest(method, url string, data interface{}) (*http.Request, error) {
 	var buf io.Reader
 

--- a/stats/cloud/client.go
+++ b/stats/cloud/client.go
@@ -85,8 +85,6 @@ func (c *Client) NewRequest(method, url string, data interface{}) (*http.Request
 		return nil, err
 	}
 
-	c.prepareHeaders(req)
-
 	return req, nil
 }
 
@@ -104,6 +102,9 @@ func (c *Client) Do(req *http.Request, v interface{}) error {
 			err = cerr
 		}
 	}
+
+	// TODO(cuonglm): finding away to move this back to NewRequest
+	c.prepareHeaders(req)
 
 	for i := 1; i <= c.retries; i++ {
 		if len(originalBody) > 0 {


### PR DESCRIPTION
In 09007b3, cloud request headers is centralized preparing, but it
breaks "k6 cloud" because some methods of Client still uses
http.NewRequest to create POST request with form data.

To fix it, we move back prepareHeaders inside Do.