### PR TITLE
Additional unit tests for #1007

### DIFF
--- a/lib/executor/common_test.go
+++ b/lib/executor/common_test.go
@@ -1,3 +1,23 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2019 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 package executor
 
 import (

--- a/lib/executor/constant_arrival_rate_test.go
+++ b/lib/executor/constant_arrival_rate_test.go
@@ -1,3 +1,23 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2019 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 package executor
 
 import (

--- a/lib/executor/constant_looping_vus_test.go
+++ b/lib/executor/constant_looping_vus_test.go
@@ -1,0 +1,70 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2019 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package executor
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	null "gopkg.in/guregu/null.v3"
+
+	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/types"
+)
+
+func getTestConstantLoopingVUsConfig() ConstantLoopingVUsConfig {
+	return ConstantLoopingVUsConfig{
+		VUs:      null.IntFrom(10),
+		Duration: types.NullDurationFrom(1 * time.Second),
+	}
+}
+
+func TestConstantLoopingVUsRun(t *testing.T) {
+	t.Parallel()
+	var result sync.Map
+	es := lib.NewExecutionState(lib.Options{}, 10, 50)
+	var ctx, cancel, executor, _ = setupExecutor(
+		t, getTestConstantLoopingVUsConfig(), es,
+		simpleRunner(func(ctx context.Context) error {
+			time.Sleep(200 * time.Millisecond)
+			state := lib.GetState(ctx)
+			currIter, _ := result.LoadOrStore(state.Vu, uint64(0))
+			result.Store(state.Vu, currIter.(uint64)+1)
+			return nil
+		}),
+	)
+	defer cancel()
+	err := executor.Run(ctx, nil)
+	require.NoError(t, err)
+
+	var totalIters uint64
+	result.Range(func(key, value interface{}) bool {
+		vuIters := value.(uint64)
+		assert.Equal(t, uint64(5), vuIters)
+		totalIters += vuIters
+		return true
+	})
+	assert.Equal(t, uint64(50), totalIters)
+}

--- a/lib/executor/externally_controlled.go
+++ b/lib/executor/externally_controlled.go
@@ -230,11 +230,15 @@ func (mex *ExternallyControlled) GetConfig() lib.ExecutorConfig {
 
 // GetProgress just returns the executor's progress bar instance.
 func (mex ExternallyControlled) GetProgress() *pb.ProgressBar {
+	mex.configLock.RLock()
+	defer mex.configLock.RUnlock()
 	return mex.progress
 }
 
 // GetLogger just returns the executor's logger instance.
 func (mex ExternallyControlled) GetLogger() *logrus.Entry {
+	mex.configLock.RLock()
+	defer mex.configLock.RUnlock()
 	return mex.logger
 }
 

--- a/lib/executor/externally_controlled_test.go
+++ b/lib/executor/externally_controlled_test.go
@@ -1,0 +1,110 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2019 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package executor
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	null "gopkg.in/guregu/null.v3"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/types"
+)
+
+func getTestExternallyControlledConfig() ExternallyControlledConfig {
+	return ExternallyControlledConfig{
+		ExternallyControlledConfigParams: ExternallyControlledConfigParams{
+			VUs:      null.IntFrom(2),
+			MaxVUs:   null.IntFrom(10),
+			Duration: types.NullDurationFrom(2 * time.Second),
+		},
+	}
+}
+
+func TestExternallyControlledRun(t *testing.T) {
+	t.Parallel()
+	var doneIters uint64
+	es := lib.NewExecutionState(lib.Options{}, 10, 50)
+	var ctx, cancel, executor, _ = setupExecutor(
+		t, getTestExternallyControlledConfig(), es,
+		simpleRunner(func(ctx context.Context) error {
+			time.Sleep(200 * time.Millisecond)
+			atomic.AddUint64(&doneIters, 1)
+			return nil
+		}),
+	)
+	defer cancel()
+
+	var (
+		wg            sync.WaitGroup
+		errCh         = make(chan error, 1)
+		doneCh        = make(chan struct{})
+		resultVUCount []int64
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		errCh <- executor.Run(ctx, nil)
+		close(doneCh)
+	}()
+
+	updateConfig := func(vus int) {
+		newConfig := ExternallyControlledConfigParams{
+			VUs:      null.IntFrom(int64(vus)),
+			MaxVUs:   null.IntFrom(10),
+			Duration: types.NullDurationFrom(2 * time.Second),
+		}
+		err := executor.(*ExternallyControlled).UpdateConfig(ctx, newConfig)
+		assert.NoError(t, err)
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		es.MarkStarted()
+		time.Sleep(150 * time.Millisecond) // wait for startup
+		resultVUCount = append(resultVUCount, es.GetCurrentlyActiveVUsCount())
+		time.Sleep(500 * time.Millisecond)
+		updateConfig(4)
+		time.Sleep(100 * time.Millisecond)
+		resultVUCount = append(resultVUCount, es.GetCurrentlyActiveVUsCount())
+		time.Sleep(500 * time.Millisecond)
+		updateConfig(8)
+		time.Sleep(100 * time.Millisecond)
+		resultVUCount = append(resultVUCount, es.GetCurrentlyActiveVUsCount())
+		time.Sleep(1 * time.Second)
+		resultVUCount = append(resultVUCount, es.GetCurrentlyActiveVUsCount())
+		es.MarkEnded()
+	}()
+
+	<-doneCh
+	wg.Wait()
+	require.NoError(t, <-errCh)
+	assert.Equal(t, uint64(50), doneIters)
+	assert.Equal(t, []int64{2, 4, 8, 0}, resultVUCount)
+}

--- a/lib/executor/per_vu_iterations_test.go
+++ b/lib/executor/per_vu_iterations_test.go
@@ -1,3 +1,23 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2019 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 package executor
 
 import (

--- a/lib/executor/per_vu_iterations_test.go
+++ b/lib/executor/per_vu_iterations_test.go
@@ -23,6 +23,7 @@ package executor
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -38,11 +39,12 @@ func getTestPerVUIterationsConfig() PerVUIterationsConfig {
 	return PerVUIterationsConfig{
 		VUs:         null.IntFrom(10),
 		Iterations:  null.IntFrom(100),
-		MaxDuration: types.NullDurationFrom(5 * time.Second),
+		MaxDuration: types.NullDurationFrom(3 * time.Second),
 	}
 }
 
-func TestPerVUIterations(t *testing.T) {
+// Baseline test
+func TestPerVUIterationsRun(t *testing.T) {
 	t.Parallel()
 	var result sync.Map
 	es := lib.NewExecutionState(lib.Options{}, 10, 50)
@@ -67,4 +69,53 @@ func TestPerVUIterations(t *testing.T) {
 		return true
 	})
 	assert.Equal(t, uint64(1000), totalIters)
+}
+
+// Test that when one VU "slows down", others will *not* pick up the workload.
+// This is the reverse behavior of the SharedIterations executor.
+func TestPerVUIterationsRunVariableVU(t *testing.T) {
+	t.Parallel()
+	var (
+		result   sync.Map
+		slowVUID int64
+	)
+	es := lib.NewExecutionState(lib.Options{}, 10, 50)
+	var ctx, cancel, executor, _ = setupExecutor(
+		t, getTestPerVUIterationsConfig(), es,
+		simpleRunner(func(ctx context.Context) error {
+			state := lib.GetState(ctx)
+			// Pick one VU randomly and always slow it down.
+			sid := atomic.LoadInt64(&slowVUID)
+			if sid == int64(0) {
+				atomic.StoreInt64(&slowVUID, state.Vu)
+			}
+			if sid == state.Vu {
+				time.Sleep(200 * time.Millisecond)
+			}
+			currIter, _ := result.LoadOrStore(state.Vu, uint64(0))
+			result.Store(state.Vu, currIter.(uint64)+1)
+			return nil
+		}),
+	)
+	defer cancel()
+	err := executor.Run(ctx, nil)
+	require.NoError(t, err)
+
+	val, ok := result.Load(slowVUID)
+	assert.True(t, ok)
+
+	var totalIters uint64
+	result.Range(func(key, value interface{}) bool {
+		vuIters := value.(uint64)
+		if key != slowVUID {
+			assert.Equal(t, uint64(100), vuIters)
+		}
+		totalIters += vuIters
+		return true
+	})
+
+	// The slow VU should complete 16 iterations given these timings,
+	// while the rest should equally complete their assigned 100 iterations.
+	assert.Equal(t, uint64(16), val)
+	assert.Equal(t, uint64(916), totalIters)
 }

--- a/lib/executor/per_vu_iterations_test.go
+++ b/lib/executor/per_vu_iterations_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/loadimpact/k6/lib"
-	"github.com/loadimpact/k6/lib/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	null "gopkg.in/guregu/null.v3"
+
+	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/types"
 )
 
 func getTestPerVUIterationsConfig() PerVUIterationsConfig {
@@ -24,8 +25,9 @@ func getTestPerVUIterationsConfig() PerVUIterationsConfig {
 func TestPerVUIterations(t *testing.T) {
 	t.Parallel()
 	var result sync.Map
+	es := lib.NewExecutionState(lib.Options{}, 10, 50)
 	var ctx, cancel, executor, _ = setupExecutor(
-		t, getTestPerVUIterationsConfig(),
+		t, getTestPerVUIterationsConfig(), es,
 		simpleRunner(func(ctx context.Context) error {
 			state := lib.GetState(ctx)
 			currIter, _ := result.LoadOrStore(state.Vu, uint64(0))

--- a/lib/executor/shared_iterations_test.go
+++ b/lib/executor/shared_iterations_test.go
@@ -1,3 +1,23 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2019 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 package executor
 
 import (

--- a/lib/executor/shared_iterations_test.go
+++ b/lib/executor/shared_iterations_test.go
@@ -1,0 +1,38 @@
+package executor
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	null "gopkg.in/guregu/null.v3"
+
+	"github.com/loadimpact/k6/lib/types"
+)
+
+func getTestSharedIterationsConfig() SharedIterationsConfig {
+	return SharedIterationsConfig{
+		VUs:         null.IntFrom(10),
+		Iterations:  null.IntFrom(100),
+		MaxDuration: types.NullDurationFrom(5 * time.Second),
+	}
+}
+
+func TestSharedIterationsRun(t *testing.T) {
+	t.Parallel()
+	var doneIters uint64
+	var ctx, cancel, executor, _ = setupExecutor(
+		t, getTestSharedIterationsConfig(),
+		simpleRunner(func(ctx context.Context) error {
+			atomic.AddUint64(&doneIters, 1)
+			return nil
+		}),
+	)
+	defer cancel()
+	err := executor.Run(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), doneIters)
+}

--- a/lib/executor/shared_iterations_test.go
+++ b/lib/executor/shared_iterations_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	null "gopkg.in/guregu/null.v3"
 
+	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/lib/types"
 )
 
@@ -24,8 +25,9 @@ func getTestSharedIterationsConfig() SharedIterationsConfig {
 func TestSharedIterationsRun(t *testing.T) {
 	t.Parallel()
 	var doneIters uint64
+	es := lib.NewExecutionState(lib.Options{}, 10, 50)
 	var ctx, cancel, executor, _ = setupExecutor(
-		t, getTestSharedIterationsConfig(),
+		t, getTestSharedIterationsConfig(), es,
 		simpleRunner(func(ctx context.Context) error {
 			atomic.AddUint64(&doneIters, 1)
 			return nil

--- a/lib/executor/variable_arrival_rate_test.go
+++ b/lib/executor/variable_arrival_rate_test.go
@@ -1,3 +1,23 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2019 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 package executor
 
 import (

--- a/lib/executor/variable_arrival_rate_test.go
+++ b/lib/executor/variable_arrival_rate_test.go
@@ -8,12 +8,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/loadimpact/k6/lib"
-	"github.com/loadimpact/k6/lib/types"
-	"github.com/loadimpact/k6/stats"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	null "gopkg.in/guregu/null.v3"
+
+	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/types"
+	"github.com/loadimpact/k6/stats"
 )
 
 func TestGetPlannedRateChanges0DurationStage(t *testing.T) {
@@ -222,8 +223,9 @@ func getTestVariableArrivalRateConfig() VariableArrivalRateConfig {
 
 func TestVariableArrivalRateRunNotEnoughAllocatedVUsWarn(t *testing.T) {
 	t.Parallel()
+	es := lib.NewExecutionState(lib.Options{}, 10, 50)
 	var ctx, cancel, executor, logHook = setupExecutor(
-		t, getTestVariableArrivalRateConfig(),
+		t, getTestVariableArrivalRateConfig(), es,
 		simpleRunner(func(ctx context.Context) error {
 			time.Sleep(time.Second)
 			return nil
@@ -246,8 +248,9 @@ func TestVariableArrivalRateRunNotEnoughAllocatedVUsWarn(t *testing.T) {
 func TestVariableArrivalRateRunCorrectRate(t *testing.T) {
 	t.Parallel()
 	var count int64
+	es := lib.NewExecutionState(lib.Options{}, 10, 50)
 	var ctx, cancel, executor, logHook = setupExecutor(
-		t, getTestVariableArrivalRateConfig(),
+		t, getTestVariableArrivalRateConfig(), es,
 		simpleRunner(func(ctx context.Context) error {
 			atomic.AddInt64(&count, 1)
 			return nil

--- a/lib/executor/variable_looping_vus_test.go
+++ b/lib/executor/variable_looping_vus_test.go
@@ -1,3 +1,23 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2019 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 package executor
 
 import (

--- a/lib/executor/variable_looping_vus_test.go
+++ b/lib/executor/variable_looping_vus_test.go
@@ -1,0 +1,76 @@
+package executor
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	null "gopkg.in/guregu/null.v3"
+
+	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/types"
+)
+
+func getTestVariableLoopingVUsConfig() VariableLoopingVUsConfig {
+	return VariableLoopingVUsConfig{
+		BaseConfig: BaseConfig{GracefulStop: types.NullDurationFrom(0)},
+		StartVUs:   null.IntFrom(5),
+		Stages: []Stage{
+			{
+				Duration: types.NullDurationFrom(1 * time.Second),
+				Target:   null.IntFrom(5),
+			},
+			{
+				Duration: types.NullDurationFrom(0),
+				Target:   null.IntFrom(3),
+			},
+			{
+				Duration: types.NullDurationFrom(1 * time.Second),
+				Target:   null.IntFrom(3),
+			},
+		},
+		GracefulRampDown: types.NullDurationFrom(0),
+	}
+}
+
+func TestVariableLoopingVUsRun(t *testing.T) {
+	t.Parallel()
+	var iterCount int64
+	es := lib.NewExecutionState(lib.Options{}, 10, 50)
+	var ctx, cancel, executor, _ = setupExecutor(
+		t, getTestVariableLoopingVUsConfig(), es,
+		simpleRunner(func(ctx context.Context) error {
+			time.Sleep(200 * time.Millisecond)
+			atomic.AddInt64(&iterCount, 1)
+			return nil
+		}),
+	)
+	defer cancel()
+
+	var (
+		wg     sync.WaitGroup
+		result []int64
+	)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(100 * time.Millisecond)
+		result = append(result, es.GetCurrentlyActiveVUsCount())
+		time.Sleep(1 * time.Second)
+		result = append(result, es.GetCurrentlyActiveVUsCount())
+		time.Sleep(1 * time.Second)
+		result = append(result, es.GetCurrentlyActiveVUsCount())
+	}()
+
+	err := executor.Run(ctx, nil)
+
+	wg.Wait()
+	require.NoError(t, err)
+	assert.Equal(t, []int64{5, 3, 0}, result)
+	assert.Equal(t, int64(40), iterCount)
+}


### PR DESCRIPTION
This adds unit tests for ConstantLoopingVUs.Run, ExternallyControlled.Run, PerVUIterations.Run, SharedIterations.Run and VariableLoopingVUs.Run, while fixing a data race issue with the ExternallyControlled executor (see 36aedeff for details).

Weather warning: cloudy with a chance of flakiness for `TestExternallyControlledRun` and `TestVariableLoopingVUsRun`. I stress tested `lib/executor` using [this script](https://dave.cheney.net/2013/06/19/stress-test-your-go-packages) with `-race` enabled, and these two tests eventually fail after a few minutes. The failure rate is low in my tests (~5%), so they could still have value being merged as is.

I'm not sure how to further stabilize the tests (i.e. rely less on sleeps), so let me know if you have any suggestions.