### PR TITLE
Don't create cookiejar before each iteration if it should be reused

### DIFF
--- a/js/http_bench_test.go
+++ b/js/http_bench_test.go
@@ -28,9 +28,10 @@ func BenchmarkHTTPRequests(b *testing.B) {
 		return
 	}
 	r.SetOptions(lib.Options{
-		Throw:        null.BoolFrom(true),
-		MaxRedirects: null.IntFrom(10),
-		Hosts:        tb.Dialer.Hosts,
+		Throw:          null.BoolFrom(true),
+		MaxRedirects:   null.IntFrom(10),
+		Hosts:          tb.Dialer.Hosts,
+		NoCookiesReset: null.BoolFrom(true),
 	})
 
 	var ch = make(chan stats.SampleContainer, 100)

--- a/js/runner.go
+++ b/js/runner.go
@@ -441,13 +441,13 @@ func (u *VU) RunOnce(ctx context.Context) error {
 func (u *VU) runFn(
 	ctx context.Context, group *lib.Group, isDefault bool, fn goja.Callable, args ...goja.Value,
 ) (goja.Value, bool, time.Duration, error) {
-	cookieJar, err := cookiejar.New(nil)
-	if err != nil {
-		return goja.Undefined(), false, time.Duration(0), err
-	}
-
-	if u.Runner.Bundle.Options.NoCookiesReset.Valid && u.Runner.Bundle.Options.NoCookiesReset.Bool {
-		cookieJar = u.CookieJar
+	cookieJar := u.CookieJar
+	if !u.Runner.Bundle.Options.NoCookiesReset.ValueOrZero() {
+		var err error
+		cookieJar, err = cookiejar.New(nil)
+		if err != nil {
+			return goja.Undefined(), false, time.Duration(0), err
+		}
 	}
 
 	state := &lib.State{


### PR DESCRIPTION
```
$ benchstat old.txt new.txt
name            old time/op    new time/op    delta
HTTPRequests-4     261µs ±10%     256µs ±11%    ~     (p=0.097 n=18+18)

name            old alloc/op   new alloc/op   delta
HTTPRequests-4    27.7kB ± 0%    27.6kB ± 0%  -0.35%  (p=0.000 n=20+20)

name            old allocs/op  new allocs/op  delta
HTTPRequests-4       368 ± 0%       366 ± 0%  -0.54%  (p=0.000 n=20+20)
```