### PR TITLE
Fix wrong context is used to decide pushing metrics or not.

### DIFF
--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -275,13 +275,14 @@ func TestRequestAndBatch(t *testing.T) {
 				})
 			`))
 			endTime := time.Now()
-			assert.EqualError(t, err, sr("GoError: Get HTTPBIN_URL/delay/10: net/http: request canceled (Client.Timeout exceeded while awaiting headers)"))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "Client.Timeout exceeded while awaiting headers")
 			assert.WithinDuration(t, startTime.Add(1*time.Second), endTime, 2*time.Second)
 
 			logEntry := hook.LastEntry()
 			if assert.NotNil(t, logEntry) {
 				assert.Equal(t, logrus.WarnLevel, logEntry.Level)
-				assert.EqualError(t, logEntry.Data["error"].(error), sr("Get HTTPBIN_URL/delay/10: net/http: request canceled (Client.Timeout exceeded while awaiting headers)"))
+				assert.Contains(t, logEntry.Data["error"].(error).Error(), "Client.Timeout exceeded while awaiting headers")
 				assert.Equal(t, "Request Failed", logEntry.Message)
 			}
 		})
@@ -412,7 +413,8 @@ func TestRequestAndBatch(t *testing.T) {
 	t.Run("TLS", func(t *testing.T) {
 		t.Run("cert_expired", func(t *testing.T) {
 			_, err := common.RunString(rt, `http.get("https://expired.badssl.com/");`)
-			assert.EqualError(t, err, "GoError: Get https://expired.badssl.com/: x509: certificate has expired or is not yet valid")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "x509: certificate has expired or is not yet valid")
 		})
 		tlsVersionTests := []struct {
 			Name, URL, Version string
@@ -461,12 +463,13 @@ func TestRequestAndBatch(t *testing.T) {
 		defer hook.Reset()
 
 		_, err := common.RunString(rt, `http.request("", "");`)
-		assert.EqualError(t, err, "GoError: Get : unsupported protocol scheme \"\"")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported protocol scheme")
 
 		logEntry := hook.LastEntry()
 		if assert.NotNil(t, logEntry) {
 			assert.Equal(t, logrus.WarnLevel, logEntry.Level)
-			assert.Equal(t, "Get : unsupported protocol scheme \"\"", logEntry.Data["error"].(error).Error())
+			assert.Contains(t, logEntry.Data["error"].(error).Error(), "unsupported protocol scheme")
 			assert.Equal(t, "Request Failed", logEntry.Message)
 		}
 
@@ -478,12 +481,13 @@ func TestRequestAndBatch(t *testing.T) {
 				let res = http.request("", "", { throw: false });
 				throw new Error(res.error);
 			`)
-			assert.EqualError(t, err, "GoError: Get : unsupported protocol scheme \"\"")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unsupported protocol scheme")
 
 			logEntry := hook.LastEntry()
 			if assert.NotNil(t, logEntry) {
 				assert.Equal(t, logrus.WarnLevel, logEntry.Level)
-				assert.EqualError(t, logEntry.Data["error"].(error), "Get : unsupported protocol scheme \"\"")
+				assert.Contains(t, logEntry.Data["error"].(error).Error(), "unsupported protocol scheme")
 				assert.Equal(t, "Request Failed", logEntry.Message)
 			}
 		})

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -276,13 +276,13 @@ func TestRequestAndBatch(t *testing.T) {
 			`))
 			endTime := time.Now()
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "Client.Timeout exceeded while awaiting headers")
+			assert.Contains(t, err.Error(), "context deadline exceeded")
 			assert.WithinDuration(t, startTime.Add(1*time.Second), endTime, 2*time.Second)
 
 			logEntry := hook.LastEntry()
 			if assert.NotNil(t, logEntry) {
 				assert.Equal(t, logrus.WarnLevel, logEntry.Level)
-				assert.Contains(t, logEntry.Data["error"].(error).Error(), "Client.Timeout exceeded while awaiting headers")
+				assert.Contains(t, logEntry.Data["error"].(error).Error(), "context deadline exceeded")
 				assert.Equal(t, "Request Failed", logEntry.Message)
 			}
 		})

--- a/js/modules/k6/k6.go
+++ b/js/modules/k6/k6.go
@@ -101,7 +101,7 @@ func (*K6) Group(ctx context.Context, name string, fn goja.Callable) (goja.Value
 		tags["iter"] = strconv.FormatInt(state.Iteration, 10)
 	}
 
-	stats.PushIfNotCancelled(ctx, state.Samples, stats.Sample{
+	stats.PushIfNotDone(ctx, state.Samples, stats.Sample{
 		Time:   t,
 		Metric: metrics.GroupDuration,
 		Tags:   stats.IntoSampleTags(&tags),
@@ -176,10 +176,10 @@ func (*K6) Check(ctx context.Context, arg0, checks goja.Value, extras ...goja.Va
 		default:
 			if val.ToBoolean() {
 				atomic.AddInt64(&check.Passes, 1)
-				stats.PushIfNotCancelled(ctx, state.Samples, stats.Sample{Time: t, Metric: metrics.Checks, Tags: sampleTags, Value: 1})
+				stats.PushIfNotDone(ctx, state.Samples, stats.Sample{Time: t, Metric: metrics.Checks, Tags: sampleTags, Value: 1})
 			} else {
 				atomic.AddInt64(&check.Fails, 1)
-				stats.PushIfNotCancelled(ctx, state.Samples, stats.Sample{Time: t, Metric: metrics.Checks, Tags: sampleTags, Value: 0})
+				stats.PushIfNotDone(ctx, state.Samples, stats.Sample{Time: t, Metric: metrics.Checks, Tags: sampleTags, Value: 0})
 				// A single failure makes the return value false.
 				succ = false
 			}

--- a/js/modules/k6/metrics/metrics.go
+++ b/js/modules/k6/metrics/metrics.go
@@ -89,7 +89,8 @@ func (m Metric) Add(ctx context.Context, v goja.Value, addTags ...map[string]str
 		vfloat = 1.0
 	}
 
-	stats.PushIfNotCancelled(ctx, state.Samples, stats.Sample{Time: time.Now(), Metric: m.metric, Value: vfloat, Tags: stats.IntoSampleTags(&tags)})
+	sample := stats.Sample{Time: time.Now(), Metric: m.metric, Value: vfloat, Tags: stats.IntoSampleTags(&tags)}
+	stats.PushIfNotDone(ctx, state.Samples, sample)
 	return true, nil
 }
 

--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -289,7 +289,7 @@ func (*WS) Connect(ctx context.Context, url string, args ...goja.Value) (*WSHTTP
 
 			sampleTags := stats.IntoSampleTags(&tags)
 
-			stats.PushIfNotCancelled(ctx, state.Samples, stats.ConnectedSamples{
+			stats.PushIfNotDone(ctx, state.Samples, stats.ConnectedSamples{
 				Samples: []stats.Sample{
 					{Metric: metrics.WSSessions, Time: start, Tags: sampleTags, Value: 1},
 					{Metric: metrics.WSConnecting, Time: start, Tags: sampleTags, Value: connectionDuration},
@@ -300,7 +300,7 @@ func (*WS) Connect(ctx context.Context, url string, args ...goja.Value) (*WSHTTP
 			})
 
 			for _, msgSentTimestamp := range socket.msgSentTimestamps {
-				stats.PushIfNotCancelled(ctx, state.Samples, stats.Sample{
+				stats.PushIfNotDone(ctx, state.Samples, stats.Sample{
 					Metric: metrics.WSMessagesSent,
 					Time:   msgSentTimestamp,
 					Tags:   sampleTags,
@@ -309,7 +309,7 @@ func (*WS) Connect(ctx context.Context, url string, args ...goja.Value) (*WSHTTP
 			}
 
 			for _, msgReceivedTimestamp := range socket.msgReceivedTimestamps {
-				stats.PushIfNotCancelled(ctx, state.Samples, stats.Sample{
+				stats.PushIfNotDone(ctx, state.Samples, stats.Sample{
 					Metric: metrics.WSMessagesReceived,
 					Time:   msgReceivedTimestamp,
 					Tags:   sampleTags,
@@ -318,7 +318,7 @@ func (*WS) Connect(ctx context.Context, url string, args ...goja.Value) (*WSHTTP
 			}
 
 			for _, pingDelta := range socket.pingTimestamps {
-				stats.PushIfNotCancelled(ctx, state.Samples, stats.Sample{
+				stats.PushIfNotDone(ctx, state.Samples, stats.Sample{
 					Metric: metrics.WSPing,
 					Time:   pingDelta.pong,
 					Tags:   sampleTags,

--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -264,7 +264,7 @@ func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error
 		}
 	}
 
-	tracerTransport := newTransport(state, tags)
+	tracerTransport := newTransport(ctx, state, tags)
 	var transport http.RoundTripper = tracerTransport
 
 	if state.Options.HTTPDebug.String != "" {

--- a/lib/netext/httpext/request_test.go
+++ b/lib/netext/httpext/request_test.go
@@ -98,13 +98,21 @@ func TestMakeRequestError(t *testing.T) {
 		defer srv.Close()
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+		logger := logrus.New()
+		logger.Level = logrus.DebugLevel
 		state := &lib.State{
 			Options:   lib.Options{RunTags: &stats.SampleTags{}},
 			Transport: srv.Client().Transport,
+			Logger:    logger,
 		}
 		ctx = lib.WithState(ctx, state)
 		req, _ := http.NewRequest("GET", srv.URL, nil)
-		var preq = &ParsedHTTPRequest{Req: req, URL: &URL{u: req.URL}, Body: new(bytes.Buffer)}
+		var preq = &ParsedHTTPRequest{
+			Req:     req,
+			URL:     &URL{u: req.URL},
+			Body:    new(bytes.Buffer),
+			Timeout: 10 * time.Second,
+		}
 
 		res, err := MakeRequest(ctx, preq)
 

--- a/lib/netext/httpext/request_test.go
+++ b/lib/netext/httpext/request_test.go
@@ -9,10 +9,12 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/stats"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -137,6 +139,37 @@ func TestURL(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestMakeRequestTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+	}))
+	defer srv.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	samples := make(chan stats.SampleContainer, 10)
+	logger := logrus.New()
+	logger.Level = logrus.DebugLevel
+	state := &lib.State{
+		Options:   lib.Options{RunTags: &stats.SampleTags{}},
+		Transport: srv.Client().Transport,
+		Samples:   samples,
+		Logger:    logger,
+	}
+	ctx = lib.WithState(ctx, state)
+	req, _ := http.NewRequest("GET", srv.URL, nil)
+	var preq = &ParsedHTTPRequest{
+		Req:     req,
+		URL:     &URL{u: req.URL},
+		Body:    new(bytes.Buffer),
+		Timeout: 10 * time.Millisecond,
+	}
+
+	res, err := MakeRequest(ctx, preq)
+	require.NoError(t, err)
+	assert.NotNil(t, res)
+	assert.Len(t, samples, 1)
 }
 
 func BenchmarkWrapDecompressionError(b *testing.B) {

--- a/lib/netext/httpext/transport.go
+++ b/lib/netext/httpext/transport.go
@@ -147,7 +147,7 @@ func (t *transport) measureAndEmitMetrics(unfReq *unfinishedRequest) *finishedRe
 	}
 
 	trail.SaveSamples(stats.IntoSampleTags(&tags))
-	stats.PushIfNotCancelled(unfReq.ctx, t.state.Samples, trail)
+	stats.PushIfNotDone(unfReq.ctx, t.state.Samples, trail)
 
 	return result
 }

--- a/lib/netext/httpext/transport.go
+++ b/lib/netext/httpext/transport.go
@@ -33,9 +33,10 @@ import (
 	"github.com/loadimpact/k6/stats"
 )
 
-// transport is an implemenation of http.RoundTripper that will measure and emit
+// transport is an implementation of http.RoundTripper that will measure and emit
 // different metrics for each roundtrip
 type transport struct {
+	ctx   context.Context
 	state *lib.State
 	tags  map[string]string
 
@@ -72,10 +73,12 @@ var _ http.RoundTripper = &transport{}
 // requests made through it and annotates and emits the recorded metric samples
 // through the state.Samples channel.
 func newTransport(
+	ctx context.Context,
 	state *lib.State,
 	tags map[string]string,
 ) *transport {
 	return &transport{
+		ctx:             ctx,
 		state:           state,
 		tags:            tags,
 		lastRequestLock: new(sync.Mutex),
@@ -147,7 +150,7 @@ func (t *transport) measureAndEmitMetrics(unfReq *unfinishedRequest) *finishedRe
 	}
 
 	trail.SaveSamples(stats.IntoSampleTags(&tags))
-	stats.PushIfNotDone(unfReq.ctx, t.state.Samples, trail)
+	stats.PushIfNotDone(t.ctx, t.state.Samples, trail)
 
 	return result
 }

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -387,13 +387,11 @@ func GetBufferedSamples(input <-chan SampleContainer) (result []SampleContainer)
 	}
 }
 
-// PushIfNotCancelled first checks if the supplied context is cancelled and doesn't push
+// PushIfNotDone first checks if the supplied context is done and doesn't push
 // the sample container if it is.
-func PushIfNotCancelled(ctx context.Context, output chan<- SampleContainer, sample SampleContainer) bool {
-	select {
-	case <-ctx.Done():
+func PushIfNotDone(ctx context.Context, output chan<- SampleContainer, sample SampleContainer) bool {
+	if ctx.Err() != nil {
 		return false
-	default: // Do nothing
 	}
 	output <- sample
 	return true

--- a/stats/thresholds.go
+++ b/stats/thresholds.go
@@ -25,8 +25,9 @@ import (
 	"time"
 
 	"github.com/dop251/goja"
-	"github.com/loadimpact/k6/lib/types"
 	"github.com/pkg/errors"
+
+	"github.com/loadimpact/k6/lib/types"
 )
 
 const jsEnvSrc = `


### PR DESCRIPTION
Go 1.13 and below has a bug that client timeout will not be propagated
to http request context. That bug was fixed already and will be present
in go1.14 (golang/go#31657).

With current go master, our TestSetupTeardownThresholds fails. The
reason is that we only push sample if the request context not done. When
the bug in Go stdlib was not fixed, our own http Client.Timeout is not
passed to request context, so when client makes request, it does not
aware about the request context, and always push the sample.

Now when Client.Timeout is passed to request context, as long as the
client finish the request, the request context is consider done, and we
do not push the sample anymore.

Further more, we are using the wrong context for PushIfNotCancelled.
It's intended to use with VU context instead of the request context.

In summary, to fix it:

 - We explicitly pass the timeout to request context, instead of setting in Client.Timeout.
 - Use VU context instead of request context for whether pushing metrics or not.

Fixed #1260