### PR TITLE
Fix VariableArrivalRate not working well

### DIFF
--- a/lib/execution_segment.go
+++ b/lib/execution_segment.go
@@ -517,6 +517,10 @@ type ExecutionTuple struct { // TODO rename
 	once *sync.Once
 }
 
+func (et *ExecutionTuple) String() string {
+	return fmt.Sprintf("%s in %s", et.ES, et.sequence)
+}
+
 func fillSequence(sequence ExecutionSegmentSequence) ExecutionSegmentSequence {
 	if sequence[0].from.Cmp(zeroRat) != 0 {
 		es := newExecutionSegment(zeroRat, sequence[0].from)

--- a/lib/executor/constant_arrival_rate_test.go
+++ b/lib/executor/constant_arrival_rate_test.go
@@ -38,6 +38,23 @@ import (
 	"github.com/loadimpact/k6/stats"
 )
 
+func newExecutionSegmentFromString(str string) *lib.ExecutionSegment {
+	r, err := lib.NewExecutionSegmentFromString(str)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+func newExecutionSegmentSequenceFromString(str string) *lib.ExecutionSegmentSequence {
+	r, err := lib.NewExecutionSegmentSequenceFromString(str)
+
+	if err != nil {
+		panic(err)
+	}
+	return &r
+}
+
 func getTestConstantArrivalRateConfig() ConstantArrivalRateConfig {
 	return ConstantArrivalRateConfig{
 		TimeUnit:        types.NullDurationFrom(time.Second),
@@ -109,18 +126,6 @@ func TestConstantArrivalRateRunCorrectRate(t *testing.T) {
 }
 
 func TestConstantArrivalRateRunCorrectTiming(t *testing.T) {
-	newExecutionSegmentFromString := func(str string) *lib.ExecutionSegment {
-		r, err := lib.NewExecutionSegmentFromString(str)
-		require.NoError(t, err)
-		return r
-	}
-
-	newExecutionSegmentSequenceFromString := func(str string) *lib.ExecutionSegmentSequence {
-		r, err := lib.NewExecutionSegmentSequenceFromString(str)
-		require.NoError(t, err)
-		return &r
-	}
-
 	var tests = []struct {
 		segment  *lib.ExecutionSegment
 		sequence *lib.ExecutionSegmentSequence

--- a/lib/executor/variable_arrival_rate.go
+++ b/lib/executor/variable_arrival_rate.go
@@ -176,11 +176,65 @@ type VariableArrivalRate struct {
 // Make sure we implement the lib.Executor interface.
 var _ lib.Executor = &VariableArrivalRate{}
 
+// cal calculates the  transtitions between stages and gives the next full value produced by the
+// stages. In this explanation we are talking about events and in practice those events are starting
+// of an iteration, but could really be anything that needs to occur at a constant or linear rate.
+//
+// The basic idea is that we make a graph with the X axis being time and the Y axis being
+// events/s we know that the area of the figure between the graph and the X axis is equal to the
+// amount of events done - we multiply time by events per time so we get events ...
+// Mathematics :).
+//
+// Lets look at a simple example - lets say we start with 2 events and the first stage is 5
+// seconds to 2 events/s and then we have a second stage for 5 second that goes up to 3 events
+// (using small numbers because ... well it is easier :D). This will look something like:
+//  ^
+// 7|
+// 6|
+// 5|
+// 4|
+// 3|       ,-+
+// 2|----+-'  |
+// 1|    |    |
+//  +----+----+---------------------------------->
+//  0s   5s   10s
+// TODO: bigger and more stages
+//
+// Now the question is when(where on the graph) does the first event happen? Well in this simple
+// case it is easy it will be at 0.5 seconds as we are doing 2 events/s. If we want to know when
+// event n will happen we need to calculate n = 2 * x, where x is the time it will happen, so we
+// need to calculate x = n/2as we are interested in the time, x.
+// So if we just had a constant function for each event n we can calculate n/2 and find out when
+// it needs to start.
+// As we can see though the graph changes as stages change. But we can calculate how many events
+// each stage will have, again it is the area from the start of the stage to it's end and between
+// the graph and the X axis. So in this case we know that the first stage will have 10 full events
+// in it and no more or less. So we are trying to find out when the 12 event will happen the answer
+// will be after the 5th second.
+//
+// The graph doesn't show this well but we are ramping up linearly (we could possibly add
+// other ramping up/down functions later). So at 7.5 seconds for example we should be doing 2.5
+// events/s. You could start slicing the graph constantly and in this way to represent the ramping
+// up/down as a multiple constant functions, and you will get mostly okayish results. But here is
+// where calculus comes into play. Calculus gives us a way of exactly calculate the area for any
+// given function and linear ramp up/downs just happen to be pretty easy(actual math prove in
+// https://github.com/loadimpact/k6/issues/1299#issuecomment-575661084).
+//
+// One tricky last point is what happens if stage only completes 9.8 events? Let's say that the
+// first stage above was 4.9 seconds long 2 * 4.9 is 9.8, we have 9 events and .8 of an event, what
+// do with do with that? Well the 10th even will happen in the next stage (if any) and will happen
+// when the are from the start till time x is 0.2 (instead of 1) as 0.2 + 0.8 is 10. So the 12th for
+// example will be when the area is 2.2 as 9.8+2.2. So we just carry this around.
+//
+// So in the end what calis doing is to get formulas which will tell it when
+// a given event n in order will happen. It helps itself by knowing that in a given
+// stage will do some given amount (the area of the stage) events and if we past that one we
+// know we are not in that stage.
+//
+// The specific implementation here can only go forward and does incorporate
+// the striping algorithm from the lib.ExecutionTuple for additional speed up but this could
+// possibly be refactored if need for this arises.
 func (varc VariableArrivalRateConfig) cal(et *lib.ExecutionTuple, ch chan<- time.Duration) {
-	// TODO: add inline comments with explanation of what is happening
-	// for now just link to https://github.com/loadimpact/k6/issues/1299#issuecomment-575661084
-	// TODO: rewrite this as state based functions/lambdas or something, drop the channel and let the user call
-	// it and precalculate the values, something like the `next` below
 	start, offsets, _ := et.GetStripedOffsets(et.ES)
 	li := -1
 	// TODO: move this to a utility function, or directly what GetStripedOffsets uses once we see everywhere we will use it
@@ -191,15 +245,16 @@ func (varc VariableArrivalRateConfig) cal(et *lib.ExecutionTuple, ch chan<- time
 	defer close(ch) // TODO: maybe this is not a good design - closing a channel we get
 	var (
 		stageStart                   time.Duration
-		timeUnit                     = time.Duration(varc.TimeUnit.Duration).Nanoseconds() // TODO: test
+		timeUnit                     = float64(varc.TimeUnit.Duration)
 		doneSoFar, endCount, to, dur float64
-		from                         = float64(varc.StartRate.ValueOrZero()) / float64(timeUnit)
-		i                            = float64(start + 1)
+		from                         = float64(varc.StartRate.ValueOrZero()) / timeUnit
+		// start .. starts at 0 but the algorithm works with area so we need to start from 1 not 0
+		i = float64(start + 1)
 	)
 
 	for _, stage := range varc.Stages {
-		to = float64(stage.Target.ValueOrZero()) / float64(timeUnit)
-		dur = float64(time.Duration(stage.Duration.Duration).Nanoseconds())
+		to = float64(stage.Target.ValueOrZero()) / timeUnit
+		dur = float64(stage.Duration.Duration)
 		if from != to { // ramp up/down
 			endCount += dur * ((to-from)/2 + from)
 			for ; i <= endCount; i += float64(next()) {

--- a/lib/executor/variable_arrival_rate_test.go
+++ b/lib/executor/variable_arrival_rate_test.go
@@ -22,6 +22,7 @@ package executor
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"sync"
 	"sync/atomic"
@@ -29,6 +30,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	null "gopkg.in/guregu/null.v3"
 
@@ -36,191 +38,6 @@ import (
 	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/stats"
 )
-
-func TestGetPlannedRateChanges0DurationStage(t *testing.T) {
-	t.Parallel()
-	var config = VariableArrivalRateConfig{
-		TimeUnit:  types.NullDurationFrom(time.Second),
-		StartRate: null.IntFrom(0),
-		Stages: []Stage{
-			{
-				Duration: types.NullDurationFrom(0),
-				Target:   null.IntFrom(50),
-			},
-			{
-				Duration: types.NullDurationFrom(time.Minute),
-				Target:   null.IntFrom(50),
-			},
-			{
-				Duration: types.NullDurationFrom(0),
-				Target:   null.IntFrom(100),
-			},
-			{
-				Duration: types.NullDurationFrom(time.Minute),
-				Target:   null.IntFrom(100),
-			},
-		},
-	}
-	et, err := lib.NewExecutionTuple(nil, nil)
-	require.NoError(t, err)
-	changes := config.getPlannedRateChanges(et)
-	require.Equal(t, 2, len(changes))
-	require.Equal(t, time.Duration(0), changes[0].timeOffset)
-	require.Equal(t, types.NullDurationFrom(time.Millisecond*20), changes[0].tickerPeriod)
-
-	require.Equal(t, time.Minute, changes[1].timeOffset)
-	require.Equal(t, types.NullDurationFrom(time.Millisecond*10), changes[1].tickerPeriod)
-}
-
-// helper function to calculate the expected rate change at a given time
-func calculateTickerPeriod(current, start, duration time.Duration, from, to int64) types.Duration {
-	var coef = big.NewRat(
-		(current - start).Nanoseconds(),
-		duration.Nanoseconds(),
-	)
-
-	var oneRat = new(big.Rat).Mul(big.NewRat(from-to, 1), coef)
-	oneRat = new(big.Rat).Sub(big.NewRat(from, 1), oneRat)
-	oneRat = new(big.Rat).Mul(big.NewRat(int64(time.Second), 1), new(big.Rat).Inv(oneRat))
-	return types.Duration(new(big.Int).Div(oneRat.Num(), oneRat.Denom()).Int64())
-}
-
-func TestGetPlannedRateChangesZeroDurationStart(t *testing.T) {
-	// TODO: Make multiple of those tests
-	t.Parallel()
-	var config = VariableArrivalRateConfig{
-		TimeUnit:  types.NullDurationFrom(time.Second),
-		StartRate: null.IntFrom(0),
-		Stages: []Stage{
-			{
-				Duration: types.NullDurationFrom(0),
-				Target:   null.IntFrom(50),
-			},
-			{
-				Duration: types.NullDurationFrom(time.Minute),
-				Target:   null.IntFrom(50),
-			},
-			{
-				Duration: types.NullDurationFrom(0),
-				Target:   null.IntFrom(100),
-			},
-			{
-				Duration: types.NullDurationFrom(time.Minute),
-				Target:   null.IntFrom(100),
-			},
-			{
-				Duration: types.NullDurationFrom(time.Minute),
-				Target:   null.IntFrom(0),
-			},
-		},
-	}
-
-	et, err := lib.NewExecutionTuple(nil, nil)
-	require.NoError(t, err)
-	changes := config.getPlannedRateChanges(et)
-	var expectedTickerPeriod types.Duration
-	for i, change := range changes {
-		switch {
-		case change.timeOffset == 0:
-			expectedTickerPeriod = types.Duration(20 * time.Millisecond)
-		case change.timeOffset == time.Minute*1:
-			expectedTickerPeriod = types.Duration(10 * time.Millisecond)
-		case change.timeOffset < time.Minute*3:
-			expectedTickerPeriod = calculateTickerPeriod(change.timeOffset, 2*time.Minute, time.Minute, 100, 0)
-		case change.timeOffset == time.Minute*3:
-			expectedTickerPeriod = 0
-		default:
-			t.Fatalf("this shouldn't happen %d index %+v", i, change)
-		}
-		require.Equal(t, time.Duration(0),
-			change.timeOffset%minIntervalBetweenRateAdjustments, "%d index %+v", i, change)
-		require.Equal(t, change.tickerPeriod.Duration, expectedTickerPeriod, "%d index %+v", i, change)
-	}
-}
-
-func TestGetPlannedRateChanges(t *testing.T) {
-	// TODO: Make multiple of those tests
-	t.Parallel()
-	var config = VariableArrivalRateConfig{
-		TimeUnit:  types.NullDurationFrom(time.Second),
-		StartRate: null.IntFrom(0),
-		Stages: []Stage{
-			{
-				Duration: types.NullDurationFrom(2 * time.Minute),
-				Target:   null.IntFrom(50),
-			},
-			{
-				Duration: types.NullDurationFrom(time.Minute),
-				Target:   null.IntFrom(50),
-			},
-			{
-				Duration: types.NullDurationFrom(time.Minute),
-				Target:   null.IntFrom(100),
-			},
-			{
-				Duration: types.NullDurationFrom(0),
-				Target:   null.IntFrom(200),
-			},
-
-			{
-				Duration: types.NullDurationFrom(time.Second * 23),
-				Target:   null.IntFrom(50),
-			},
-		},
-	}
-
-	et, err := lib.NewExecutionTuple(nil, nil)
-	require.NoError(t, err)
-	changes := config.getPlannedRateChanges(et)
-	var expectedTickerPeriod types.Duration
-	for i, change := range changes {
-		switch {
-		case change.timeOffset <= time.Minute*2:
-			expectedTickerPeriod = calculateTickerPeriod(change.timeOffset, 0, time.Minute*2, 0, 50)
-		case change.timeOffset < time.Minute*4:
-			expectedTickerPeriod = calculateTickerPeriod(change.timeOffset, time.Minute*3, time.Minute, 50, 100)
-		case change.timeOffset == time.Minute*4:
-			expectedTickerPeriod = types.Duration(5 * time.Millisecond)
-		default:
-			expectedTickerPeriod = calculateTickerPeriod(change.timeOffset, 4*time.Minute, 23*time.Second, 200, 50)
-		}
-		require.Equal(t, time.Duration(0),
-			change.timeOffset%minIntervalBetweenRateAdjustments, "%d index %+v", i, change)
-		require.Equal(t, change.tickerPeriod.Duration, expectedTickerPeriod, "%d index %+v", i, change)
-	}
-}
-
-func BenchmarkGetPlannedRateChanges(b *testing.B) {
-	var config = VariableArrivalRateConfig{
-		TimeUnit:  types.NullDurationFrom(time.Second),
-		StartRate: null.IntFrom(0),
-		Stages: []Stage{
-			{
-				Duration: types.NullDurationFrom(5 * time.Minute),
-				Target:   null.IntFrom(5000),
-			},
-			{
-				Duration: types.NullDurationFrom(50 * time.Minute),
-				Target:   null.IntFrom(5000),
-			},
-			{
-				Duration: types.NullDurationFrom(5 * time.Minute),
-				Target:   null.IntFrom(0),
-			},
-		},
-	}
-
-	b.RunParallel(func(pb *testing.PB) {
-		et, err := lib.NewExecutionTuple(nil, nil)
-		require.NoError(b, err)
-		for pb.Next() {
-			changes := config.getPlannedRateChanges(et)
-
-			require.Equal(b, time.Duration(0),
-				changes[0].timeOffset%minIntervalBetweenRateAdjustments, "%+v", changes[0])
-		}
-	})
-}
 
 func getTestVariableArrivalRateConfig() VariableArrivalRateConfig {
 	return VariableArrivalRateConfig{
@@ -294,21 +111,391 @@ func TestVariableArrivalRateRunCorrectRate(t *testing.T) {
 
 		time.Sleep(time.Second)
 		currentCount = atomic.SwapInt64(&count, 0)
-		require.InDelta(t, 10, currentCount, 1)
+		assert.InDelta(t, 10, currentCount, 1)
 
 		time.Sleep(time.Second)
 		currentCount = atomic.SwapInt64(&count, 0)
-		// this is highly dependant on minIntervalBetweenRateAdjustments
-		// TODO find out why this isn't 30 and fix it
-		require.InDelta(t, 23, currentCount, 2)
+		assert.InDelta(t, 30, currentCount, 2)
 
 		time.Sleep(time.Second)
 		currentCount = atomic.SwapInt64(&count, 0)
-		require.InDelta(t, 50, currentCount, 2)
+		assert.InDelta(t, 50, currentCount, 2)
 	}()
 	var engineOut = make(chan stats.SampleContainer, 1000)
 	err = executor.Run(ctx, engineOut)
 	wg.Wait()
 	require.NoError(t, err)
 	require.Empty(t, logHook.Drain())
+}
+
+func TestVariableArrivalRateRunCorrectRateWithSlowRate(t *testing.T) {
+	t.Parallel()
+	var count int64
+	var now = time.Now()
+	et, err := lib.NewExecutionTuple(nil, nil)
+	require.NoError(t, err)
+	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
+	var expectedTimes = []time.Duration{
+		time.Millisecond * 3464, time.Millisecond * 4898, time.Second * 6}
+	var ctx, cancel, executor, logHook = setupExecutor(
+		t, VariableArrivalRateConfig{
+			TimeUnit: types.NullDurationFrom(time.Second),
+			Stages: []Stage{
+				{
+					Duration: types.NullDurationFrom(time.Second * 6),
+					Target:   null.IntFrom(1),
+				},
+				{
+					Duration: types.NullDurationFrom(time.Second * 0),
+					Target:   null.IntFrom(0),
+				},
+				{
+					Duration: types.NullDurationFrom(time.Second * 1),
+					Target:   null.IntFrom(0),
+				},
+			},
+			PreAllocatedVUs: null.IntFrom(10),
+			MaxVUs:          null.IntFrom(20),
+		},
+		es,
+		simpleRunner(func(ctx context.Context) error {
+			current := atomic.AddInt64(&count, 1)
+			if !assert.True(t, int(current) <= len(expectedTimes)) {
+				return nil
+			}
+			expectedTime := expectedTimes[current-1]
+			assert.WithinDuration(t,
+				now.Add(expectedTime),
+				time.Now(),
+				time.Millisecond*100,
+				"%d expectedTime %s", current, expectedTime,
+			)
+			return nil
+		}),
+	)
+	defer cancel()
+	var engineOut = make(chan stats.SampleContainer, 1000)
+	err = executor.Run(ctx, engineOut)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(expectedTimes)), count)
+	require.Empty(t, logHook.Drain())
+}
+
+func mustNewExecutionTuple(seg *lib.ExecutionSegment, seq *lib.ExecutionSegmentSequence) *lib.ExecutionTuple {
+	et, err := lib.NewExecutionTuple(seg, seq)
+	if err != nil {
+		panic(err)
+	}
+	return et
+}
+
+func TestVariableArrivalRateCal(t *testing.T) {
+	t.Parallel()
+
+	var config = VariableArrivalRateConfig{
+		TimeUnit:  types.NullDurationFrom(time.Second),
+		StartRate: null.IntFrom(0),
+		Stages: []Stage{ // TODO make this even bigger and longer .. will need more time
+			{
+				Duration: types.NullDurationFrom(time.Second * 5),
+				Target:   null.IntFrom(1),
+			},
+			{
+				Duration: types.NullDurationFrom(time.Second * 1),
+				Target:   null.IntFrom(1),
+			},
+			{
+				Duration: types.NullDurationFrom(time.Second * 5),
+				Target:   null.IntFrom(0),
+			},
+		},
+	}
+
+	testCases := []struct {
+		expectedTimes []time.Duration
+		et            *lib.ExecutionTuple
+	}{
+		{
+			expectedTimes: []time.Duration{time.Millisecond * 3162, time.Millisecond * 4472, time.Millisecond * 5500, time.Millisecond * 6527, time.Millisecond * 7837, time.Second * 11},
+			et:            mustNewExecutionTuple(nil, nil),
+		},
+		{
+			expectedTimes: []time.Duration{time.Millisecond * 4472, time.Millisecond * 7837},
+			et:            mustNewExecutionTuple(newExecutionSegmentFromString("0:1/3"), nil),
+		},
+		{
+			expectedTimes: []time.Duration{time.Millisecond * 4472, time.Millisecond * 7837},
+			et:            mustNewExecutionTuple(newExecutionSegmentFromString("0:1/3"), newExecutionSegmentSequenceFromString("0,1/3,1")),
+		},
+		{
+			expectedTimes: []time.Duration{time.Millisecond * 4472, time.Millisecond * 7837},
+			et:            mustNewExecutionTuple(newExecutionSegmentFromString("1/3:2/3"), nil),
+		},
+		{
+			expectedTimes: []time.Duration{time.Millisecond * 4472, time.Millisecond * 7837},
+			et:            mustNewExecutionTuple(newExecutionSegmentFromString("2/3:1"), nil),
+		},
+		{
+			expectedTimes: []time.Duration{time.Millisecond * 3162, time.Millisecond * 6527},
+			et:            mustNewExecutionTuple(newExecutionSegmentFromString("0:1/3"), newExecutionSegmentSequenceFromString("0,1/3,2/3,1")),
+		},
+		{
+			expectedTimes: []time.Duration{time.Millisecond * 4472, time.Millisecond * 7837},
+			et:            mustNewExecutionTuple(newExecutionSegmentFromString("1/3:2/3"), newExecutionSegmentSequenceFromString("0,1/3,2/3,1")),
+		},
+		{
+			expectedTimes: []time.Duration{time.Millisecond * 5500, time.Millisecond * 11000},
+			et:            mustNewExecutionTuple(newExecutionSegmentFromString("2/3:1"), newExecutionSegmentSequenceFromString("0,1/3,2/3,1")),
+		},
+	}
+	for _, testCase := range testCases {
+		et := testCase.et
+		expectedTimes := testCase.expectedTimes
+
+		t.Run(fmt.Sprintf("%v", et), func(t *testing.T) { // TODO implement String on ExecutionTuple
+			var ch = make(chan time.Duration)
+			go config.cal(et, ch)
+			var changes = make([]time.Duration, 0, len(expectedTimes))
+			for c := range ch {
+				changes = append(changes, c)
+			}
+			assert.Equal(t, len(expectedTimes), len(changes))
+			for i, expectedTime := range expectedTimes {
+				require.True(t, i < len(changes))
+				change := changes[i]
+				assert.InEpsilon(t, expectedTime, change, 0.001, "%s %s", expectedTime, change)
+			}
+		})
+	}
+}
+
+func BenchmarkCal(b *testing.B) {
+	for _, t := range []time.Duration{
+		time.Second, time.Minute,
+	} {
+		t := t
+		b.Run(t.String(), func(b *testing.B) {
+			var config = VariableArrivalRateConfig{
+				TimeUnit:  types.NullDurationFrom(time.Second),
+				StartRate: null.IntFrom(50),
+				Stages: []Stage{
+					{
+						Duration: types.NullDurationFrom(t),
+						Target:   null.IntFrom(49),
+					},
+					{
+						Duration: types.NullDurationFrom(t),
+						Target:   null.IntFrom(50),
+					},
+				},
+			}
+			et := mustNewExecutionTuple(nil, nil)
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					var ch = make(chan time.Duration, 20)
+					go config.cal(et, ch)
+					for c := range ch {
+						_ = c
+					}
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkCalRat(b *testing.B) {
+	for _, t := range []time.Duration{
+		time.Second, time.Minute,
+	} {
+		t := t
+		b.Run(t.String(), func(b *testing.B) {
+			var config = VariableArrivalRateConfig{
+				TimeUnit:  types.NullDurationFrom(time.Second),
+				StartRate: null.IntFrom(50),
+				Stages: []Stage{
+					{
+						Duration: types.NullDurationFrom(t),
+						Target:   null.IntFrom(49),
+					},
+					{
+						Duration: types.NullDurationFrom(t),
+						Target:   null.IntFrom(50),
+					},
+				},
+			}
+			et := mustNewExecutionTuple(nil, nil)
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					var ch = make(chan time.Duration, 20)
+					go config.calRat(et, ch)
+					for c := range ch {
+						_ = c
+					}
+				}
+			})
+		})
+	}
+}
+
+func TestCompareCalImplementation(t *testing.T) {
+	t.Parallel()
+	// This test checks that the cal and calRat implementation get roughly similar numbers
+	// in my experiment the difference is 1(nanosecond) in 7 case for the whole test
+	// the duration is 1 second for each stage as calRat takes way longer - a longer better test can
+	// be done when/if it's performance is improved
+	var config = VariableArrivalRateConfig{
+		TimeUnit:  types.NullDurationFrom(time.Second),
+		StartRate: null.IntFrom(0),
+		Stages: []Stage{
+			{
+				Duration: types.NullDurationFrom(1 * time.Second),
+				Target:   null.IntFrom(200),
+			},
+			{
+				Duration: types.NullDurationFrom(1 * time.Second),
+				Target:   null.IntFrom(200),
+			},
+			{
+				Duration: types.NullDurationFrom(1 * time.Second),
+				Target:   null.IntFrom(2000),
+			},
+			{
+				Duration: types.NullDurationFrom(1 * time.Second),
+				Target:   null.IntFrom(2000),
+			},
+			{
+				Duration: types.NullDurationFrom(1 * time.Second),
+				Target:   null.IntFrom(300),
+			},
+			{
+				Duration: types.NullDurationFrom(1 * time.Second),
+				Target:   null.IntFrom(300),
+			},
+			{
+				Duration: types.NullDurationFrom(1 * time.Second),
+				Target:   null.IntFrom(1333),
+			},
+			{
+				Duration: types.NullDurationFrom(1 * time.Second),
+				Target:   null.IntFrom(1334),
+			},
+			{
+				Duration: types.NullDurationFrom(1 * time.Second),
+				Target:   null.IntFrom(1334),
+			},
+		},
+	}
+
+	et := mustNewExecutionTuple(nil, nil)
+	var chRat = make(chan time.Duration, 20)
+	var ch = make(chan time.Duration, 20)
+	go config.calRat(et, chRat)
+	go config.cal(et, ch)
+	count := 0
+	var diff int
+	for c := range ch {
+		count++
+		cRat := <-chRat
+		if !assert.InDelta(t, c, cRat, 1, "%d", count) {
+			diff++
+		}
+	}
+	require.Equal(t, 0, diff)
+}
+
+// calRat code here is just to check how accurate the cal implemenattion is
+// there are no other tests for it so it depends on the test of cal that it is actually accurate :D
+
+//nolint:gochecknoglobals
+var two = big.NewRat(2, 1)
+
+// from https://groups.google.com/forum/#!topic/golang-nuts/aIcDf8T-Png
+func sqrtRat(x *big.Rat) *big.Rat {
+	var z, a, b big.Rat
+	var ns, ds big.Int
+	ni, di := x.Num(), x.Denom()
+	z.SetFrac(ns.Rsh(ni, uint(ni.BitLen())/2), ds.Rsh(di, uint(di.BitLen())/2))
+	for i := 10; i > 0; i-- { //TODO: better termination
+		a.Sub(a.Mul(&z, &z), x)
+		f, _ := a.Float64()
+		if f == 0 {
+			break
+		}
+		// fmt.Println(x, z, i)
+		z.Sub(&z, b.Quo(&a, b.Mul(two, &z)))
+	}
+	return &z
+}
+
+// This implementation is just for reference and accuracy testing
+func (varc VariableArrivalRateConfig) calRat(et *lib.ExecutionTuple, ch chan<- time.Duration) {
+	defer close(ch)
+
+	start, offsets, _ := et.GetStripedOffsets(et.ES)
+	li := -1
+	next := func() int64 {
+		li++
+		return offsets[li%len(offsets)]
+	}
+	iRat := big.NewRat(start+1, 1)
+
+	var carry = big.NewRat(0, 1)
+	var doneSoFar = big.NewRat(0, 1)
+	var endCount = big.NewRat(0, 1)
+	curr := varc.StartRate.ValueOrZero()
+	var base time.Duration
+	for _, stage := range varc.Stages {
+		target := stage.Target.ValueOrZero()
+		if target != curr {
+			var (
+				from = big.NewRat(curr, int64(time.Second))
+				to   = big.NewRat(target, int64(time.Second))
+				dur  = big.NewRat(time.Duration(stage.Duration.Duration).Nanoseconds(), 1)
+			)
+			// precalcualations :)
+			toMinusFrom := new(big.Rat).Sub(to, from)
+			fromSquare := new(big.Rat).Mul(from, from)
+			durMulSquare := new(big.Rat).Mul(dur, fromSquare)
+			fromMulDur := new(big.Rat).Mul(from, dur)
+			oneOverToMinusFrom := new(big.Rat).Inv(toMinusFrom)
+
+			endCount.Add(endCount,
+				new(big.Rat).Mul(
+					dur,
+					new(big.Rat).Add(new(big.Rat).Mul(toMinusFrom, big.NewRat(1, 2)), from)))
+			for ; endCount.Cmp(iRat) >= 0; iRat.Add(iRat, big.NewRat(next(), 1)) {
+				// even with all of this optimizations sqrtRat is taking so long this is still
+				// extremely slow ... :(
+				buf := new(big.Rat).Sub(iRat, doneSoFar)
+				buf.Mul(buf, two)
+				buf.Mul(buf, toMinusFrom)
+				buf.Add(buf, durMulSquare)
+				buf.Mul(buf, dur)
+				buf.Sub(fromMulDur, sqrtRat(buf))
+				buf.Mul(buf, oneOverToMinusFrom)
+
+				r, _ := buf.Float64()
+				ch <- base + time.Duration(-r) // the minus is because we don't deive by from-to but by to-from above
+			}
+		} else {
+			step := big.NewRat(int64(time.Second), target)
+			first := big.NewRat(0, 1)
+			first.Sub(first, carry)
+			endCount.Add(endCount, new(big.Rat).Mul(big.NewRat(target, 1), big.NewRat(time.Duration(stage.Duration.Duration).Nanoseconds(), time.Duration(varc.TimeUnit.Duration).Nanoseconds())))
+
+			for ; endCount.Cmp(iRat) >= 0; iRat.Add(iRat, big.NewRat(next(), 1)) {
+				res := new(big.Rat).Sub(iRat, doneSoFar) // this can get next added to it but will need to change the above for .. so
+				r, _ := res.Mul(res, step).Float64()
+				ch <- base + time.Duration(r)
+				first.Add(first, step)
+			}
+		}
+		doneSoFar.Set(endCount) // copy
+		curr = target
+		base += time.Duration(stage.Duration.Duration)
+	}
 }


### PR DESCRIPTION
The previous implementation worked basically as follows:
A list of changes to the arrival rate is generated where there is a
minimum time between this changes (currently 250ms). This means that for
any ramp-up/down there is a step every 250ms (more or less).
After this is generated a goroutine will read that list and send the
change on a channel at the appropriate time. During ramp-up/down this is
every 250ms (more or less).
Another goroutine will be receiving those changes and resetting a timer
to the new value. And here is where the problem lies:
If the arrival rate is more then 1 iteration each 250ms this means that
it will never trigger a start of a VU.
The extreme example is having ramp-up to 4 iteration per second - this
is exactly 1 iteration each 250ms, which means that for the whole
duration up to end of the ramp up there will be zero iterations started.

In order to completely remove this I went the step further. The way we
seperate the interval in small pieces reminded me of integrals and
is one of the very easy cases for using integrals.
So I just calculate the integral of the function that is the number of
VUs over time. The answer is how many ioterations need to be done there,
so if I reverse this and instead calculate for how much time I will get
1 I get when the first iteration should start. I can do that for any
iteration number and if there is no result then obviously we can get
that :D.

This also has the awesome sideeffect that if we split the executib in 10
we only need to calculate 1/10th of the integrals on each instance.