### PR TITLE
Cleanup build script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
             cd $GOPATH/src/github.com/loadimpact/k6
 
             echo "Building k6..."
-            CGO_ENABLED=0 GOARCH=$ARCH go build -a -ldflags '-s -w' -o /tmp/k6
+            CGO_ENABLED=0 GOARCH=$ARCH go build -a -trimpath -ldflags '-s -w' -o /tmp/k6
             echo "Done!"
 
             VERSION=${CIRCLE_TAG:1} ./packaging/gen-packages.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.13-alpine as builder
 WORKDIR $GOPATH/src/github.com/loadimpact/k6
 ADD . .
 RUN apk --no-cache add git
-RUN CGO_ENABLED=0 go install -a -ldflags "-s -w -X github.com/loadimpact/k6/lib/consts.VersionDetails=$(date -u +"%FT%T%z")/$(git describe --always --long --dirty)"
+RUN CGO_ENABLED=0 go install -a -trimpath -ldflags "-s -w -X github.com/loadimpact/k6/lib/consts.VersionDetails=$(date -u +"%FT%T%z")/$(git describe --always --long --dirty)"
 
 FROM alpine:3.10
 RUN apk add --no-cache ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.13-alpine as builder
 WORKDIR $GOPATH/src/github.com/loadimpact/k6
 ADD . .
 RUN apk --no-cache add git
-RUN CGO_ENABLED=0 go install -a -ldflags "-s -w -X github.com/loadimpact/k6/lib/consts.VersionDetails=$(date --utc -Is)/$(git describe --always --long --dirty)"
+RUN CGO_ENABLED=0 go install -a -ldflags "-s -w -X github.com/loadimpact/k6/lib/consts.VersionDetails=$(date -u +"%FT%T%z")/$(git describe --always --long --dirty)"
 
 FROM alpine:3.10
 RUN apk add --no-cache ca-certificates

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,7 @@ build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
   - pandoc -s -f markdown -t rtf -o packaging\LICENSE.rtf LICENSE.md
   - go version
-  - go build -a -ldflags "-s -w" -o packaging\k6.exe
+  - go build -a -trimpath -ldflags "-s -w" -o packaging\k6.exe
   - cd %APPVEYOR_BUILD_FOLDER%\packaging
   - candle.exe -arch x64 -dVERSION=%VERSION% k6.wxs
   - light.exe -ext WixUIExtension k6.wixobj

--- a/build-release.sh
+++ b/build-release.sh
@@ -28,7 +28,7 @@ build_dist() {
 	local DIR="k6-${VERSION}-${ALIAS}"
 
 	local BUILD_ENV=("${@:4}")
-	local BUILD_ARGS=(-o "dist/$DIR/k6${SUFFIX}")
+	local BUILD_ARGS=(-o "dist/$DIR/k6${SUFFIX}" -trimpath)
 
 	if [ -n "$VERSION_DETAILS" ]; then
 		BUILD_ARGS+=(-ldflags "-X github.com/loadimpact/k6/lib/consts.VersionDetails=$VERSION_DETAILS")

--- a/build-release.sh
+++ b/build-release.sh
@@ -39,7 +39,6 @@ build_dist() {
 	# Clean out any old remnants of failed builds.
 	rm -rf "dist/$DIR"
 	mkdir -p "dist/$DIR"
-	trap "rm -rf \"dist/$DIR\"" INT TERM
 
 	# Subshell to not mess with the current env vars or CWD
 	(
@@ -70,7 +69,7 @@ checksum() {
 	fi
 
 	rm -f "dist/$CHECKSUM_FILE"
-	( cd dist && for x in *; do "${CHECKSUM_CMD[@]}" -- "$x" >> "$CHECKSUM_FILE"; done )
+	( cd dist && for x in *; do [ -f "$x" ] && "${CHECKSUM_CMD[@]}" -- "$x" >> "$CHECKSUM_FILE"; done )
 }
 
 echo "--- Building Release: ${VERSION}"


### PR DESCRIPTION
Build release script assumes GNU toolchains to make it works, thus running the script under Mac OSX fails. There're two problems:

 - `date` command invocation using GNU specific parameters.
 - Incorrect handling of checksum command invocation.

To fix them:

 - Use common parameters of both GNU `date` and BSD `date`, also use a specific time format form, instead of relying on `--iso-8601` GNU option. This will change the timezone offset format from `+00:00` to `+0000`.
 - Use an array to handle checksum command invocation.

While at it, also add `-trimpath` to all `go build` and `go install` command.