### PR TITLE
Fix issues with the linux package builds and the README

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,13 +123,13 @@ jobs:
             export PATH=$GOPATH/bin:$PATH
 
             go get github.com/Masterminds/glide
-            go get github.com/mh-cbon/go-bin-deb \
+            go get -d github.com/mh-cbon/go-bin-deb \
               && cd $GOPATH/src/github.com/mh-cbon/go-bin-deb \
               && glide install \
               && go install
 
-            go get github.com/mh-cbon/go-bin-rpm \
-              && cd $GOPATHsrc/github.com/mh-cbon/go-bin-rpm \
+            go get -d github.com/mh-cbon/go-bin-rpm \
+              && cd $GOPATH/src/github.com/mh-cbon/go-bin-rpm \
               && glide install \
               && go install
 
@@ -139,7 +139,7 @@ jobs:
             cd $GOPATH/src/github.com/loadimpact/k6
 
             echo "Building k6..."
-            CGO_ENABLED=0 GOARCH=$ARCH go build -a -trimpath -ldflags '-s -w' -o /tmp/k6
+            CGO_ENABLED=0 GOARCH=amd64 go build -a -trimpath -ldflags "-s -w -X github.com/loadimpact/k6/lib/consts.VersionDetails=$(date -u +"%FT%T%z")/$(git describe --always --long --dirty)" -o /tmp/k6
             echo "Done!"
 
             VERSION=${CIRCLE_TAG:1} ./packaging/gen-packages.sh

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ brew install k6
 
 ### Windows
 
-You can manually download and install the [official `.msi` installation package](https://dl.bintray.com/loadimpact/windows/k6-v0.25.1-amd64.msi) or, if you use the [chocolatey package manager](https://chocolatey.org/), follow [these instructions](https://bintray.com/repo/buildSettings?repoPath=%2Floadimpact%2Fchoco) to set up the k6 repository.
+You can manually download and install the [official `.msi` installation package](https://dl.bintray.com/loadimpact/windows/k6-latest-amd64.msi) or, if you use the [chocolatey package manager](https://chocolatey.org/), follow [these instructions](https://bintray.com/repo/buildSettings?repoPath=%2Floadimpact%2Fchoco) to set up the k6 repository.
 
 ### Linux
 

--- a/release notes/v0.26.0.md
+++ b/release notes/v0.26.0.md
@@ -102,14 +102,14 @@ We made several small improvements to the mechanism for executing multiple HTTP 
 * HTTP: Use Request's `GetBody` in order to be able to get the body multiple times for a single request as needed in 308 redirects of posts and if the server sends GOAWAY with no error. (#1093)
 * JS: Don't export internal go struct fields of script options.(#1151)
 * JS: Ignore `minIterationDuration` for `setup` and `teardown`. (#1175)
-* HTTP: Return error on any request that returns 101 status code as k6 currently doesn't support any protocol upgrade behaviour. (#1172)
+* HTTP: Return error on any request that returns 101 status code as k6 currently doesn't support any protocol upgrade behavior. (#1172)
 * HTTP: Correctly capture TCP reset by peer and broken pipe errors and give them the appropriate `error_code` metric tag values. (#1164)
 * Config: Don't interpret non-`K6_` prefixed environment variables as k6 configuration, most notably `DURATION` and `ITERATIONS`. (#1215)
 * JS/html: `Selection.map` was not wrapping the nodes it was outputting, which lead to wrongly using the internal `Goquery.Selection` instead of k6's `Selection`. Thanks to @MMartyn for reporting this! (#1198)
 * HTTP: When there are redirects, k6 will now correctly set the cookie for the current URL, instead of for the one the current response is redirecting to. Thanks @dimatock! (#1201)
 * Cloud: Add token to make calls to the cloud API idempotent. (#1208)
 * Cloud: Improve aggregation of HTTP metrics for requests to different URLs, but with the same explicitly set `name` tag. (#1220)
-* Cloud: Fix a bug where you weren't able to run a script, outputting to cloud, if it was using the shortcut urls for github/cdnjs. (#1237)
+* Cloud: Fix a bug where you weren't able to run a script, outputting to cloud, if it was using the shortcut URLs for github/cdnjs. (#1237)
 * Config: The previous default value for `batchPerHost` of `20` wasn't propagated properly and was instead `0`. (#1264)
 
 
@@ -124,9 +124,13 @@ We made several small improvements to the mechanism for executing multiple HTTP 
 * Update `envconfig` as it was very old and the newer versions had fixes and features we want. (#1214)
 * Metrics: Emit iterations as part of `netext.NetTrail`, instead of as a standalone one. Also cutting down on amount of bytes we sent to the cloud output. (#1203)
 * JS: goja has been updated to the latest `master` version (commit [`007eef3`](https://github.com/dop251/goja/commit/007eef3bc40fd33b3dbb80ec16da59e8b63b8572)) (#1259)
+* All official binary packages now are built with `-trimpath` and `CGO_ENABLED=0`. Previously the GitHub release assets were built with `CGO_ENABLED=0`, making them unsuitable for non-glibc systems (like Alpine Linux). (#1244, #1245)
+
 
 ## Breaking changes
 
-We had to make a few minor breaking changes in the course of improving `http.batch()` (#1259):
-- The default value for `batchPerHost` has been reduced from `0` (unlimited) to `6`, to more closely match browser behavior. The default value for the `batch` option remains unchanged at `20`.
-- Calling `http.batch(arg)`, where `arg` is an array, would now return an array. Previously, this would have returned an object with integer keys, as explained in [#767](https://github.com/loadimpact/k6/issues/767)... Now `http.batch()` will return an array when you pass it an array, and return an object when you pass an object.
+- The output of `k6 version` is different. It now contains not only the k6 version number, but also information about the git commit, build date, Go version and system architecture. For example, if previously the output of `k6 version` looked like `k6 v0.25.1`, now it is like this: `k6 v0.26.0 (2019-12-16T10:58:59+0000/v0.26.0-0-gaeec9a7f, go1.13.5, linux/amd64)`. (#1235)
+
+- We had to make a few minor breaking changes in the course of improving `http.batch()` (#1259):
+  - The default value for `batchPerHost` has been reduced from `0` (unlimited) to `6`, to more closely match browser behavior. The default value for the `batch` option remains unchanged at `20`.
+  - Calling `http.batch(arg)`, where `arg` is an array, would now return an array. Previously, this would have returned an object with integer keys, as explained in [#767](https://github.com/loadimpact/k6/issues/767)... Now `http.batch()` will return an array when you pass it an array, and return an object when you pass an object.


### PR DESCRIPTION
This is just a collection of short-term fixes:
- pin the latest .msi package in the README, instead of using a specific version
- use `go get -d` for the go-bin-deb and go-bin-rpm packages, to only download the source (without building them) before we use glide to get their precise dependencies
- inject the new full version information in the build process

As mentioned in https://github.com/loadimpact/k6/issues/1247#issuecomment-566029167, we should build and test the linux packages regularly, so we can fix them if something breaks...