### PR TITLE
Better release build script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,4 @@
 k6
-samples
 dist
 js/node_modules
 .vagrant
-.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM golang:1.13-alpine as builder
 WORKDIR $GOPATH/src/github.com/loadimpact/k6
 ADD . .
-RUN apk --no-cache add --virtual .build-deps git make build-base && \
-  go get . && CGO_ENABLED=0 go install -a -ldflags '-s -w'
+RUN apk --no-cache add git
+RUN CGO_ENABLED=0 go install -a -ldflags "-s -w -X github.com/loadimpact/k6/lib/consts.VersionDetails=$(date --utc -Is)/$(git describe --always --long --dirty)"
 
 FROM alpine:3.10
 RUN apk add --no-cache ca-certificates

--- a/build-release.sh
+++ b/build-release.sh
@@ -1,52 +1,47 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
-eval $(go env)
+set -eEuo pipefail
+
+eval "$(go env)"
 
 # To override the latest git tag as the version, pass something else as the first arg.
 VERSION=${1:-$(git describe --tags --abbrev=0)}
 
 make_archive() {
-	FMT=$1
-	DIR=$2
+	local FMT="$1" DIR="$2"
 
 	case $FMT in
 	zip)
-		zip -rq9 $DIR.zip $DIR
+		zip -rq9 "$DIR.zip" "$DIR"
 		;;
 	tgz)
-		tar -zcf $DIR.tar.gz $DIR
+		tar -zcf "$DIR.tar.gz" "$DIR"
 		;;
 	esac
 }
 
 build_dist() {
-	ALIAS=$1
-	GOOS=$2
-	GOARCH=$3
-	FMT=$4
-	SUFFIX=$5
+	local ALIAS="$1" GOOS="$2" GOARCH="$3" FMT="${4}" SUFFIX="${5:-}"
 
 	echo "- Building platform: ${ALIAS} (${GOOS} ${GOARCH})"
-	DIR=k6-${VERSION}-${ALIAS}
-	BIN=k6${SUFFIX}
+	local DIR="k6-${VERSION}-${ALIAS}"
 
 	# Clean out any old remnants of failed builds.
-	rm -rf dist/$DIR
-	mkdir -p dist/$DIR
+	rm -rf "dist/$DIR"
+	mkdir -p "dist/$DIR"
 
 	# Build a binary, embed what we can by means of static assets inside it.
-	GOARCH=$GOARCH GOOS=$GOOS go build -o dist/$DIR/$BIN
+	GOARCH="$GOARCH" GOOS="$GOOS" go build -o "dist/$DIR/k6${SUFFIX}"
 
 	# Archive it all, native format depends on the platform. Subshell to not mess with $PWD.
-	( cd dist && make_archive $FMT $DIR )
+	( cd dist && make_archive "$FMT" "$DIR" )
 
 	# Delete the source files.
-	rm -rf dist/$DIR
+	rm -rf "dist/$DIR"
 }
 
 checksum() {
-	CHECKSUM_FILE=k6-${VERSION}-checksums.txt
+	local CHECKSUM_FILE="k6-${VERSION}-checksums.txt"
 
 	if command -v sha256sum > /dev/null; then
 		CHECKSUM_CMD="sha256sum"
@@ -57,8 +52,8 @@ checksum() {
 		return 1
 	fi
 
-	rm -f dist/$CHECKSUM_FILE
-	( cd dist && for x in $(ls -1); do $CHECKSUM_CMD $x >> $CHECKSUM_FILE; done )
+	rm -f "dist/$CHECKSUM_FILE"
+	( cd dist && for x in *; do "$CHECKSUM_CMD" "$x" >> "$CHECKSUM_FILE"; done )
 }
 
 echo "--- Building Release: ${VERSION}"


### PR DESCRIPTION
This refactors the `build-release.sh` script and adds detailed version information and (for Linux builds only) `CGO_ENABLED=0`. Reviewing commit by commit should be easier. 

Not sure if I should do anything with the .rpm, .deb, or .msi packages, considering that they are only ever built for properly tagged official releases, and the Linux packages already had `CGO_ENABLED=0`:  https://github.com/loadimpact/k6/blob/b41ed21c081900b3409955490ad9aea99819375e/.circleci/config.yml#L142

Forgot to specify, this closes https://github.com/loadimpact/k6/issues/930