### PR TITLE
Move MiniRunner to testutils and simplify executor test setup

### DIFF
--- a/api/server_test.go
+++ b/api/server_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/loadimpact/k6/core"
 	"github.com/loadimpact/k6/core/local"
 	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/testutils"
 )
 
 func testHTTPHandler(rw http.ResponseWriter, r *http.Request) {
@@ -76,7 +77,7 @@ func TestLogger(t *testing.T) {
 }
 
 func TestWithEngine(t *testing.T) {
-	execScheduler, err := local.NewExecutionScheduler(&lib.MiniRunner{}, logrus.StandardLogger())
+	execScheduler, err := local.NewExecutionScheduler(&testutils.MiniRunner{}, logrus.StandardLogger())
 	require.NoError(t, err)
 	engine, err := core.NewEngine(execScheduler, lib.Options{}, logrus.StandardLogger())
 	require.NoError(t, err)

--- a/api/v1/group_routes_test.go
+++ b/api/v1/group_routes_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/loadimpact/k6/core"
 	"github.com/loadimpact/k6/core/local"
 	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/testutils"
 	"github.com/manyminds/api2go/jsonapi"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -43,7 +44,7 @@ func TestGetGroups(t *testing.T) {
 	g2, err := g1.Group("group 2")
 	assert.NoError(t, err)
 
-	execScheduler, err := local.NewExecutionScheduler(&lib.MiniRunner{Group: g0}, logrus.StandardLogger())
+	execScheduler, err := local.NewExecutionScheduler(&testutils.MiniRunner{Group: g0}, logrus.StandardLogger())
 	require.NoError(t, err)
 	engine, err := core.NewEngine(execScheduler, lib.Options{}, logrus.StandardLogger())
 	require.NoError(t, err)

--- a/api/v1/metric_routes_test.go
+++ b/api/v1/metric_routes_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/loadimpact/k6/core"
 	"github.com/loadimpact/k6/core/local"
 	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/testutils"
 	"github.com/loadimpact/k6/stats"
 	"github.com/manyminds/api2go/jsonapi"
 	"github.com/stretchr/testify/assert"
@@ -40,7 +41,7 @@ import (
 )
 
 func TestGetMetrics(t *testing.T) {
-	execScheduler, err := local.NewExecutionScheduler(&lib.MiniRunner{}, logrus.StandardLogger())
+	execScheduler, err := local.NewExecutionScheduler(&testutils.MiniRunner{}, logrus.StandardLogger())
 	require.NoError(t, err)
 	engine, err := core.NewEngine(execScheduler, lib.Options{}, logrus.StandardLogger())
 	require.NoError(t, err)
@@ -81,7 +82,7 @@ func TestGetMetrics(t *testing.T) {
 }
 
 func TestGetMetric(t *testing.T) {
-	execScheduler, err := local.NewExecutionScheduler(&lib.MiniRunner{}, logrus.StandardLogger())
+	execScheduler, err := local.NewExecutionScheduler(&testutils.MiniRunner{}, logrus.StandardLogger())
 	require.NoError(t, err)
 	engine, err := core.NewEngine(execScheduler, lib.Options{}, logrus.StandardLogger())
 	require.NoError(t, err)

--- a/api/v1/status_routes_test.go
+++ b/api/v1/status_routes_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/loadimpact/k6/core"
 	"github.com/loadimpact/k6/core/local"
 	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/testutils"
 	"github.com/manyminds/api2go/jsonapi"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -36,7 +37,7 @@ import (
 )
 
 func TestGetStatus(t *testing.T) {
-	execScheduler, err := local.NewExecutionScheduler(&lib.MiniRunner{}, logrus.StandardLogger())
+	execScheduler, err := local.NewExecutionScheduler(&testutils.MiniRunner{}, logrus.StandardLogger())
 	require.NoError(t, err)
 	engine, err := core.NewEngine(execScheduler, lib.Options{}, logrus.StandardLogger())
 	require.NoError(t, err)

--- a/cmd/config_consolidation_test.go
+++ b/cmd/config_consolidation_test.go
@@ -452,7 +452,7 @@ func runTestCase(
 
 	var runner lib.Runner
 	if testCase.options.runner != nil {
-		runner = &lib.MiniRunner{Options: *testCase.options.runner}
+		runner = &testutils.MiniRunner{Options: *testCase.options.runner}
 	}
 	if testCase.options.fs == nil {
 		t.Logf("Creating an empty FS for this test")

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -51,7 +51,7 @@ const isWindows = runtime.GOOS == "windows"
 // Wrapper around NewEngine that applies a logger and manages the options.
 func newTestEngine(t *testing.T, ctx context.Context, runner lib.Runner, opts lib.Options) *Engine { //nolint: golint
 	if runner == nil {
-		runner = &lib.MiniRunner{}
+		runner = &testutils.MiniRunner{}
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -109,7 +109,7 @@ func TestEngineRun(t *testing.T) {
 
 		signalChan := make(chan interface{})
 
-		runner := &lib.MiniRunner{Fn: func(ctx context.Context, out chan<- stats.SampleContainer) error {
+		runner := &testutils.MiniRunner{Fn: func(ctx context.Context, out chan<- stats.SampleContainer) error {
 			stats.PushIfNotDone(ctx, out, stats.Sample{Metric: testMetric, Time: time.Now(), Value: 1})
 			close(signalChan)
 			<-ctx.Done()
@@ -158,7 +158,7 @@ func TestEngineAtTime(t *testing.T) {
 func TestEngineCollector(t *testing.T) {
 	testMetric := stats.New("test_metric", stats.Trend)
 
-	runner := &lib.MiniRunner{Fn: func(ctx context.Context, out chan<- stats.SampleContainer) error {
+	runner := &testutils.MiniRunner{Fn: func(ctx context.Context, out chan<- stats.SampleContainer) error {
 		out <- stats.Sample{Metric: testMetric}
 		return nil
 	}}

--- a/lib/executor/execution_test.go
+++ b/lib/executor/execution_test.go
@@ -18,7 +18,7 @@
  *
  */
 
-package lib
+package executor
 
 import (
 	"context"
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/lib/testutils"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -36,7 +37,7 @@ import (
 
 func TestExecutionStateVUIDs(t *testing.T) {
 	t.Parallel()
-	es := NewExecutionState(Options{}, 0, 0)
+	es := lib.NewExecutionState(lib.Options{}, 0, 0)
 	assert.Equal(t, uint64(1), es.GetUniqueVUIdentifier())
 	assert.Equal(t, uint64(2), es.GetUniqueVUIdentifier())
 	assert.Equal(t, uint64(3), es.GetUniqueVUIdentifier())
@@ -56,7 +57,7 @@ func TestExecutionStateVUIDs(t *testing.T) {
 
 func TestExecutionStateGettingVUsWhenNonAreAvailable(t *testing.T) {
 	t.Parallel()
-	es := NewExecutionState(Options{}, 0, 0)
+	es := lib.NewExecutionState(lib.Options{}, 0, 0)
 	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.WarnLevel}}
 	testLog := logrus.New()
 	testLog.AddHook(logHook)
@@ -66,7 +67,7 @@ func TestExecutionStateGettingVUsWhenNonAreAvailable(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "could not get a VU from the buffer in")
 	entries := logHook.Drain()
-	require.Equal(t, MaxRetriesGetPlannedVU, len(entries))
+	require.Equal(t, lib.MaxRetriesGetPlannedVU, len(entries))
 	for _, entry := range entries {
 		require.Contains(t, entry.Message, "Could not get a VU from the buffer for ")
 	}
@@ -80,9 +81,9 @@ func TestExecutionStateGettingVUs(t *testing.T) {
 	testLog.SetOutput(ioutil.Discard)
 	logEntry := logrus.NewEntry(testLog)
 
-	es := NewExecutionState(Options{}, 10, 20)
-	es.SetInitVUFunc(func(_ context.Context, _ *logrus.Entry) (VU, error) {
-		return &MiniRunnerVU{}, nil
+	es := lib.NewExecutionState(lib.Options{}, 10, 20)
+	es.SetInitVUFunc(func(_ context.Context, _ *logrus.Entry) (lib.VU, error) {
+		return &testutils.MiniRunnerVU{}, nil
 	})
 
 	for i := 0; i < 10; i++ {
@@ -112,7 +113,7 @@ func TestExecutionStateGettingVUs(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "could not get a VU from the buffer in")
 	entries := logHook.Drain()
-	require.Equal(t, MaxRetriesGetPlannedVU, len(entries))
+	require.Equal(t, lib.MaxRetriesGetPlannedVU, len(entries))
 	for _, entry := range entries {
 		require.Contains(t, entry.Message, "Could not get a VU from the buffer for ")
 	}
@@ -134,7 +135,7 @@ func TestExecutionStateGettingVUs(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "could not get a VU from the buffer in")
 	entries = logHook.Drain()
-	require.Equal(t, MaxRetriesGetPlannedVU, len(entries))
+	require.Equal(t, lib.MaxRetriesGetPlannedVU, len(entries))
 	for _, entry := range entries {
 		require.Contains(t, entry.Message, "Could not get a VU from the buffer for ")
 	}
@@ -142,7 +143,7 @@ func TestExecutionStateGettingVUs(t *testing.T) {
 
 func TestMarkStartedPanicsOnSecondRun(t *testing.T) {
 	t.Parallel()
-	es := NewExecutionState(Options{}, 0, 0)
+	es := lib.NewExecutionState(lib.Options{}, 0, 0)
 	require.False(t, es.HasStarted())
 	es.MarkStarted()
 	require.True(t, es.HasStarted())
@@ -151,7 +152,7 @@ func TestMarkStartedPanicsOnSecondRun(t *testing.T) {
 
 func TestMarkEnded(t *testing.T) {
 	t.Parallel()
-	es := NewExecutionState(Options{}, 0, 0)
+	es := lib.NewExecutionState(lib.Options{}, 0, 0)
 	require.False(t, es.HasEnded())
 	es.MarkEnded()
 	require.True(t, es.HasEnded())

--- a/lib/executor/per_vu_iterations_test.go
+++ b/lib/executor/per_vu_iterations_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/lib/types"
-	"github.com/loadimpact/k6/stats"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	null "gopkg.in/guregu/null.v3"
@@ -27,12 +26,12 @@ func TestPerVUIterations(t *testing.T) {
 	var result sync.Map
 	var ctx, cancel, executor, _ = setupExecutor(
 		t, getTestPerVUIterationsConfig(),
-		func(ctx context.Context, out chan<- stats.SampleContainer) error {
+		simpleRunner(func(ctx context.Context) error {
 			state := lib.GetState(ctx)
 			currIter, _ := result.LoadOrStore(state.Vu, uint64(0))
 			result.Store(state.Vu, currIter.(uint64)+1)
 			return nil
-		},
+		}),
 	)
 	defer cancel()
 	err := executor.Run(ctx, nil)

--- a/lib/executor/variable_arrival_rate_test.go
+++ b/lib/executor/variable_arrival_rate_test.go
@@ -224,10 +224,10 @@ func TestVariableArrivalRateRunNotEnoughAllocatedVUsWarn(t *testing.T) {
 	t.Parallel()
 	var ctx, cancel, executor, logHook = setupExecutor(
 		t, getTestVariableArrivalRateConfig(),
-		func(ctx context.Context, out chan<- stats.SampleContainer) error {
+		simpleRunner(func(ctx context.Context) error {
 			time.Sleep(time.Second)
 			return nil
-		},
+		}),
 	)
 	defer cancel()
 	var engineOut = make(chan stats.SampleContainer, 1000)
@@ -248,10 +248,10 @@ func TestVariableArrivalRateRunCorrectRate(t *testing.T) {
 	var count int64
 	var ctx, cancel, executor, logHook = setupExecutor(
 		t, getTestVariableArrivalRateConfig(),
-		func(ctx context.Context, out chan<- stats.SampleContainer) error {
+		simpleRunner(func(ctx context.Context) error {
 			atomic.AddInt64(&count, 1)
 			return nil
-		},
+		}),
 	)
 	defer cancel()
 	var wg sync.WaitGroup

--- a/lib/testutils/mini_runner.go
+++ b/lib/testutils/mini_runner.go
@@ -1,0 +1,137 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2019 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutils
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/stats"
+)
+
+// Ensure mock implementations conform to the interfaces.
+var _ lib.Runner = &MiniRunner{}
+var _ lib.VU = &MiniRunnerVU{}
+
+// MiniRunner partially implements the lib.Runner interface, but instead of
+// using a real JS runtime, it allows us to directly specify the options and
+// functions with Go code.
+type MiniRunner struct {
+	Fn         func(ctx context.Context, out chan<- stats.SampleContainer) error
+	SetupFn    func(ctx context.Context, out chan<- stats.SampleContainer) ([]byte, error)
+	TeardownFn func(ctx context.Context, out chan<- stats.SampleContainer) error
+
+	SetupData []byte
+
+	NextVUID int64
+	Group    *lib.Group
+	Options  lib.Options
+}
+
+// MakeArchive isn't implemented, it always returns nil and is just here to
+// satisfy the lib.Runner interface.
+func (r MiniRunner) MakeArchive() *lib.Archive {
+	return nil
+}
+
+// NewVU returns a new MiniRunnerVU with an incremental ID.
+func (r *MiniRunner) NewVU(out chan<- stats.SampleContainer) (lib.VU, error) {
+	nextVUNum := atomic.AddInt64(&r.NextVUID, 1)
+	return &MiniRunnerVU{R: r, Out: out, ID: nextVUNum - 1}, nil
+}
+
+// Setup calls the supplied mock setup() function, if present.
+func (r *MiniRunner) Setup(ctx context.Context, out chan<- stats.SampleContainer) (err error) {
+	if fn := r.SetupFn; fn != nil {
+		r.SetupData, err = fn(ctx, out)
+	}
+	return
+}
+
+// GetSetupData returns json representation of the setup data if setup() is
+// specified and was ran, nil otherwise.
+func (r MiniRunner) GetSetupData() []byte {
+	return r.SetupData
+}
+
+// SetSetupData saves the externally supplied setup data as JSON in the runner.
+func (r *MiniRunner) SetSetupData(data []byte) {
+	r.SetupData = data
+}
+
+// Teardown calls the supplied mock teardown() function, if present.
+func (r MiniRunner) Teardown(ctx context.Context, out chan<- stats.SampleContainer) error {
+	if fn := r.TeardownFn; fn != nil {
+		return fn(ctx, out)
+	}
+	return nil
+}
+
+// GetDefaultGroup returns the default group.
+func (r MiniRunner) GetDefaultGroup() *lib.Group {
+	if r.Group == nil {
+		r.Group = &lib.Group{}
+	}
+	return r.Group
+}
+
+// GetOptions returns the supplied options struct.
+func (r MiniRunner) GetOptions() lib.Options {
+	return r.Options
+}
+
+// SetOptions allows you to override the runner options.
+func (r *MiniRunner) SetOptions(opts lib.Options) error {
+	r.Options = opts
+	return nil
+}
+
+// MiniRunnerVU is a mock VU, spawned by a MiniRunner.
+type MiniRunnerVU struct {
+	R         *MiniRunner
+	Out       chan<- stats.SampleContainer
+	ID        int64
+	Iteration int64
+}
+
+// RunOnce runs the mock default function once, incrementing its iteration.
+func (vu MiniRunnerVU) RunOnce(ctx context.Context) error {
+	if vu.R.Fn == nil {
+		return nil
+	}
+
+	state := &lib.State{
+		Vu:        vu.ID,
+		Iteration: vu.Iteration,
+	}
+	newctx := lib.WithState(ctx, state)
+
+	vu.Iteration++
+
+	return vu.R.Fn(newctx, vu.Out)
+}
+
+// Reconfigure changes the VU ID.
+func (vu *MiniRunnerVU) Reconfigure(id int64) error {
+	vu.ID = id
+	return nil
+}


### PR DESCRIPTION
Since I was a bit late posting my review of https://github.com/loadimpact/k6/pull/1255, I decided to transform my unpublished comments into actual code... Beside moving the `MiniRunner`, it was also slightly improved to not use random VU IDs, so it matches the JS runner more closely.

