### PR TITLE
Add PerVUIterations test for #1007

### DIFF
--- a/lib/executor/common_test.go
+++ b/lib/executor/common_test.go
@@ -16,10 +16,9 @@ import (
 func setupExecutor(
 	t *testing.T, config lib.ExecutorConfig,
 	vuFn func(context.Context, chan<- stats.SampleContainer) error,
-	logLevels []logrus.Level,
 ) (context.Context, context.CancelFunc, lib.Executor, *testutils.SimpleLogrusHook) {
 	ctx, cancel := context.WithCancel(context.Background())
-	logHook := &testutils.SimpleLogrusHook{HookedLevels: logLevels}
+	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.WarnLevel}}
 	testLog := logrus.New()
 	testLog.AddHook(logHook)
 	testLog.SetOutput(ioutil.Discard)
@@ -30,7 +29,7 @@ func setupExecutor(
 	}
 
 	es.SetInitVUFunc(func(_ context.Context, logger *logrus.Entry) (lib.VU, error) {
-		return &lib.MiniRunnerVU{R: runner, ID: rand.Int63(), Logger: logger}, nil
+		return &lib.MiniRunnerVU{R: runner, ID: rand.Int63()}, nil
 	})
 
 	initializeVUs(ctx, t, logEntry, es, 10)

--- a/lib/executor/common_test.go
+++ b/lib/executor/common_test.go
@@ -1,0 +1,53 @@
+package executor
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/testutils"
+	"github.com/loadimpact/k6/stats"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func setupExecutor(t *testing.T, config lib.ExecutorConfig, vuFn func(context.Context, chan<- stats.SampleContainer) error) (
+	context.Context, context.CancelFunc, lib.Executor, *testutils.SimpleLogrusHook) {
+	ctx, cancel := context.WithCancel(context.Background())
+	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.WarnLevel}}
+	testLog := logrus.New()
+	testLog.AddHook(logHook)
+	testLog.SetOutput(ioutil.Discard)
+	logEntry := logrus.NewEntry(testLog)
+	es := lib.NewExecutionState(lib.Options{}, 10, 50)
+	runner := lib.MiniRunner{
+		Fn: vuFn,
+	}
+
+	es.SetInitVUFunc(func(_ context.Context, _ *logrus.Entry) (lib.VU, error) {
+		return &lib.MiniRunnerVU{R: runner}, nil
+	})
+
+	initializeVUs(ctx, t, logEntry, es, 10)
+
+	executor, err := config.NewExecutor(es, logEntry)
+	require.NoError(t, err)
+	err = executor.Init(ctx)
+	require.NoError(t, err)
+	return ctx, cancel, executor, logHook
+}
+
+func initializeVUs(
+	ctx context.Context, t testing.TB, logEntry *logrus.Entry, es *lib.ExecutionState, number int,
+) {
+	for i := 0; i < number; i++ {
+		require.EqualValues(t, i, es.GetInitializedVUsCount())
+		vu, err := es.InitializeNewVU(ctx, logEntry)
+		require.NoError(t, err)
+		require.EqualValues(t, i+1, es.GetInitializedVUsCount())
+		es.ReturnVU(vu, false)
+		require.EqualValues(t, 0, es.GetCurrentlyActiveVUsCount())
+		require.EqualValues(t, i+1, es.GetInitializedVUsCount())
+	}
+}

--- a/lib/executor/constant_arrival_rate_test.go
+++ b/lib/executor/constant_arrival_rate_test.go
@@ -33,7 +33,9 @@ func TestConstantArrivalRateRunNotEnoughAllocatedVUsWarn(t *testing.T) {
 		func(ctx context.Context, out chan<- stats.SampleContainer) error {
 			time.Sleep(time.Second)
 			return nil
-		})
+		},
+		[]logrus.Level{logrus.WarnLevel},
+	)
 	defer cancel()
 	var engineOut = make(chan stats.SampleContainer, 1000)
 	err := executor.Run(ctx, engineOut)
@@ -56,7 +58,9 @@ func TestConstantArrivalRateRunCorrectRate(t *testing.T) {
 		func(ctx context.Context, out chan<- stats.SampleContainer) error {
 			atomic.AddInt64(&count, 1)
 			return nil
-		})
+		},
+		[]logrus.Level{logrus.WarnLevel},
+	)
 	defer cancel()
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -86,11 +90,11 @@ func TestArrivalRateCancel(t *testing.T) {
 	) (context.Context, context.CancelFunc, lib.Executor, *testutils.SimpleLogrusHook){
 		"constant": func(t *testing.T, vuFn func(ctx context.Context, out chan<- stats.SampleContainer) error) (
 			context.Context, context.CancelFunc, lib.Executor, *testutils.SimpleLogrusHook) {
-			return setupExecutor(t, getTestConstantArrivalRateConfig(), vuFn)
+			return setupExecutor(t, getTestConstantArrivalRateConfig(), vuFn, []logrus.Level{logrus.WarnLevel})
 		},
 		"variable": func(t *testing.T, vuFn func(ctx context.Context, out chan<- stats.SampleContainer) error) (
 			context.Context, context.CancelFunc, lib.Executor, *testutils.SimpleLogrusHook) {
-			return setupExecutor(t, getTestVariableArrivalRateConfig(), vuFn)
+			return setupExecutor(t, getTestVariableArrivalRateConfig(), vuFn, []logrus.Level{logrus.WarnLevel})
 		},
 	}
 	for name, fn := range mat {

--- a/lib/executor/constant_arrival_rate_test.go
+++ b/lib/executor/constant_arrival_rate_test.go
@@ -34,7 +34,6 @@ func TestConstantArrivalRateRunNotEnoughAllocatedVUsWarn(t *testing.T) {
 			time.Sleep(time.Second)
 			return nil
 		},
-		[]logrus.Level{logrus.WarnLevel},
 	)
 	defer cancel()
 	var engineOut = make(chan stats.SampleContainer, 1000)
@@ -59,7 +58,6 @@ func TestConstantArrivalRateRunCorrectRate(t *testing.T) {
 			atomic.AddInt64(&count, 1)
 			return nil
 		},
-		[]logrus.Level{logrus.WarnLevel},
 	)
 	defer cancel()
 	var wg sync.WaitGroup
@@ -90,11 +88,11 @@ func TestArrivalRateCancel(t *testing.T) {
 	) (context.Context, context.CancelFunc, lib.Executor, *testutils.SimpleLogrusHook){
 		"constant": func(t *testing.T, vuFn func(ctx context.Context, out chan<- stats.SampleContainer) error) (
 			context.Context, context.CancelFunc, lib.Executor, *testutils.SimpleLogrusHook) {
-			return setupExecutor(t, getTestConstantArrivalRateConfig(), vuFn, []logrus.Level{logrus.WarnLevel})
+			return setupExecutor(t, getTestConstantArrivalRateConfig(), vuFn)
 		},
 		"variable": func(t *testing.T, vuFn func(ctx context.Context, out chan<- stats.SampleContainer) error) (
 			context.Context, context.CancelFunc, lib.Executor, *testutils.SimpleLogrusHook) {
-			return setupExecutor(t, getTestVariableArrivalRateConfig(), vuFn, []logrus.Level{logrus.WarnLevel})
+			return setupExecutor(t, getTestVariableArrivalRateConfig(), vuFn)
 		},
 	}
 	for name, fn := range mat {

--- a/lib/executor/per_vu_iterations_test.go
+++ b/lib/executor/per_vu_iterations_test.go
@@ -1,0 +1,52 @@
+package executor
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/loadimpact/k6/lib/types"
+	"github.com/loadimpact/k6/stats"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	null "gopkg.in/guregu/null.v3"
+)
+
+func getTestPerVUIterationsConfig() PerVUIterationsConfig {
+	return PerVUIterationsConfig{
+		VUs:         null.IntFrom(10),
+		Iterations:  null.IntFrom(100),
+		MaxDuration: types.NullDurationFrom(5 * time.Second),
+	}
+}
+
+func TestPerVUIterations(t *testing.T) {
+	t.Parallel()
+	doneIters := uint64(0)
+	var ctx, cancel, executor, logHook = setupExecutor(
+		t, getTestPerVUIterationsConfig(),
+		func(ctx context.Context, out chan<- stats.SampleContainer) error {
+			atomic.AddUint64(&doneIters, 1)
+			return nil
+		},
+		[]logrus.Level{logrus.InfoLevel},
+	)
+	defer cancel()
+	err := executor.Run(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1000), doneIters)
+
+	entries := logHook.Drain()
+	require.NotEmpty(t, entries)
+	result := map[int64]uint64{}
+	for _, entry := range entries {
+		vuID := entry.Data["vu_id"].(int64)
+		result[vuID]++
+	}
+	assert.Equal(t, 10, len(result))
+	for _, vuIterCount := range result {
+		assert.Equal(t, uint64(100), vuIterCount)
+	}
+}

--- a/lib/executor/per_vu_iterations_test.go
+++ b/lib/executor/per_vu_iterations_test.go
@@ -2,13 +2,13 @@ package executor
 
 import (
 	"context"
-	"sync/atomic"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/stats"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	null "gopkg.in/guregu/null.v3"
@@ -24,29 +24,26 @@ func getTestPerVUIterationsConfig() PerVUIterationsConfig {
 
 func TestPerVUIterations(t *testing.T) {
 	t.Parallel()
-	doneIters := uint64(0)
-	var ctx, cancel, executor, logHook = setupExecutor(
+	var result sync.Map
+	var ctx, cancel, executor, _ = setupExecutor(
 		t, getTestPerVUIterationsConfig(),
 		func(ctx context.Context, out chan<- stats.SampleContainer) error {
-			atomic.AddUint64(&doneIters, 1)
+			state := lib.GetState(ctx)
+			currIter, _ := result.LoadOrStore(state.Vu, uint64(0))
+			result.Store(state.Vu, currIter.(uint64)+1)
 			return nil
 		},
-		[]logrus.Level{logrus.InfoLevel},
 	)
 	defer cancel()
 	err := executor.Run(ctx, nil)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(1000), doneIters)
 
-	entries := logHook.Drain()
-	require.NotEmpty(t, entries)
-	result := map[int64]uint64{}
-	for _, entry := range entries {
-		vuID := entry.Data["vu_id"].(int64)
-		result[vuID]++
-	}
-	assert.Equal(t, 10, len(result))
-	for _, vuIterCount := range result {
-		assert.Equal(t, uint64(100), vuIterCount)
-	}
+	var totalIters uint64
+	result.Range(func(key, value interface{}) bool {
+		vuIters := value.(uint64)
+		assert.Equal(t, uint64(100), vuIters)
+		totalIters += vuIters
+		return true
+	})
+	assert.Equal(t, uint64(1000), totalIters)
 }

--- a/lib/executor/variable_arrival_rate_test.go
+++ b/lib/executor/variable_arrival_rate_test.go
@@ -2,7 +2,6 @@ package executor
 
 import (
 	"context"
-	"io/ioutil"
 	"math/big"
 	"sync"
 	"sync/atomic"
@@ -10,7 +9,6 @@ import (
 	"time"
 
 	"github.com/loadimpact/k6/lib"
-	"github.com/loadimpact/k6/lib/testutils"
 	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/stats"
 	"github.com/sirupsen/logrus"
@@ -199,24 +197,8 @@ func BenchmarkGetPlannedRateChanges(b *testing.B) {
 	})
 }
 
-func initializeVUs(
-	ctx context.Context, t testing.TB, logEntry *logrus.Entry, es *lib.ExecutionState, number int,
-) {
-	for i := 0; i < number; i++ {
-		require.EqualValues(t, i, es.GetInitializedVUsCount())
-		vu, err := es.InitializeNewVU(ctx, logEntry)
-		require.NoError(t, err)
-		require.EqualValues(t, i+1, es.GetInitializedVUsCount())
-		es.ReturnVU(vu, false)
-		require.EqualValues(t, 0, es.GetCurrentlyActiveVUsCount())
-		require.EqualValues(t, i+1, es.GetInitializedVUsCount())
-	}
-}
-
-func testVariableArrivalRateSetup(t *testing.T, vuFn func(context.Context, chan<- stats.SampleContainer) error) (
-	context.Context, context.CancelFunc, lib.Executor, *testutils.SimpleLogrusHook) {
-	ctx, cancel := context.WithCancel(context.Background())
-	var config = VariableArrivalRateConfig{
+func getTestVariableArrivalRateConfig() VariableArrivalRateConfig {
+	return VariableArrivalRateConfig{
 		TimeUnit:  types.NullDurationFrom(time.Second),
 		StartRate: null.IntFrom(10),
 		Stages: []Stage{
@@ -236,33 +218,13 @@ func testVariableArrivalRateSetup(t *testing.T, vuFn func(context.Context, chan<
 		PreAllocatedVUs: null.IntFrom(10),
 		MaxVUs:          null.IntFrom(20),
 	}
-	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.WarnLevel}}
-	testLog := logrus.New()
-	testLog.AddHook(logHook)
-	testLog.SetOutput(ioutil.Discard)
-	logEntry := logrus.NewEntry(testLog)
-	es := lib.NewExecutionState(lib.Options{}, 10, 50)
-	runner := lib.MiniRunner{
-		Fn: vuFn,
-	}
-
-	es.SetInitVUFunc(func(_ context.Context, _ *logrus.Entry) (lib.VU, error) {
-		return &lib.MiniRunnerVU{R: runner}, nil
-	})
-
-	initializeVUs(ctx, t, logEntry, es, 10)
-
-	executor, err := config.NewExecutor(es, logEntry)
-	require.NoError(t, err)
-	err = executor.Init(ctx)
-	require.NoError(t, err)
-	return ctx, cancel, executor, logHook
 }
 
 func TestVariableArrivalRateRunNotEnoughAllocatedVUsWarn(t *testing.T) {
 	t.Parallel()
-	var ctx, cancel, executor, logHook = testVariableArrivalRateSetup(
-		t, func(ctx context.Context, out chan<- stats.SampleContainer) error {
+	var ctx, cancel, executor, logHook = setupExecutor(
+		t, getTestVariableArrivalRateConfig(),
+		func(ctx context.Context, out chan<- stats.SampleContainer) error {
 			time.Sleep(time.Second)
 			return nil
 		})
@@ -283,8 +245,9 @@ func TestVariableArrivalRateRunNotEnoughAllocatedVUsWarn(t *testing.T) {
 func TestVariableArrivalRateRunCorrectRate(t *testing.T) {
 	t.Parallel()
 	var count int64
-	var ctx, cancel, executor, logHook = testVariableArrivalRateSetup(
-		t, func(ctx context.Context, out chan<- stats.SampleContainer) error {
+	var ctx, cancel, executor, logHook = setupExecutor(
+		t, getTestVariableArrivalRateConfig(),
+		func(ctx context.Context, out chan<- stats.SampleContainer) error {
 			atomic.AddInt64(&count, 1)
 			return nil
 		})

--- a/lib/executor/variable_arrival_rate_test.go
+++ b/lib/executor/variable_arrival_rate_test.go
@@ -227,7 +227,9 @@ func TestVariableArrivalRateRunNotEnoughAllocatedVUsWarn(t *testing.T) {
 		func(ctx context.Context, out chan<- stats.SampleContainer) error {
 			time.Sleep(time.Second)
 			return nil
-		})
+		},
+		[]logrus.Level{logrus.WarnLevel},
+	)
 	defer cancel()
 	var engineOut = make(chan stats.SampleContainer, 1000)
 	err := executor.Run(ctx, engineOut)
@@ -250,7 +252,9 @@ func TestVariableArrivalRateRunCorrectRate(t *testing.T) {
 		func(ctx context.Context, out chan<- stats.SampleContainer) error {
 			atomic.AddInt64(&count, 1)
 			return nil
-		})
+		},
+		[]logrus.Level{logrus.WarnLevel},
+	)
 	defer cancel()
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/lib/executor/variable_arrival_rate_test.go
+++ b/lib/executor/variable_arrival_rate_test.go
@@ -228,7 +228,6 @@ func TestVariableArrivalRateRunNotEnoughAllocatedVUsWarn(t *testing.T) {
 			time.Sleep(time.Second)
 			return nil
 		},
-		[]logrus.Level{logrus.WarnLevel},
 	)
 	defer cancel()
 	var engineOut = make(chan stats.SampleContainer, 1000)
@@ -253,7 +252,6 @@ func TestVariableArrivalRateRunCorrectRate(t *testing.T) {
 			atomic.AddInt64(&count, 1)
 			return nil
 		},
-		[]logrus.Level{logrus.WarnLevel},
 	)
 	defer cancel()
 	var wg sync.WaitGroup

--- a/lib/runner.go
+++ b/lib/runner.go
@@ -25,7 +25,6 @@ import (
 	"math/rand"
 
 	"github.com/loadimpact/k6/stats"
-	"github.com/sirupsen/logrus"
 )
 
 // Ensure mock implementations conform to the interfaces.
@@ -155,23 +154,26 @@ func (r *MiniRunner) SetOptions(opts Options) error {
 
 // A VU spawned by a MiniRunner.
 type MiniRunnerVU struct {
-	R      MiniRunner
-	Out    chan<- stats.SampleContainer
-	ID     int64
-	Logger *logrus.Entry
+	R         MiniRunner
+	Out       chan<- stats.SampleContainer
+	ID        int64
+	Iteration int64
 }
 
 func (vu MiniRunnerVU) RunOnce(ctx context.Context) error {
 	if vu.R.Fn == nil {
 		return nil
 	}
-	// HACK: fixme, we shouldn't rely on logging for testing
-	if vu.Logger != nil {
-		vu.Logger.WithFields(
-			logrus.Fields{"vu_id": vu.ID},
-		).Info("running function")
+
+	state := &State{
+		Vu:        vu.ID,
+		Iteration: vu.Iteration,
 	}
-	return vu.R.Fn(ctx, vu.Out)
+	newctx := WithState(ctx, state)
+
+	vu.Iteration++
+
+	return vu.R.Fn(newctx, vu.Out)
 }
 
 func (vu *MiniRunnerVU) Reconfigure(id int64) error {


### PR DESCRIPTION
This adds a test for `PerVUIterations` while modeling `lib.MiniRunnerVU` closer to how `js.VU` works (setting `lib.State` in the context when `RunOnce`/`runFn` is called).