### PR TITLE
Clean up and optimize http.batch(), fix batchPerHost

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -97,7 +97,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9af09d68bd80a20b3fae068ab7c6476c9b53a145963b57df6d508180aabae7b9"
+  digest = "1:a96fa4c60aed526368ef2ee9ee40e1eb89b1901792a7bd29865cf120651ce034"
   name = "github.com/dop251/goja"
   packages = [
     ".",
@@ -107,7 +107,7 @@
     "token",
   ]
   pruneopts = "NUT"
-  revision = "9183045acc25574e0dd2ad37d5e7f978b1a4de12"
+  revision = "007eef3bc40fd33b3dbb80ec16da59e8b63b8572"
 
 [[projects]]
   branch = "master"

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -52,7 +52,7 @@ func optionFlagSet() *pflag.FlagSet {
 	flags.BoolP("paused", "p", false, "start the test in a paused state")
 	flags.Int64("max-redirects", 10, "follow at most n redirects")
 	flags.Int64("batch", 20, "max parallel batch reqs")
-	flags.Int64("batch-per-host", 20, "max parallel batch reqs per host")
+	flags.Int64("batch-per-host", 6, "max parallel batch reqs per host")
 	flags.Int64("rps", 0, "limit requests per second")
 	flags.String("user-agent", fmt.Sprintf("k6/%s (https://k6.io/)", consts.Version), "user agent for http requests")
 	flags.String("http-debug", "", "log all HTTP requests and responses. Excludes body by default. To include body use '--http-debug=full'")

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -94,6 +94,7 @@ func getOptions(flags *pflag.FlagSet) (lib.Options, error) {
 		Paused:                getNullBool(flags, "paused"),
 		MaxRedirects:          getNullInt64(flags, "max-redirects"),
 		Batch:                 getNullInt64(flags, "batch"),
+		BatchPerHost:          getNullInt64(flags, "batch-per-host"),
 		RPS:                   getNullInt64(flags, "rps"),
 		UserAgent:             getNullString(flags, "user-agent"),
 		HTTPDebug:             getNullString(flags, "http-debug"),

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -574,6 +574,7 @@ func TestSentReceivedMetrics(t *testing.T) {
 			Hosts:                 tb.Dialer.Hosts,
 			InsecureSkipTLSVerify: null.BoolFrom(true),
 			NoVUConnectionReuse:   null.BoolFrom(noConnReuse),
+			Batch:                 null.IntFrom(20),
 		}
 
 		r.SetOptions(options)

--- a/js/modules/k6/http/response.go
+++ b/js/modules/k6/http/response.go
@@ -21,7 +21,6 @@
 package http
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/url"
@@ -34,22 +33,18 @@ import (
 )
 
 // Response is a representation of an HTTP response to be returned to the goja VM
-// TODO: refactor after https://github.com/dop251/goja/issues/84
-type Response httpext.Response
-
-// GetCtx returns the Context of the httpext.Response
-func (res *Response) GetCtx() context.Context {
-	return ((*httpext.Response)(res)).GetCtx()
+type Response struct {
+	*httpext.Response `js:"-"`
 }
 
 func responseFromHttpext(resp *httpext.Response) *Response {
-	res := Response(*resp)
+	res := Response{resp}
 	return &res
 }
 
 // JSON parses the body of a response as json and returns it to the goja VM
 func (res *Response) JSON(selector ...string) goja.Value {
-	v, err := ((*httpext.Response)(res)).JSON(selector...)
+	v, err := res.Response.JSON(selector...)
 	if err != nil {
 		common.Throw(common.GetRuntime(res.GetCtx()), err)
 	}

--- a/lib/limiter.go
+++ b/lib/limiter.go
@@ -18,7 +18,7 @@
  *
  */
 
-package http
+package lib
 
 import (
 	"sync"

--- a/lib/limiter_test.go
+++ b/lib/limiter_test.go
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-package http
+package lib
 
 import (
 	"fmt"
@@ -69,11 +69,12 @@ func TestSlotLimiters(t *testing.T) {
 			l := NewSlotLimiter(tc.limit)
 			wg := sync.WaitGroup{}
 
-			if tc.limit == 0 {
+			switch {
+			case tc.limit == 0:
 				wg.Add(tc.launches)
-			} else if tc.launches < tc.limit {
+			case tc.launches < tc.limit:
 				wg.Add(tc.launches)
-			} else {
+			default:
 				wg.Add(tc.limit)
 			}
 

--- a/lib/netext/httpext/batch.go
+++ b/lib/netext/httpext/batch.go
@@ -1,0 +1,84 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2019 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package httpext
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/loadimpact/k6/lib"
+)
+
+// BatchParsedHTTPRequest extends the normal parsed HTTP request with a pointer
+// to a Response object, so that the batch goroutines can concurrently store the
+// responses they receive, without any locking.
+type BatchParsedHTTPRequest struct {
+	*ParsedHTTPRequest
+	Response *Response // this is modified by MakeBatchRequests()
+}
+
+// MakeBatchRequests concurrently makes multiple requests. It spawns
+// min(reqCount, globalLimit) goroutines that asynchronously process all
+// requests coming from the requests channel. Responses are recorded in the
+// pointers contained in each BatchParsedHTTPRequest object, so they need to be
+// pre-initialized. In addition, each processed request would emit either a nil
+// value, or an error, via the returned errors channel. The goroutines exit when
+// the requests channel is closed.
+func MakeBatchRequests(
+	ctx context.Context,
+	requests []BatchParsedHTTPRequest,
+	reqCount, globalLimit, perHostLimit int,
+) <-chan error {
+	workers := globalLimit
+	if reqCount < workers {
+		workers = reqCount
+	}
+	result := make(chan error, reqCount)
+	perHostLimiter := lib.NewMultiSlotLimiter(perHostLimit)
+
+	makeRequest := func(req BatchParsedHTTPRequest) {
+		if hl := perHostLimiter.Slot(req.URL.GetURL().Host); hl != nil {
+			hl.Begin()
+			defer hl.End()
+		}
+
+		resp, err := MakeRequest(ctx, req.ParsedHTTPRequest)
+		if resp != nil {
+			*req.Response = *resp
+		}
+		result <- err
+	}
+
+	counter, i32reqCount := int32(-1), int32(reqCount)
+	for i := 0; i < workers; i++ {
+		go func() {
+			for {
+				reqNum := atomic.AddInt32(&counter, 1)
+				if reqNum >= i32reqCount {
+					return
+				}
+				makeRequest(requests[reqNum])
+			}
+		}()
+	}
+
+	return result
+}

--- a/vendor/github.com/dop251/goja/array.go
+++ b/vendor/github.com/dop251/goja/array.go
@@ -22,10 +22,6 @@ func (a *arrayObject) init() {
 	a._put("length", &a.lengthProp)
 }
 
-func (a *arrayObject) getLength() Value {
-	return intToValue(a.length)
-}
-
 func (a *arrayObject) _setLengthInt(l int64, throw bool) bool {
 	if l >= 0 && l <= math.MaxUint32 {
 		ret := true
@@ -57,7 +53,7 @@ func (a *arrayObject) _setLengthInt(l int64, throw bool) bool {
 				a.values = ar
 			} else {
 				ar := a.values[l:len(a.values)]
-				for i, _ := range ar {
+				for i := range ar {
 					ar[i] = nil
 				}
 				a.values = a.values[:l]

--- a/vendor/github.com/dop251/goja/array_sparse.go
+++ b/vendor/github.com/dop251/goja/array_sparse.go
@@ -27,10 +27,6 @@ func (a *sparseArrayObject) init() {
 	a._put("length", &a.lengthProp)
 }
 
-func (a *sparseArrayObject) getLength() Value {
-	return intToValue(a.length)
-}
-
 func (a *sparseArrayObject) findIdx(idx int64) int {
 	return sort.Search(len(a.items), func(i int) bool {
 		return a.items[i].idx >= idx
@@ -64,7 +60,7 @@ func (a *sparseArrayObject) _setLengthInt(l int64, throw bool) bool {
 		idx := a.findIdx(l)
 
 		aa := a.items[idx:]
-		for i, _ := range aa {
+		for i := range aa {
 			aa[i].value = nil
 		}
 		a.items = a.items[:idx]

--- a/vendor/github.com/dop251/goja/builtin_array.go
+++ b/vendor/github.com/dop251/goja/builtin_array.go
@@ -48,12 +48,12 @@ func (r *Runtime) arrayproto_push(call FunctionCall) Value {
 }
 
 func (r *Runtime) arrayproto_pop_generic(obj *Object, call FunctionCall) Value {
-	l := int(toLength(obj.self.getStr("length")))
+	l := toLength(obj.self.getStr("length"))
 	if l == 0 {
 		obj.self.putStr("length", intToValue(0), true)
 		return _undefined
 	}
-	idx := intToValue(int64(l - 1))
+	idx := intToValue(l - 1)
 	val := obj.self.get(idx)
 	obj.self.delete(idx, true)
 	obj.self.putStr("length", idx, true)

--- a/vendor/github.com/dop251/goja/builtin_string.go
+++ b/vendor/github.com/dop251/goja/builtin_string.go
@@ -11,9 +11,14 @@ import (
 	"unicode/utf8"
 )
 
-var (
-	collator = collate.New(language.Und)
-)
+func (r *Runtime) collator() *collate.Collator {
+	collator := r._collator
+	if collator == nil {
+		collator = collate.New(language.Und)
+		r._collator = collator
+	}
+	return collator
+}
 
 func (r *Runtime) builtin_String(call FunctionCall) Value {
 	if len(call.Arguments) > 0 {
@@ -94,7 +99,7 @@ func (r *Runtime) string_fromcharcode(call FunctionCall) Value {
 		chr := toUInt16(arg)
 		if chr >= utf8.RuneSelf {
 			bb := make([]uint16, len(call.Arguments))
-			for j := 0; i < i; j++ {
+			for j := 0; j < i; j++ {
 				bb[j] = uint16(b[j])
 			}
 			bb[i] = chr
@@ -216,7 +221,7 @@ func (r *Runtime) stringproto_localeCompare(call FunctionCall) Value {
 	r.checkObjectCoercible(call.This)
 	this := norm.NFD.String(call.This.String())
 	that := norm.NFD.String(call.Argument(0).String())
-	return intToValue(int64(collator.CompareString(this, that)))
+	return intToValue(int64(r.collator().CompareString(this, that)))
 }
 
 func (r *Runtime) stringproto_match(call FunctionCall) Value {

--- a/vendor/github.com/dop251/goja/compiler.go
+++ b/vendor/github.com/dop251/goja/compiler.go
@@ -278,7 +278,7 @@ func (c *compiler) compile(in *ast.Program) {
 	}
 
 	c.p.code = append(c.p.code, code...)
-	for i, _ := range c.p.srcMap {
+	for i := range c.p.srcMap {
 		c.p.srcMap[i].pc += len(c.scope.names)
 	}
 

--- a/vendor/github.com/dop251/goja/compiler_expr.go
+++ b/vendor/github.com/dop251/goja/compiler_expr.go
@@ -770,11 +770,6 @@ func (e *compiledFunctionLiteral) emitGetter(putOnStack bool) {
 			needCallee = true
 		}
 	}
-	lenBefore := len(e.c.scope.names)
-	namesBefore := make([]string, 0, lenBefore)
-	for key, _ := range e.c.scope.names {
-		namesBefore = append(namesBefore, key)
-	}
 	maxPreambleLen := 2
 	e.c.p.code = make([]instruction, maxPreambleLen)
 	if needCallee {
@@ -801,7 +796,7 @@ func (e *compiledFunctionLiteral) emitGetter(putOnStack bool) {
 			e.c.p.code = e.c.p.code[maxPreambleLen-1:]
 		}
 		e.c.convertFunctionToStashless(e.c.p.code, paramsCount)
-		for i, _ := range e.c.p.srcMap {
+		for i := range e.c.p.srcMap {
 			e.c.p.srcMap[i].pc -= maxPreambleLen - l
 		}
 	} else {
@@ -842,7 +837,7 @@ func (e *compiledFunctionLiteral) emitGetter(putOnStack bool) {
 
 		copy(code[l:], e.c.p.code[maxPreambleLen:])
 		e.c.p.code = code
-		for i, _ := range e.c.p.srcMap {
+		for i := range e.c.p.srcMap {
 			e.c.p.srcMap[i].pc += l - maxPreambleLen
 		}
 	}

--- a/vendor/github.com/dop251/goja/compiler_stmt.go
+++ b/vendor/github.com/dop251/goja/compiler_stmt.go
@@ -783,8 +783,11 @@ func (c *compiler) compileSwitchStatement(v *ast.SwitchStatement, needResult boo
 		c.compileStatements(s.Consequent, nr)
 	}
 	if jumpNoMatch != -1 {
+		if needResult {
+			c.emit(jump(2))
+		}
 		c.p.code[jumpNoMatch] = jump(len(c.p.code) - jumpNoMatch)
-		if len(v.Body) == 0 && needResult {
+		if needResult {
 			c.emit(loadUndef)
 		}
 	}

--- a/vendor/github.com/dop251/goja/date.go
+++ b/vendor/github.com/dop251/goja/date.go
@@ -1,7 +1,6 @@
 package goja
 
 import (
-	"regexp"
 	"time"
 )
 
@@ -23,9 +22,21 @@ type dateObject struct {
 
 var (
 	dateLayoutList = []string{
+		"2006-01-02T15:04:05Z0700",
+		"2006-01-02T15:04:05",
+		"2006-01-02",
+		"2006-01-02 15:04:05",
+		time.RFC1123,
+		time.RFC1123Z,
+		dateTimeLayout,
+		time.UnixDate,
+		time.ANSIC,
+		time.RubyDate,
+		"Mon, 02 Jan 2006 15:04:05 GMT-0700 (MST)",
+		"Mon, 02 Jan 2006 15:04:05 -0700 (MST)",
+
 		"2006",
 		"2006-01",
-		"2006-01-02",
 
 		"2006T15:04",
 		"2006-01T15:04",
@@ -33,51 +44,27 @@ var (
 
 		"2006T15:04:05",
 		"2006-01T15:04:05",
-		"2006-01-02T15:04:05",
 
-		"2006T15:04:05.000",
-		"2006-01T15:04:05.000",
-		"2006-01-02T15:04:05.000",
+		"2006T15:04Z0700",
+		"2006-01T15:04Z0700",
+		"2006-01-02T15:04Z0700",
 
-		"2006T15:04-0700",
-		"2006-01T15:04-0700",
-		"2006-01-02T15:04-0700",
-
-		"2006T15:04:05-0700",
-		"2006-01T15:04:05-0700",
-		"2006-01-02T15:04:05-0700",
-
-		"2006T15:04:05.000-0700",
-		"2006-01T15:04:05.000-0700",
-		"2006-01-02T15:04:05.000-0700",
-
-		time.RFC1123,
-		dateTimeLayout,
+		"2006T15:04:05Z0700",
+		"2006-01T15:04:05Z0700",
 	}
-	matchDateTimeZone = regexp.MustCompile(`^(.*)(?:(Z)|([\+\-]\d{2}):(\d{2}))$`)
 )
 
 func dateParse(date string) (time.Time, bool) {
-	// YYYY-MM-DDTHH:mm:ss.sssZ
 	var t time.Time
 	var err error
-	{
-		date := date
-		if match := matchDateTimeZone.FindStringSubmatch(date); match != nil {
-			if match[2] == "Z" {
-				date = match[1] + "+0000"
-			} else {
-				date = match[1] + match[3] + match[4]
-			}
-		}
-		for _, layout := range dateLayoutList {
-			t, err = time.Parse(layout, date)
-			if err == nil {
-				break
-			}
+	for _, layout := range dateLayoutList {
+		t, err = parseDate(layout, date, time.UTC)
+		if err == nil {
+			break
 		}
 	}
-	return t, err == nil
+	unix := timeToMsec(t)
+	return t, err == nil && unix >= -8640000000000000 && unix <= 8640000000000000
 }
 
 func (r *Runtime) newDateObject(t time.Time, isSet bool) *Object {

--- a/vendor/github.com/dop251/goja/date_parser.go
+++ b/vendor/github.com/dop251/goja/date_parser.go
@@ -1,0 +1,860 @@
+package goja
+
+// This is a slightly modified version of the standard Go parser to make it more compatible with ECMAScript 5.1
+// Changes:
+// - 6-digit extended years are supported in place of long year (2006) in the form of +123456
+// - Timezone formats tolerate colons, e.g. -0700 will parse -07:00
+// - Short week day will also parse long week day
+// - Timezone in brackets, "(MST)", will match any string in brackets (e.g. "(GMT Standard Time)")
+// - If offset is not set and timezone name is unknown, an error is returned
+// - If offset and timezone name are both set the offset takes precedence and the resulting Location will be FixedZone("", offset)
+
+// Original copyright message:
+
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import (
+	"errors"
+	"time"
+)
+
+const (
+	_                        = iota
+	stdLongMonth             = iota + stdNeedDate  // "January"
+	stdMonth                                       // "Jan"
+	stdNumMonth                                    // "1"
+	stdZeroMonth                                   // "01"
+	stdLongWeekDay                                 // "Monday"
+	stdWeekDay                                     // "Mon"
+	stdDay                                         // "2"
+	stdUnderDay                                    // "_2"
+	stdZeroDay                                     // "02"
+	stdHour                  = iota + stdNeedClock // "15"
+	stdHour12                                      // "3"
+	stdZeroHour12                                  // "03"
+	stdMinute                                      // "4"
+	stdZeroMinute                                  // "04"
+	stdSecond                                      // "5"
+	stdZeroSecond                                  // "05"
+	stdLongYear              = iota + stdNeedDate  // "2006"
+	stdYear                                        // "06"
+	stdPM                    = iota + stdNeedClock // "PM"
+	stdpm                                          // "pm"
+	stdTZ                    = iota                // "MST"
+	stdBracketTZ                                   // "(MST)"
+	stdISO8601TZ                                   // "Z0700"  // prints Z for UTC
+	stdISO8601SecondsTZ                            // "Z070000"
+	stdISO8601ShortTZ                              // "Z07"
+	stdISO8601ColonTZ                              // "Z07:00" // prints Z for UTC
+	stdISO8601ColonSecondsTZ                       // "Z07:00:00"
+	stdNumTZ                                       // "-0700"  // always numeric
+	stdNumSecondsTz                                // "-070000"
+	stdNumShortTZ                                  // "-07"    // always numeric
+	stdNumColonTZ                                  // "-07:00" // always numeric
+	stdNumColonSecondsTZ                           // "-07:00:00"
+	stdFracSecond0                                 // ".0", ".00", ... , trailing zeros included
+	stdFracSecond9                                 // ".9", ".99", ..., trailing zeros omitted
+
+	stdNeedDate  = 1 << 8             // need month, day, year
+	stdNeedClock = 2 << 8             // need hour, minute, second
+	stdArgShift  = 16                 // extra argument in high bits, above low stdArgShift
+	stdMask      = 1<<stdArgShift - 1 // mask out argument
+)
+
+var errBad = errors.New("bad value for field") // placeholder not passed to user
+
+func parseDate(layout, value string, defaultLocation *time.Location) (time.Time, error) {
+	alayout, avalue := layout, value
+	rangeErrString := "" // set if a value is out of range
+	amSet := false       // do we need to subtract 12 from the hour for midnight?
+	pmSet := false       // do we need to add 12 to the hour?
+
+	// Time being constructed.
+	var (
+		year       int
+		month      int = 1 // January
+		day        int = 1
+		hour       int
+		min        int
+		sec        int
+		nsec       int
+		z          *time.Location
+		zoneOffset int = -1
+		zoneName   string
+	)
+
+	// Each iteration processes one std value.
+	for {
+		var err error
+		prefix, std, suffix := nextStdChunk(layout)
+		stdstr := layout[len(prefix) : len(layout)-len(suffix)]
+		value, err = skip(value, prefix)
+		if err != nil {
+			return time.Time{}, &time.ParseError{Layout: alayout, Value: avalue, LayoutElem: prefix, ValueElem: value}
+		}
+		if std == 0 {
+			if len(value) != 0 {
+				return time.Time{}, &time.ParseError{Layout: alayout, Value: avalue, ValueElem: value, Message: ": extra text: " + value}
+			}
+			break
+		}
+		layout = suffix
+		var p string
+		switch std & stdMask {
+		case stdYear:
+			if len(value) < 2 {
+				err = errBad
+				break
+			}
+			p, value = value[0:2], value[2:]
+			year, err = atoi(p)
+			if year >= 69 { // Unix time starts Dec 31 1969 in some time zones
+				year += 1900
+			} else {
+				year += 2000
+			}
+		case stdLongYear:
+			if len(value) >= 7 && (value[0] == '-' || value[0] == '+') { // extended year
+				neg := value[0] == '-'
+				p, value = value[1:7], value[7:]
+				year, err = atoi(p)
+				if neg {
+					year = -year
+				}
+			} else {
+				if len(value) < 4 || !isDigit(value, 0) {
+					err = errBad
+					break
+				}
+				p, value = value[0:4], value[4:]
+				year, err = atoi(p)
+			}
+
+		case stdMonth:
+			month, value, err = lookup(shortMonthNames, value)
+			month++
+		case stdLongMonth:
+			month, value, err = lookup(longMonthNames, value)
+			month++
+		case stdNumMonth, stdZeroMonth:
+			month, value, err = getnum(value, std == stdZeroMonth)
+			if month <= 0 || 12 < month {
+				rangeErrString = "month"
+			}
+		case stdWeekDay:
+			// Ignore weekday except for error checking.
+			_, value, err = lookup(longDayNames, value)
+			if err != nil {
+				_, value, err = lookup(shortDayNames, value)
+			}
+		case stdLongWeekDay:
+			_, value, err = lookup(longDayNames, value)
+		case stdDay, stdUnderDay, stdZeroDay:
+			if std == stdUnderDay && len(value) > 0 && value[0] == ' ' {
+				value = value[1:]
+			}
+			day, value, err = getnum(value, std == stdZeroDay)
+			if day < 0 {
+				// Note that we allow any one- or two-digit day here.
+				rangeErrString = "day"
+			}
+		case stdHour:
+			hour, value, err = getnum(value, false)
+			if hour < 0 || 24 <= hour {
+				rangeErrString = "hour"
+			}
+		case stdHour12, stdZeroHour12:
+			hour, value, err = getnum(value, std == stdZeroHour12)
+			if hour < 0 || 12 < hour {
+				rangeErrString = "hour"
+			}
+		case stdMinute, stdZeroMinute:
+			min, value, err = getnum(value, std == stdZeroMinute)
+			if min < 0 || 60 <= min {
+				rangeErrString = "minute"
+			}
+		case stdSecond, stdZeroSecond:
+			sec, value, err = getnum(value, std == stdZeroSecond)
+			if sec < 0 || 60 <= sec {
+				rangeErrString = "second"
+				break
+			}
+			// Special case: do we have a fractional second but no
+			// fractional second in the format?
+			if len(value) >= 2 && value[0] == '.' && isDigit(value, 1) {
+				_, std, _ = nextStdChunk(layout)
+				std &= stdMask
+				if std == stdFracSecond0 || std == stdFracSecond9 {
+					// Fractional second in the layout; proceed normally
+					break
+				}
+				// No fractional second in the layout but we have one in the input.
+				n := 2
+				for ; n < len(value) && isDigit(value, n); n++ {
+				}
+				nsec, rangeErrString, err = parseNanoseconds(value, n)
+				value = value[n:]
+			}
+		case stdPM:
+			if len(value) < 2 {
+				err = errBad
+				break
+			}
+			p, value = value[0:2], value[2:]
+			switch p {
+			case "PM":
+				pmSet = true
+			case "AM":
+				amSet = true
+			default:
+				err = errBad
+			}
+		case stdpm:
+			if len(value) < 2 {
+				err = errBad
+				break
+			}
+			p, value = value[0:2], value[2:]
+			switch p {
+			case "pm":
+				pmSet = true
+			case "am":
+				amSet = true
+			default:
+				err = errBad
+			}
+		case stdISO8601TZ, stdISO8601ColonTZ, stdISO8601SecondsTZ, stdISO8601ShortTZ, stdISO8601ColonSecondsTZ, stdNumTZ, stdNumShortTZ, stdNumColonTZ, stdNumSecondsTz, stdNumColonSecondsTZ:
+			if (std == stdISO8601TZ || std == stdISO8601ShortTZ || std == stdISO8601ColonTZ ||
+				std == stdISO8601SecondsTZ || std == stdISO8601ColonSecondsTZ) && len(value) >= 1 && value[0] == 'Z' {
+
+				value = value[1:]
+				z = time.UTC
+				break
+			}
+			var sign, hour, min, seconds string
+			if std == stdISO8601ColonTZ || std == stdNumColonTZ || std == stdNumTZ || std == stdISO8601TZ {
+				if len(value) < 4 {
+					err = errBad
+					break
+				}
+				if value[3] != ':' {
+					if std == stdNumColonTZ || std == stdISO8601ColonTZ || len(value) < 5 {
+						err = errBad
+						break
+					}
+					sign, hour, min, seconds, value = value[0:1], value[1:3], value[3:5], "00", value[5:]
+				} else {
+					if len(value) < 6 {
+						err = errBad
+						break
+					}
+					sign, hour, min, seconds, value = value[0:1], value[1:3], value[4:6], "00", value[6:]
+				}
+			} else if std == stdNumShortTZ || std == stdISO8601ShortTZ {
+				if len(value) < 3 {
+					err = errBad
+					break
+				}
+				sign, hour, min, seconds, value = value[0:1], value[1:3], "00", "00", value[3:]
+			} else if std == stdISO8601ColonSecondsTZ || std == stdNumColonSecondsTZ || std == stdISO8601SecondsTZ || std == stdNumSecondsTz {
+				if len(value) < 7 {
+					err = errBad
+					break
+				}
+				if value[3] != ':' || value[6] != ':' {
+					if std == stdISO8601ColonSecondsTZ || std == stdNumColonSecondsTZ || len(value) < 7 {
+						err = errBad
+						break
+					}
+					sign, hour, min, seconds, value = value[0:1], value[1:3], value[3:5], value[5:7], value[7:]
+				} else {
+					if len(value) < 9 {
+						err = errBad
+						break
+					}
+					sign, hour, min, seconds, value = value[0:1], value[1:3], value[4:6], value[7:9], value[9:]
+				}
+			}
+			var hr, mm, ss int
+			hr, err = atoi(hour)
+			if err == nil {
+				mm, err = atoi(min)
+			}
+			if err == nil {
+				ss, err = atoi(seconds)
+			}
+			zoneOffset = (hr*60+mm)*60 + ss // offset is in seconds
+			switch sign[0] {
+			case '+':
+			case '-':
+				zoneOffset = -zoneOffset
+			default:
+				err = errBad
+			}
+		case stdTZ:
+			// Does it look like a time zone?
+			if len(value) >= 3 && value[0:3] == "UTC" {
+				z = time.UTC
+				value = value[3:]
+				break
+			}
+			n, ok := parseTimeZone(value)
+			if !ok {
+				err = errBad
+				break
+			}
+			zoneName, value = value[:n], value[n:]
+		case stdBracketTZ:
+			if len(value) < 3 || value[0] != '(' {
+				err = errBad
+				break
+			}
+			i := 1
+			for ; ; i++ {
+				if i >= len(value) {
+					err = errBad
+					break
+				}
+				if value[i] == ')' {
+					zoneName, value = value[1:i], value[i+1:]
+					break
+				}
+			}
+
+		case stdFracSecond0:
+			// stdFracSecond0 requires the exact number of digits as specified in
+			// the layout.
+			ndigit := 1 + (std >> stdArgShift)
+			if len(value) < ndigit {
+				err = errBad
+				break
+			}
+			nsec, rangeErrString, err = parseNanoseconds(value, ndigit)
+			value = value[ndigit:]
+
+		case stdFracSecond9:
+			if len(value) < 2 || value[0] != '.' || value[1] < '0' || '9' < value[1] {
+				// Fractional second omitted.
+				break
+			}
+			// Take any number of digits, even more than asked for,
+			// because it is what the stdSecond case would do.
+			i := 0
+			for i < 9 && i+1 < len(value) && '0' <= value[i+1] && value[i+1] <= '9' {
+				i++
+			}
+			nsec, rangeErrString, err = parseNanoseconds(value, 1+i)
+			value = value[1+i:]
+		}
+		if rangeErrString != "" {
+			return time.Time{}, &time.ParseError{Layout: alayout, Value: avalue, LayoutElem: stdstr, ValueElem: value, Message: ": " + rangeErrString + " out of range"}
+		}
+		if err != nil {
+			return time.Time{}, &time.ParseError{Layout: alayout, Value: avalue, LayoutElem: stdstr, ValueElem: value}
+		}
+	}
+	if pmSet && hour < 12 {
+		hour += 12
+	} else if amSet && hour == 12 {
+		hour = 0
+	}
+
+	// Validate the day of the month.
+	if day < 1 || day > daysIn(time.Month(month), year) {
+		return time.Time{}, &time.ParseError{Layout: alayout, Value: avalue, ValueElem: value, Message: ": day out of range"}
+	}
+
+	if z == nil {
+		if zoneOffset == -1 {
+			if zoneName != "" {
+				if z1, err := time.LoadLocation(zoneName); err == nil {
+					z = z1
+				} else {
+					return time.Time{}, &time.ParseError{Layout: alayout, Value: avalue, ValueElem: value, Message: ": unknown timezone"}
+				}
+			} else {
+				z = defaultLocation
+			}
+		} else if zoneOffset == 0 {
+			z = time.UTC
+		} else {
+			z = time.FixedZone("", zoneOffset)
+		}
+	}
+
+	return time.Date(year, time.Month(month), day, hour, min, sec, nsec, z), nil
+}
+
+var errLeadingInt = errors.New("time: bad [0-9]*") // never printed
+
+func signedLeadingInt(s string) (x int64, rem string, err error) {
+	neg := false
+	if s != "" && (s[0] == '-' || s[0] == '+') {
+		neg = s[0] == '-'
+		s = s[1:]
+	}
+	x, rem, err = leadingInt(s)
+	if err != nil {
+		return
+	}
+
+	if neg {
+		x = -x
+	}
+	return
+}
+
+// leadingInt consumes the leading [0-9]* from s.
+func leadingInt(s string) (x int64, rem string, err error) {
+	i := 0
+	for ; i < len(s); i++ {
+		c := s[i]
+		if c < '0' || c > '9' {
+			break
+		}
+		if x > (1<<63-1)/10 {
+			// overflow
+			return 0, "", errLeadingInt
+		}
+		x = x*10 + int64(c) - '0'
+		if x < 0 {
+			// overflow
+			return 0, "", errLeadingInt
+		}
+	}
+	return x, s[i:], nil
+}
+
+// nextStdChunk finds the first occurrence of a std string in
+// layout and returns the text before, the std string, and the text after.
+func nextStdChunk(layout string) (prefix string, std int, suffix string) {
+	for i := 0; i < len(layout); i++ {
+		switch c := int(layout[i]); c {
+		case 'J': // January, Jan
+			if len(layout) >= i+3 && layout[i:i+3] == "Jan" {
+				if len(layout) >= i+7 && layout[i:i+7] == "January" {
+					return layout[0:i], stdLongMonth, layout[i+7:]
+				}
+				if !startsWithLowerCase(layout[i+3:]) {
+					return layout[0:i], stdMonth, layout[i+3:]
+				}
+			}
+
+		case 'M': // Monday, Mon, MST
+			if len(layout) >= i+3 {
+				if layout[i:i+3] == "Mon" {
+					if len(layout) >= i+6 && layout[i:i+6] == "Monday" {
+						return layout[0:i], stdLongWeekDay, layout[i+6:]
+					}
+					if !startsWithLowerCase(layout[i+3:]) {
+						return layout[0:i], stdWeekDay, layout[i+3:]
+					}
+				}
+				if layout[i:i+3] == "MST" {
+					return layout[0:i], stdTZ, layout[i+3:]
+				}
+			}
+
+		case '0': // 01, 02, 03, 04, 05, 06
+			if len(layout) >= i+2 && '1' <= layout[i+1] && layout[i+1] <= '6' {
+				return layout[0:i], std0x[layout[i+1]-'1'], layout[i+2:]
+			}
+
+		case '1': // 15, 1
+			if len(layout) >= i+2 && layout[i+1] == '5' {
+				return layout[0:i], stdHour, layout[i+2:]
+			}
+			return layout[0:i], stdNumMonth, layout[i+1:]
+
+		case '2': // 2006, 2
+			if len(layout) >= i+4 && layout[i:i+4] == "2006" {
+				return layout[0:i], stdLongYear, layout[i+4:]
+			}
+			return layout[0:i], stdDay, layout[i+1:]
+
+		case '_': // _2, _2006
+			if len(layout) >= i+2 && layout[i+1] == '2' {
+				//_2006 is really a literal _, followed by stdLongYear
+				if len(layout) >= i+5 && layout[i+1:i+5] == "2006" {
+					return layout[0 : i+1], stdLongYear, layout[i+5:]
+				}
+				return layout[0:i], stdUnderDay, layout[i+2:]
+			}
+
+		case '3':
+			return layout[0:i], stdHour12, layout[i+1:]
+
+		case '4':
+			return layout[0:i], stdMinute, layout[i+1:]
+
+		case '5':
+			return layout[0:i], stdSecond, layout[i+1:]
+
+		case 'P': // PM
+			if len(layout) >= i+2 && layout[i+1] == 'M' {
+				return layout[0:i], stdPM, layout[i+2:]
+			}
+
+		case 'p': // pm
+			if len(layout) >= i+2 && layout[i+1] == 'm' {
+				return layout[0:i], stdpm, layout[i+2:]
+			}
+
+		case '-': // -070000, -07:00:00, -0700, -07:00, -07
+			if len(layout) >= i+7 && layout[i:i+7] == "-070000" {
+				return layout[0:i], stdNumSecondsTz, layout[i+7:]
+			}
+			if len(layout) >= i+9 && layout[i:i+9] == "-07:00:00" {
+				return layout[0:i], stdNumColonSecondsTZ, layout[i+9:]
+			}
+			if len(layout) >= i+5 && layout[i:i+5] == "-0700" {
+				return layout[0:i], stdNumTZ, layout[i+5:]
+			}
+			if len(layout) >= i+6 && layout[i:i+6] == "-07:00" {
+				return layout[0:i], stdNumColonTZ, layout[i+6:]
+			}
+			if len(layout) >= i+3 && layout[i:i+3] == "-07" {
+				return layout[0:i], stdNumShortTZ, layout[i+3:]
+			}
+
+		case 'Z': // Z070000, Z07:00:00, Z0700, Z07:00,
+			if len(layout) >= i+7 && layout[i:i+7] == "Z070000" {
+				return layout[0:i], stdISO8601SecondsTZ, layout[i+7:]
+			}
+			if len(layout) >= i+9 && layout[i:i+9] == "Z07:00:00" {
+				return layout[0:i], stdISO8601ColonSecondsTZ, layout[i+9:]
+			}
+			if len(layout) >= i+5 && layout[i:i+5] == "Z0700" {
+				return layout[0:i], stdISO8601TZ, layout[i+5:]
+			}
+			if len(layout) >= i+6 && layout[i:i+6] == "Z07:00" {
+				return layout[0:i], stdISO8601ColonTZ, layout[i+6:]
+			}
+			if len(layout) >= i+3 && layout[i:i+3] == "Z07" {
+				return layout[0:i], stdISO8601ShortTZ, layout[i+3:]
+			}
+
+		case '.': // .000 or .999 - repeated digits for fractional seconds.
+			if i+1 < len(layout) && (layout[i+1] == '0' || layout[i+1] == '9') {
+				ch := layout[i+1]
+				j := i + 1
+				for j < len(layout) && layout[j] == ch {
+					j++
+				}
+				// String of digits must end here - only fractional second is all digits.
+				if !isDigit(layout, j) {
+					std := stdFracSecond0
+					if layout[i+1] == '9' {
+						std = stdFracSecond9
+					}
+					std |= (j - (i + 1)) << stdArgShift
+					return layout[0:i], std, layout[j:]
+				}
+			}
+		case '(':
+			if len(layout) >= i+5 && layout[i:i+5] == "(MST)" {
+				return layout[0:i], stdBracketTZ, layout[i+5:]
+			}
+		}
+	}
+	return layout, 0, ""
+}
+
+var longDayNames = []string{
+	"Sunday",
+	"Monday",
+	"Tuesday",
+	"Wednesday",
+	"Thursday",
+	"Friday",
+	"Saturday",
+}
+
+var shortDayNames = []string{
+	"Sun",
+	"Mon",
+	"Tue",
+	"Wed",
+	"Thu",
+	"Fri",
+	"Sat",
+}
+
+var shortMonthNames = []string{
+	"Jan",
+	"Feb",
+	"Mar",
+	"Apr",
+	"May",
+	"Jun",
+	"Jul",
+	"Aug",
+	"Sep",
+	"Oct",
+	"Nov",
+	"Dec",
+}
+
+var longMonthNames = []string{
+	"January",
+	"February",
+	"March",
+	"April",
+	"May",
+	"June",
+	"July",
+	"August",
+	"September",
+	"October",
+	"November",
+	"December",
+}
+
+// isDigit reports whether s[i] is in range and is a decimal digit.
+func isDigit(s string, i int) bool {
+	if len(s) <= i {
+		return false
+	}
+	c := s[i]
+	return '0' <= c && c <= '9'
+}
+
+// getnum parses s[0:1] or s[0:2] (fixed forces the latter)
+// as a decimal integer and returns the integer and the
+// remainder of the string.
+func getnum(s string, fixed bool) (int, string, error) {
+	if !isDigit(s, 0) {
+		return 0, s, errBad
+	}
+	if !isDigit(s, 1) {
+		if fixed {
+			return 0, s, errBad
+		}
+		return int(s[0] - '0'), s[1:], nil
+	}
+	return int(s[0]-'0')*10 + int(s[1]-'0'), s[2:], nil
+}
+
+func cutspace(s string) string {
+	for len(s) > 0 && s[0] == ' ' {
+		s = s[1:]
+	}
+	return s
+}
+
+// skip removes the given prefix from value,
+// treating runs of space characters as equivalent.
+func skip(value, prefix string) (string, error) {
+	for len(prefix) > 0 {
+		if prefix[0] == ' ' {
+			if len(value) > 0 && value[0] != ' ' {
+				return value, errBad
+			}
+			prefix = cutspace(prefix)
+			value = cutspace(value)
+			continue
+		}
+		if len(value) == 0 || value[0] != prefix[0] {
+			return value, errBad
+		}
+		prefix = prefix[1:]
+		value = value[1:]
+	}
+	return value, nil
+}
+
+// Never printed, just needs to be non-nil for return by atoi.
+var atoiError = errors.New("time: invalid number")
+
+// Duplicates functionality in strconv, but avoids dependency.
+func atoi(s string) (x int, err error) {
+	q, rem, err := signedLeadingInt(s)
+	x = int(q)
+	if err != nil || rem != "" {
+		return 0, atoiError
+	}
+	return x, nil
+}
+
+// match reports whether s1 and s2 match ignoring case.
+// It is assumed s1 and s2 are the same length.
+func match(s1, s2 string) bool {
+	for i := 0; i < len(s1); i++ {
+		c1 := s1[i]
+		c2 := s2[i]
+		if c1 != c2 {
+			// Switch to lower-case; 'a'-'A' is known to be a single bit.
+			c1 |= 'a' - 'A'
+			c2 |= 'a' - 'A'
+			if c1 != c2 || c1 < 'a' || c1 > 'z' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func lookup(tab []string, val string) (int, string, error) {
+	for i, v := range tab {
+		if len(val) >= len(v) && match(val[0:len(v)], v) {
+			return i, val[len(v):], nil
+		}
+	}
+	return -1, val, errBad
+}
+
+// daysBefore[m] counts the number of days in a non-leap year
+// before month m begins. There is an entry for m=12, counting
+// the number of days before January of next year (365).
+var daysBefore = [...]int32{
+	0,
+	31,
+	31 + 28,
+	31 + 28 + 31,
+	31 + 28 + 31 + 30,
+	31 + 28 + 31 + 30 + 31,
+	31 + 28 + 31 + 30 + 31 + 30,
+	31 + 28 + 31 + 30 + 31 + 30 + 31,
+	31 + 28 + 31 + 30 + 31 + 30 + 31 + 31,
+	31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30,
+	31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31,
+	31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30,
+	31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30 + 31,
+}
+
+func isLeap(year int) bool {
+	return year%4 == 0 && (year%100 != 0 || year%400 == 0)
+}
+
+func daysIn(m time.Month, year int) int {
+	if m == time.February && isLeap(year) {
+		return 29
+	}
+	return int(daysBefore[m] - daysBefore[m-1])
+}
+
+// parseTimeZone parses a time zone string and returns its length. Time zones
+// are human-generated and unpredictable. We can't do precise error checking.
+// On the other hand, for a correct parse there must be a time zone at the
+// beginning of the string, so it's almost always true that there's one
+// there. We look at the beginning of the string for a run of upper-case letters.
+// If there are more than 5, it's an error.
+// If there are 4 or 5 and the last is a T, it's a time zone.
+// If there are 3, it's a time zone.
+// Otherwise, other than special cases, it's not a time zone.
+// GMT is special because it can have an hour offset.
+func parseTimeZone(value string) (length int, ok bool) {
+	if len(value) < 3 {
+		return 0, false
+	}
+	// Special case 1: ChST and MeST are the only zones with a lower-case letter.
+	if len(value) >= 4 && (value[:4] == "ChST" || value[:4] == "MeST") {
+		return 4, true
+	}
+	// Special case 2: GMT may have an hour offset; treat it specially.
+	if value[:3] == "GMT" {
+		length = parseGMT(value)
+		return length, true
+	}
+	// Special Case 3: Some time zones are not named, but have +/-00 format
+	if value[0] == '+' || value[0] == '-' {
+		length = parseSignedOffset(value)
+		return length, true
+	}
+	// How many upper-case letters are there? Need at least three, at most five.
+	var nUpper int
+	for nUpper = 0; nUpper < 6; nUpper++ {
+		if nUpper >= len(value) {
+			break
+		}
+		if c := value[nUpper]; c < 'A' || 'Z' < c {
+			break
+		}
+	}
+	switch nUpper {
+	case 0, 1, 2, 6:
+		return 0, false
+	case 5: // Must end in T to match.
+		if value[4] == 'T' {
+			return 5, true
+		}
+	case 4:
+		// Must end in T, except one special case.
+		if value[3] == 'T' || value[:4] == "WITA" {
+			return 4, true
+		}
+	case 3:
+		return 3, true
+	}
+	return 0, false
+}
+
+// parseGMT parses a GMT time zone. The input string is known to start "GMT".
+// The function checks whether that is followed by a sign and a number in the
+// range -14 through 12 excluding zero.
+func parseGMT(value string) int {
+	value = value[3:]
+	if len(value) == 0 {
+		return 3
+	}
+
+	return 3 + parseSignedOffset(value)
+}
+
+// parseSignedOffset parses a signed timezone offset (e.g. "+03" or "-04").
+// The function checks for a signed number in the range -14 through +12 excluding zero.
+// Returns length of the found offset string or 0 otherwise
+func parseSignedOffset(value string) int {
+	sign := value[0]
+	if sign != '-' && sign != '+' {
+		return 0
+	}
+	x, rem, err := leadingInt(value[1:])
+	if err != nil {
+		return 0
+	}
+	if sign == '-' {
+		x = -x
+	}
+	if x == 0 || x < -14 || 12 < x {
+		return 0
+	}
+	return len(value) - len(rem)
+}
+
+func parseNanoseconds(value string, nbytes int) (ns int, rangeErrString string, err error) {
+	if value[0] != '.' {
+		err = errBad
+		return
+	}
+	if ns, err = atoi(value[1:nbytes]); err != nil {
+		return
+	}
+	if ns < 0 || 1e9 <= ns {
+		rangeErrString = "fractional second"
+		return
+	}
+	// We need nanoseconds, which means scaling by the number
+	// of missing digits in the format, maximum length 10. If it's
+	// longer than 10, we won't scale.
+	scaleDigits := 10 - nbytes
+	for i := 0; i < scaleDigits; i++ {
+		ns *= 10
+	}
+	return
+}
+
+// std0x records the std values for "01", "02", ..., "06".
+var std0x = [...]int{stdZeroMonth, stdZeroDay, stdZeroHour12, stdZeroMinute, stdZeroSecond, stdYear}
+
+// startsWithLowerCase reports whether the string has a lower-case letter at the beginning.
+// Its purpose is to prevent matching strings like "Month" when looking for "Mon".
+func startsWithLowerCase(str string) bool {
+	if len(str) == 0 {
+		return false
+	}
+	c := str[0]
+	return 'a' <= c && c <= 'z'
+}

--- a/vendor/github.com/dop251/goja/dtoa.go
+++ b/vendor/github.com/dop251/goja/dtoa.go
@@ -219,7 +219,7 @@ func dtobasestr(num float64, radix int) string {
 		}
 		mlo := big.NewInt(1)
 		mhi := mlo
-		if (word1 == 0) && ((word0 & bndry_mask) == 0) && ((word0 & (exp_mask & exp_mask << 1)) != 0) {
+		if (word1 == 0) && ((word0 & bndry_mask) == 0) && ((word0 & (exp_mask & (exp_mask << 1))) != 0) {
 			/* The special case.  Here we want to be within a quarter of the last input
 			   significant digit instead of one half of it when the output string's value is less than d.  */
 			s2 += log2P

--- a/vendor/github.com/dop251/goja/object_goreflect.go
+++ b/vendor/github.com/dop251/goja/object_goreflect.go
@@ -18,7 +18,7 @@ type FieldNameMapper interface {
 	// If this method returns "" the field becomes hidden.
 	FieldName(t reflect.Type, f reflect.StructField) string
 
-	// FieldName returns a JavaScript name for the given method in the given type.
+	// MethodName returns a JavaScript name for the given method in the given type.
 	// If this method returns "" the method becomes hidden.
 	MethodName(t reflect.Type, m reflect.Method) string
 }
@@ -147,7 +147,7 @@ func (o *objectGoReflect) getOwnProp(name string) Value {
 		if v := o._getField(name); v.IsValid() {
 			return &valueProperty{
 				value:      o.val.runtime.ToValue(v.Interface()),
-				writable:   true,
+				writable:   v.CanSet(),
 				enumerable: true,
 			}
 		}
@@ -176,6 +176,10 @@ func (o *objectGoReflect) putStr(name string, val Value, throw bool) {
 func (o *objectGoReflect) _put(name string, val Value, throw bool) bool {
 	if o.value.Kind() == reflect.Struct {
 		if v := o._getField(name); v.IsValid() {
+			if !v.CanSet() {
+				o.val.runtime.typeErrorResult(throw, "Cannot assign to a non-addressable or read-only property %s of a host object", name)
+				return false
+			}
 			vv, err := o.val.runtime.toReflectValue(val, v.Type())
 			if err != nil {
 				o.val.runtime.typeErrorResult(throw, "Go struct conversion error: %v", err)
@@ -212,25 +216,23 @@ func (r *Runtime) checkHostObjectPropertyDescr(name string, descr propertyDescr,
 }
 
 func (o *objectGoReflect) defineOwnProperty(n Value, descr propertyDescr, throw bool) bool {
-	name := n.String()
-	if ast.IsExported(name) {
-		if o.value.Kind() == reflect.Struct {
-			if v := o._getField(name); v.IsValid() {
-				if !o.val.runtime.checkHostObjectPropertyDescr(name, descr, throw) {
-					return false
-				}
-				val := descr.Value
-				if val == nil {
-					val = _undefined
-				}
-				vv, err := o.val.runtime.toReflectValue(val, v.Type())
-				if err != nil {
-					o.val.runtime.typeErrorResult(throw, "Go struct conversion error: %v", err)
-					return false
-				}
-				v.Set(vv)
-				return true
+	if o.value.Kind() == reflect.Struct {
+		name := n.String()
+		if v := o._getField(name); v.IsValid() {
+			if !o.val.runtime.checkHostObjectPropertyDescr(name, descr, throw) {
+				return false
 			}
+			val := descr.Value
+			if val == nil {
+				val = _undefined
+			}
+			vv, err := o.val.runtime.toReflectValue(val, v.Type())
+			if err != nil {
+				o.val.runtime.typeErrorResult(throw, "Go struct conversion error: %v", err)
+				return false
+			}
+			v.Set(vv)
+			return true
 		}
 	}
 
@@ -238,9 +240,6 @@ func (o *objectGoReflect) defineOwnProperty(n Value, descr propertyDescr, throw 
 }
 
 func (o *objectGoReflect) _has(name string) bool {
-	if !ast.IsExported(name) {
-		return false
-	}
 	if o.value.Kind() == reflect.Struct {
 		if v := o._getField(name); v.IsValid() {
 			return true
@@ -421,34 +420,37 @@ func (r *Runtime) buildFieldInfo(t reflect.Type, index []int, info *reflectTypeI
 		}
 		if r.fieldNameMapper != nil {
 			name = r.fieldNameMapper.FieldName(t, field)
-			if name == "" {
-				continue
+		}
+
+		if name != "" {
+			if inf, exists := info.Fields[name]; !exists {
+				info.FieldNames = append(info.FieldNames, name)
+			} else {
+				if len(inf.Index) <= len(index) {
+					continue
+				}
 			}
 		}
 
-		if inf, exists := info.Fields[name]; !exists {
-			info.FieldNames = append(info.FieldNames, name)
-		} else {
-			if len(inf.Index) <= len(index) {
-				continue
-			}
-		}
+		if name != "" || field.Anonymous {
+			idx := make([]int, len(index)+1)
+			copy(idx, index)
+			idx[len(idx)-1] = i
 
-		idx := make([]int, len(index)+1)
-		copy(idx, index)
-		idx[len(idx)-1] = i
-
-		info.Fields[name] = reflectFieldInfo{
-			Index:     idx,
-			Anonymous: field.Anonymous,
-		}
-		if field.Anonymous {
-			typ := field.Type
-			for typ.Kind() == reflect.Ptr {
-				typ = typ.Elem()
+			if name != "" {
+				info.Fields[name] = reflectFieldInfo{
+					Index:     idx,
+					Anonymous: field.Anonymous,
+				}
 			}
-			if typ.Kind() == reflect.Struct {
-				r.buildFieldInfo(typ, idx, info)
+			if field.Anonymous {
+				typ := field.Type
+				for typ.Kind() == reflect.Ptr {
+					typ = typ.Elem()
+				}
+				if typ.Kind() == reflect.Struct {
+					r.buildFieldInfo(typ, idx, info)
+				}
 			}
 		}
 	}
@@ -501,7 +503,7 @@ func (r *Runtime) typeInfo(t reflect.Type) (info *reflectTypeInfo) {
 	return
 }
 
-// Sets a custom field name mapper for Go types. It can be called at any time, however
+// SetFieldNameMapper sets a custom field name mapper for Go types. It can be called at any time, however
 // the mapping for any given value is fixed at the point of creation.
 // Setting this to nil restores the default behaviour which is all exported fields and methods are mapped to their
 // original unchanged names.

--- a/vendor/github.com/dop251/goja/parser/expression.go
+++ b/vendor/github.com/dop251/goja/parser/expression.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-
 	"github.com/dop251/goja/ast"
 	"github.com/dop251/goja/file"
 	"github.com/dop251/goja/token"
@@ -273,9 +272,10 @@ func (self *_parser) parseObjectLiteral() ast.Expression {
 	for self.token != token.RIGHT_BRACE && self.token != token.EOF {
 		property := self.parseObjectProperty()
 		value = append(value, property)
-		if self.token == token.COMMA {
-			self.next()
-			continue
+		if self.token != token.RIGHT_BRACE {
+			self.expect(token.COMMA)
+		} else {
+			break
 		}
 	}
 	idx1 := self.expect(token.RIGHT_BRACE)
@@ -399,7 +399,7 @@ func (self *_parser) parseLeftHandSideExpression() ast.Expression {
 	for {
 		if self.token == token.PERIOD {
 			left = self.parseDotMember(left)
-		} else if self.token == token.LEFT_BRACE {
+		} else if self.token == token.LEFT_BRACKET {
 			left = self.parseBracketMember(left)
 		} else {
 			break

--- a/vendor/github.com/dop251/goja/parser/lexer.go
+++ b/vendor/github.com/dop251/goja/parser/lexer.go
@@ -631,7 +631,7 @@ func parseStringLiteral(literal string) (string, error) {
 	str := literal
 	buffer := bytes.NewBuffer(make([]byte, 0, 3*len(literal)/2))
 	var surrogate rune
-	S:
+S:
 	for len(str) > 0 {
 		switch chr := str[0]; {
 		// We do not explicitly handle the case of the quote

--- a/vendor/github.com/dop251/goja/parser/parser.go
+++ b/vendor/github.com/dop251/goja/parser/parser.go
@@ -52,9 +52,9 @@ const (
 )
 
 type _parser struct {
-	str      string
-	length   int
-	base     int
+	str    string
+	length int
+	base   int
 
 	chr       rune // The current character
 	chrOffset int  // The offset of current character

--- a/vendor/github.com/dop251/goja/parser/regexp.go
+++ b/vendor/github.com/dop251/goja/parser/regexp.go
@@ -144,7 +144,6 @@ func (self *_RegExp_parser) scanBracket() {
 		return
 	}
 
-
 	self.pass()
 	for self.chr != -1 {
 		if self.chr == ']' {

--- a/vendor/github.com/dop251/goja/parser/statement.go
+++ b/vendor/github.com/dop251/goja/parser/statement.go
@@ -1,15 +1,15 @@
 package parser
 
 import (
+	"encoding/base64"
 	"github.com/dop251/goja/ast"
 	"github.com/dop251/goja/file"
 	"github.com/dop251/goja/token"
 	"github.com/go-sourcemap/sourcemap"
-	"encoding/base64"
-	"strings"
-	"os"
 	"io/ioutil"
 	"net/url"
+	"os"
+	"strings"
 )
 
 func (self *_parser) parseBlockStatement() *ast.BlockStatement {
@@ -483,6 +483,9 @@ func (self *_parser) parseDoWhileStatement() ast.Statement {
 	self.expect(token.LEFT_PARENTHESIS)
 	node.Test = self.parseExpression()
 	self.expect(token.RIGHT_PARENTHESIS)
+	if self.token == token.SEMICOLON {
+		self.next()
+	}
 
 	return node
 }
@@ -555,7 +558,7 @@ func (self *_parser) parseProgram() *ast.Program {
 }
 
 func (self *_parser) parseSourceMap() *sourcemap.Consumer {
-	lastLine := self.str[strings.LastIndexByte(self.str, '\n') + 1:]
+	lastLine := self.str[strings.LastIndexByte(self.str, '\n')+1:]
 	if strings.HasPrefix(lastLine, "//# sourceMappingURL") {
 		urlIndex := strings.Index(lastLine, "=")
 		urlStr := lastLine[urlIndex+1:]

--- a/vendor/github.com/dop251/goja/runtime.go
+++ b/vendor/github.com/dop251/goja/runtime.go
@@ -9,6 +9,9 @@ import (
 	"math/rand"
 	"reflect"
 	"strconv"
+	"time"
+
+	"golang.org/x/text/collate"
 
 	js_ast "github.com/dop251/goja/ast"
 	"github.com/dop251/goja/parser"
@@ -21,6 +24,7 @@ const (
 var (
 	typeCallable = reflect.TypeOf(Callable(nil))
 	typeValue    = reflect.TypeOf((*Value)(nil)).Elem()
+	typeTime     = reflect.TypeOf(time.Time{})
 )
 
 type global struct {
@@ -93,11 +97,15 @@ func ToFlag(b bool) Flag {
 
 type RandSource func() float64
 
+type Now func() time.Time
+
 type Runtime struct {
 	global          global
 	globalObject    *Object
 	stringSingleton *stringObject
 	rand            RandSource
+	now             Now
+	_collator       *collate.Collator
 
 	typeInfoCache   map[reflect.Type]*reflectTypeInfo
 	fieldNameMapper FieldNameMapper
@@ -231,6 +239,7 @@ func (r *Runtime) addToGlobal(name string, value Value) {
 
 func (r *Runtime) init() {
 	r.rand = rand.Float64
+	r.now = time.Now
 	r.global.ObjectPrototype = r.newBaseObject(nil, classObject).val
 	r.globalObject = r.NewObject()
 
@@ -965,7 +974,7 @@ func (r *Runtime) ToValue(i interface{}) Value {
 	case int64:
 		return intToValue(i)
 	case uint:
-		if int64(i) <= math.MaxInt64 {
+		if uint64(i) <= math.MaxInt64 {
 			return intToValue(int64(i))
 		} else {
 			return floatToValue(float64(i))
@@ -986,6 +995,9 @@ func (r *Runtime) ToValue(i interface{}) Value {
 	case float64:
 		return floatToValue(i)
 	case map[string]interface{}:
+		if i == nil {
+			return _null
+		}
 		obj := &Object{runtime: r}
 		m := &objectGoMapSimple{
 			baseObject: baseObject{
@@ -998,6 +1010,9 @@ func (r *Runtime) ToValue(i interface{}) Value {
 		m.init()
 		return obj
 	case []interface{}:
+		if i == nil {
+			return _null
+		}
 		obj := &Object{runtime: r}
 		a := &objectGoSlice{
 			baseObject: baseObject{
@@ -1009,6 +1024,9 @@ func (r *Runtime) ToValue(i interface{}) Value {
 		a.init()
 		return obj
 	case *[]interface{}:
+		if i == nil {
+			return _null
+		}
 		obj := &Object{runtime: r}
 		a := &objectGoSlice{
 			baseObject: baseObject{
@@ -1242,6 +1260,14 @@ func (r *Runtime) toReflectValue(v Value, typ reflect.Type) (reflect.Value, erro
 		return reflect.ValueOf(v.Export()).Convert(typ), nil
 	}
 
+	if typ == typeTime && et.Kind() == reflect.String {
+		time, ok := dateParse(v.String())
+		if !ok {
+			return reflect.Value{}, fmt.Errorf("Could not convert string %v to %v", v, typ)
+		}
+		return reflect.ValueOf(time), nil
+	}
+
 	switch typ.Kind() {
 	case reflect.Slice:
 		if o, ok := v.(*Object); ok {
@@ -1253,7 +1279,7 @@ func (r *Runtime) toReflectValue(v Value, typ reflect.Type) (reflect.Value, erro
 					item := o.self.get(intToValue(int64(i)))
 					itemval, err := r.toReflectValue(item, elemTyp)
 					if err != nil {
-						return reflect.Value{}, fmt.Errorf("Could not convert array element %v to %v at %d", v, typ, i)
+						return reflect.Value{}, fmt.Errorf("Could not convert array element %v to %v at %d: %s", v, typ, i, err)
 					}
 					s.Index(i).Set(itemval)
 				}
@@ -1300,11 +1326,17 @@ func (r *Runtime) toReflectValue(v Value, typ reflect.Type) (reflect.Value, erro
 			for i := 0; i < typ.NumField(); i++ {
 				field := typ.Field(i)
 				if ast.IsExported(field.Name) {
-					v := o.self.getStr(field.Name)
+					var v Value
+					if field.Anonymous {
+						v = o
+					} else {
+						v = o.self.getStr(field.Name)
+					}
+
 					if v != nil {
 						vv, err := r.toReflectValue(v, field.Type)
 						if err != nil {
-							return reflect.Value{}, fmt.Errorf("Could not convert struct value %v to %v for field %s", v, field.Type, field.Name)
+							return reflect.Value{}, fmt.Errorf("Could not convert struct value %v to %v for field %s: %s", v, field.Type, field.Name, err)
 
 						}
 						s.Field(i).Set(vv)
@@ -1317,6 +1349,17 @@ func (r *Runtime) toReflectValue(v Value, typ reflect.Type) (reflect.Value, erro
 		if fn, ok := AssertFunction(v); ok {
 			return reflect.MakeFunc(typ, r.wrapJSFunc(fn, typ)), nil
 		}
+	case reflect.Ptr:
+		elemTyp := typ.Elem()
+		v, err := r.toReflectValue(v, elemTyp)
+		if err != nil {
+			return reflect.Value{}, err
+		}
+
+		ptrVal := reflect.New(v.Type())
+		ptrVal.Elem().Set(v)
+
+		return ptrVal, nil
 	}
 
 	return reflect.Value{}, fmt.Errorf("Could not convert %v to %v", v, typ)
@@ -1391,6 +1434,12 @@ func (r *Runtime) SetRandSource(source RandSource) {
 	r.rand = source
 }
 
+// SetTimeSource sets the current time source for this Runtime.
+// If not called, the default time.Now() is used.
+func (r *Runtime) SetTimeSource(now Now) {
+	r.now = now
+}
+
 // Callable represents a JavaScript function that can be called from Go.
 type Callable func(this Value, args ...Value) (Value, error)
 
@@ -1436,6 +1485,17 @@ func IsNull(v Value) bool {
 	return v == _null
 }
 
+// IsNaN returns true if the supplied value is NaN.
+func IsNaN(v Value) bool {
+	f, ok := v.assertFloat()
+	return ok && math.IsNaN(f)
+}
+
+// IsInfinity returns true if the supplied is (+/-)Infinity
+func IsInfinity(v Value) bool {
+	return v == _positiveInf || v == _negativeInf
+}
+
 // Undefined returns JS undefined value. Note if global 'undefined' property is changed this still returns the original value.
 func Undefined() Value {
 	return _undefined
@@ -1444,6 +1504,21 @@ func Undefined() Value {
 // Null returns JS null value.
 func Null() Value {
 	return _null
+}
+
+// NaN returns a JS NaN value.
+func NaN() Value {
+	return _NaN
+}
+
+// PositiveInf returns a JS +Inf value.
+func PositiveInf() Value {
+	return _positiveInf
+}
+
+// NegativeInf returns a JS -Inf value.
+func NegativeInf() Value {
+	return _negativeInf
 }
 
 func tryFunc(f func()) (err error) {

--- a/vendor/github.com/dop251/goja/srcfile.go
+++ b/vendor/github.com/dop251/goja/srcfile.go
@@ -5,6 +5,7 @@ import (
 	"github.com/go-sourcemap/sourcemap"
 	"sort"
 	"strings"
+	"sync"
 )
 
 type Position struct {
@@ -16,6 +17,7 @@ type SrcFile struct {
 	src  string
 
 	lineOffsets       []int
+	lineOffsetsLock   sync.Mutex
 	lastScannedOffset int
 	sourceMap         *sourcemap.Consumer
 }
@@ -30,15 +32,21 @@ func NewSrcFile(name, src string, sourceMap *sourcemap.Consumer) *SrcFile {
 
 func (f *SrcFile) Position(offset int) Position {
 	var line int
+	var lineOffsets []int
+	f.lineOffsetsLock.Lock()
 	if offset > f.lastScannedOffset {
 		line = f.scanTo(offset)
+		lineOffsets = f.lineOffsets
+		f.lineOffsetsLock.Unlock()
 	} else {
-		line = sort.Search(len(f.lineOffsets), func(x int) bool { return f.lineOffsets[x] > offset }) - 1
+		lineOffsets = f.lineOffsets
+		f.lineOffsetsLock.Unlock()
+		line = sort.Search(len(lineOffsets), func(x int) bool { return lineOffsets[x] > offset }) - 1
 	}
 
 	var lineStart int
 	if line >= 0 {
-		lineStart = f.lineOffsets[line]
+		lineStart = lineOffsets[line]
 	}
 
 	row := line + 2

--- a/vendor/github.com/dop251/goja/token/token.go
+++ b/vendor/github.com/dop251/goja/token/token.go
@@ -15,7 +15,7 @@ type Token int
 // name (e.g. for the token IDENTIFIER, the string is "IDENTIFIER").
 //
 func (tkn Token) String() string {
-	if 0 == tkn {
+	if tkn == 0 {
 		return "UNKNOWN"
 	}
 	if tkn < Token(len(token2string)) {

--- a/vendor/github.com/dop251/goja/value.go
+++ b/vendor/github.com/dop251/goja/value.go
@@ -765,6 +765,11 @@ func (o *Object) MarshalJSON() ([]byte, error) {
 	return ctx.buf.Bytes(), nil
 }
 
+// ClassName returns the class name
+func (o *Object) ClassName() string {
+	return o.self.className()
+}
+
 func (o valueUnresolved) throw() {
 	o.r.throwReferenceError(o.ref)
 }


### PR DESCRIPTION
This removes unnecessary goroutine spawning, synchronization, type conversion, etc. I had to update goja because of https://github.com/dop251/goja/issues/84, since I needed to refactor this:https://github.com/loadimpact/k6/blob/a2e1c6f4e6207d69461a1b0f24c3aa2c72233101/js/modules/k6/http/response.go#L36-L38

I also reduced the default `batchPerHost` value from 20 to 6, so k6 would be more in-line with browsers. Also, thanks to @MStoykov and https://github.com/loadimpact/k6/pull/1264, the default value of `batchPerHost` now actually works.

Closes https://github.com/loadimpact/k6/issues/767 and https://github.com/loadimpact/k6/issues/967 (because of the goja update)