### PR TITLE
Silent wrong interrupted error for interrupted iteration

### DIFF
--- a/js/runner.go
+++ b/js/runner.go
@@ -438,6 +438,13 @@ func (u *VU) RunOnce(ctx context.Context) error {
 		}
 	}
 
+	// u.Runtime.Interrupt only interrupts JS script, not the go code which run it. So there might be
+	// a race condition that an interrupted iteration was recognized as full iteration. Detect that case
+	// here and masking the interrupted error.
+	if gErr, ok := err.(*goja.InterruptedError); ok && isFullIteration && gErr.Value() == errInterrupt {
+		return nil
+	}
+
 	return err
 }
 

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -587,7 +587,7 @@ func TestVURunInterruptDoesntPanic(t *testing.T) {
 					defer wg.Done()
 					close(ch)
 					vuErr := vu.RunOnce(newCtx)
-					assert.Error(t, vuErr)
+					require.Error(t, vuErr)
 					assert.Contains(t, vuErr.Error(), "context cancelled")
 				}()
 				<-ch


### PR DESCRIPTION
goja Interrupt only interrupts the JS vm, not the Go code which runs it.
So there might be a race condition that an interrupted iteration was not
probably detected, especially in case of heavy load.

Detect that case and silent the interrupted error.

Fixes #1283