### PR TITLE
circleci: give --coverpkg only the pkg's dependancies 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,12 @@ jobs:
             export PATH=$GOPATH/bin:$PATH
             echo "mode: set" > coverage.txt
             for pkg in $(go list ./... | grep -v vendor); do
-                go test -race -timeout 800s  --coverpkg="$(go list ./... | tr '\n' ',')" -coverprofile=$(echo $pkg | tr / -).coverage $pkg
+                list=$(go list -test -f  '{{ join .Deps  "\n"}}' $pkg | grep github.com/loadimpact/k6 | grep -v vendor || true)
+                if [ -n "$list" ]; then
+                    list=$(echo "$list" | cut -f1 -d ' ' | sort -u | paste -sd,)
+                fi
+
+                go test -race -timeout 800s  --coverpkg="$list" -coverprofile=$(echo $pkg | tr / -).coverage $pkg
             done
             grep -h -v "^mode:" *.coverage >> coverage.txt
             rm -f *.coverage


### PR DESCRIPTION
This reduces the amount of output `go test` generates about given pkg not being tested by the package currently under test, ultimately reducing a lot of log lines from circle's log.

Unfortunately the magical `all` includes everything (stdlib including) which just makes the tests take *way* too long ...