### PR TITLE
Fix CSV output example in release notes

### DIFF
--- a/release notes/v0.26.0.md
+++ b/release notes/v0.26.0.md
@@ -26,7 +26,7 @@ This report can be enabled by the `--summary-export <file_path>` CLI flag or the
 
 ### New CSV output (#1067)
 
-There is an entirely new `csv` output that can be enabled by using the `--out csv` CLI flag. There are two things that can be configured: the output file with `K6_CSV_FILENAME` (by default it's `file.csv`), and the interval of pushing metrics to disk, which is configured with `K6_CSV_SAVE_INTERVAL` (1 second by default). Both of those can be configured by the CLI as well: `--out csv=somefile.csv` will output to `somefile.csv` and `--out file_name=somefile.csv,save_interval=2s` will output again to `somefile.csv`, but will flush the data every 2 seconds instead of every second.
+There is an entirely new `csv` output that can be enabled by using the `--out csv` CLI flag. There are two things that can be configured: the output file with `K6_CSV_FILENAME` (by default it's `file.csv`), and the interval of pushing metrics to disk, which is configured with `K6_CSV_SAVE_INTERVAL` (1 second by default). Both of those can be configured by the CLI as well: `--out csv=somefile.csv` will output to `somefile.csv` and `--out csv=file_name=somefile.csv,save_interval=2s` will output again to `somefile.csv`, but will flush the data every 2 seconds instead of every second.
 
 The first line of the output is the names of columns and looks like:
 ```


### PR DESCRIPTION
The `csv` keyword is required, otherwise k6 will error out with `ERRO[0003] unknown output type: file_name`.

IMO the way output parameters are specified is a bit confusing, as `=` is used both for delimiting the output type from its parameters, as well as delimiting parameter names from their values. It's even more confusing if `=` is used for the option itself, e.g. `--out=csv=file_name=somefile2.csv,save_interval=2s` (this is valid). There's surely a friendlier way to specify this. :)