### PR TITLE
Improve progress bar rendering of #1007

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -65,11 +65,13 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
         k6 cloud script.js`[1:],
 	Args: exactArgsWithMsg(1, "arg should either be \"-\", if reading script from stdin, or a path to a script file"),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		logger := logrus.StandardLogger()
+
 		//TODO: disable in quiet mode?
 		_, _ = BannerColor.Fprintf(stdout, "\n%s\n\n", consts.Banner)
 
 		progressBar := pb.New(pb.WithConstLeft(" Init"))
-		printBar(progressBar, "Parsing script")
+		printBar(progressBar, "Parsing script", logger)
 
 		// Runner
 		pwd, err := os.Getwd()
@@ -89,13 +91,13 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 			return err
 		}
 
-		printBar(progressBar, "Getting script options")
+		printBar(progressBar, "Getting script options", logger)
 		r, err := newRunner(src, runType, filesystems, runtimeOptions)
 		if err != nil {
 			return err
 		}
 
-		printBar(progressBar, "Consolidating options")
+		printBar(progressBar, "Consolidating options", logger)
 		cliOpts, err := getOptions(cmd.Flags())
 		if err != nil {
 			return err
@@ -128,7 +130,7 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 			return errors.New("Not logged in, please use `k6 login cloud`.")
 		}
 
-		printBar(progressBar, "Building the archive")
+		printBar(progressBar, "Building the archive", logger)
 		arc := r.MakeArchive()
 		// TODO: Fix this
 		// We reuse cloud.Config for parsing options.ext.loadimpact, but this probably shouldn't be
@@ -177,19 +179,19 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 		}
 
 		// Start cloud test run
-		printBar(progressBar, "Validating script options")
+		printBar(progressBar, "Validating script options", logger)
 		client := cloud.NewClient(cloudConfig.Token.String, cloudConfig.Host.String, consts.Version)
 		if err := client.ValidateOptions(arc.Options); err != nil {
 			return err
 		}
 
-		printBar(progressBar, "Uploading archive")
+		printBar(progressBar, "Uploading archive", logger)
 		refID, err := client.StartCloudTestRun(name, cloudConfig.ProjectID.Int64, arc)
 		if err != nil {
 			return err
 		}
 		progressBar.Modify(pb.WithConstLeft("   Run"))
-		printBar(progressBar, "Initializing the cloud test")
+		printBar(progressBar, "Initializing the cloud test", logger)
 
 		testURL := cloud.URLForResults(refID, cloudConfig)
 		fprintf(stdout, "\n\n")
@@ -198,7 +200,7 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 		fprintf(stdout, "     output: %s\n", ui.ValueColor.Sprint(testURL))
 		//TODO: print executors information
 		fprintf(stdout, "\n")
-		printBar(progressBar, "Initializing the cloud test")
+		printBar(progressBar, "Initializing the cloud test", logger)
 
 		// The quiet option hides the progress bar and disallow aborting the test
 		if quiet {
@@ -234,7 +236,7 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 					if (testProgress.RunStatus > lib.RunStatusRunning) || (exitOnRunning && testProgress.RunStatus == lib.RunStatusRunning) {
 						shouldExitLoop = true
 					}
-					printBar(progressBar, "")
+					printBar(progressBar, "", logger)
 				} else {
 					logrus.WithError(progressErr).Error("Test progress error")
 				}

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -65,13 +65,11 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
         k6 cloud script.js`[1:],
 	Args: exactArgsWithMsg(1, "arg should either be \"-\", if reading script from stdin, or a path to a script file"),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		logger := logrus.StandardLogger()
-
 		//TODO: disable in quiet mode?
 		_, _ = BannerColor.Fprintf(stdout, "\n%s\n\n", consts.Banner)
 
 		progressBar := pb.New(pb.WithConstLeft(" Init"))
-		printBar(progressBar, "Parsing script", logger)
+		printBar(progressBar, "Parsing script")
 
 		// Runner
 		pwd, err := os.Getwd()
@@ -91,13 +89,13 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 			return err
 		}
 
-		printBar(progressBar, "Getting script options", logger)
+		printBar(progressBar, "Getting script options")
 		r, err := newRunner(src, runType, filesystems, runtimeOptions)
 		if err != nil {
 			return err
 		}
 
-		printBar(progressBar, "Consolidating options", logger)
+		printBar(progressBar, "Consolidating options")
 		cliOpts, err := getOptions(cmd.Flags())
 		if err != nil {
 			return err
@@ -130,7 +128,7 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 			return errors.New("Not logged in, please use `k6 login cloud`.")
 		}
 
-		printBar(progressBar, "Building the archive", logger)
+		printBar(progressBar, "Building the archive")
 		arc := r.MakeArchive()
 		// TODO: Fix this
 		// We reuse cloud.Config for parsing options.ext.loadimpact, but this probably shouldn't be
@@ -179,19 +177,19 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 		}
 
 		// Start cloud test run
-		printBar(progressBar, "Validating script options", logger)
+		printBar(progressBar, "Validating script options")
 		client := cloud.NewClient(cloudConfig.Token.String, cloudConfig.Host.String, consts.Version)
 		if err := client.ValidateOptions(arc.Options); err != nil {
 			return err
 		}
 
-		printBar(progressBar, "Uploading archive", logger)
+		printBar(progressBar, "Uploading archive")
 		refID, err := client.StartCloudTestRun(name, cloudConfig.ProjectID.Int64, arc)
 		if err != nil {
 			return err
 		}
 		progressBar.Modify(pb.WithConstLeft("   Run"))
-		printBar(progressBar, "Initializing the cloud test", logger)
+		printBar(progressBar, "Initializing the cloud test")
 
 		testURL := cloud.URLForResults(refID, cloudConfig)
 		fprintf(stdout, "\n\n")
@@ -200,7 +198,7 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 		fprintf(stdout, "     output: %s\n", ui.ValueColor.Sprint(testURL))
 		//TODO: print executors information
 		fprintf(stdout, "\n")
-		printBar(progressBar, "Initializing the cloud test", logger)
+		printBar(progressBar, "Initializing the cloud test")
 
 		// The quiet option hides the progress bar and disallow aborting the test
 		if quiet {
@@ -236,7 +234,7 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 					if (testProgress.RunStatus > lib.RunStatusRunning) || (exitOnRunning && testProgress.RunStatus == lib.RunStatusRunning) {
 						shouldExitLoop = true
 					}
-					printBar(progressBar, "", logger)
+					printBar(progressBar, "")
 				} else {
 					logrus.WithError(progressErr).Error("Test progress error")
 				}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -97,7 +97,7 @@ a commandline interface for interacting with it.`,
 		initBar := pb.New(pb.WithConstLeft("   init"))
 
 		// Create the Runner.
-		fprintf(stdout, "%s runner\r", initBar.String()) //TODO use printBar()
+		printBar(initBar, "runner")
 		pwd, err := os.Getwd()
 		if err != nil {
 			return err
@@ -119,7 +119,7 @@ a commandline interface for interacting with it.`,
 			return err
 		}
 
-		fprintf(stdout, "%s options\r", initBar.String())
+		printBar(initBar, "options")
 
 		cliConf, err := getConfig(cmd.Flags())
 		if err != nil {
@@ -147,7 +147,7 @@ a commandline interface for interacting with it.`,
 		defer cancel()
 
 		// Create a local execution scheduler wrapping the runner.
-		fprintf(stdout, "%s execution scheduler\r", initBar.String())
+		printBar(initBar, "execution scheduler")
 		execScheduler, err := local.NewExecutionScheduler(r, logger)
 		if err != nil {
 			return err

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -91,16 +91,13 @@ a commandline interface for interacting with it.`,
   k6 run -o influxdb=http://1.2.3.4:8086/k6`[1:],
 	Args: exactArgsWithMsg(1, "arg should either be \"-\", if reading script from stdin, or a path to a script file"),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		//TODO: don't use a global... or maybe change the logger?
-		logger := logrus.StandardLogger()
-
 		//TODO: disable in quiet mode?
 		_, _ = BannerColor.Fprintf(stdout, "\n%s\n\n", consts.Banner)
 
 		initBar := pb.New(pb.WithConstLeft("   init"))
 
 		// Create the Runner.
-		printBar(initBar, "runner", logger)
+		printBar(initBar, "runner")
 		pwd, err := os.Getwd()
 		if err != nil {
 			return err
@@ -122,7 +119,7 @@ a commandline interface for interacting with it.`,
 			return err
 		}
 
-		printBar(initBar, "options", logger)
+		printBar(initBar, "options")
 
 		cliConf, err := getConfig(cmd.Flags())
 		if err != nil {
@@ -143,11 +140,14 @@ a commandline interface for interacting with it.`,
 			return err
 		}
 
+		//TODO: don't use a global... or maybe change the logger?
+		logger := logrus.StandardLogger()
+
 		ctx, cancel := context.WithCancel(context.Background()) //TODO: move even earlier?
 		defer cancel()
 
 		// Create a local execution scheduler wrapping the runner.
-		printBar(initBar, "execution scheduler", logger)
+		printBar(initBar, "execution scheduler")
 		execScheduler, err := local.NewExecutionScheduler(r, logger)
 		if err != nil {
 			return err
@@ -158,7 +158,7 @@ a commandline interface for interacting with it.`,
 		progressBarWG := &sync.WaitGroup{}
 		progressBarWG.Add(1)
 		go func() {
-			showProgress(ctx, conf, execScheduler, logger)
+			showProgress(ctx, conf, execScheduler)
 			progressBarWG.Done()
 		}()
 

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -74,7 +74,7 @@ func printBar(bar *pb.ProgressBar, rightText string) {
 		// TODO: check for cross platform support
 		end = "\x1b[0K\r"
 	}
-	fprintf(stdout, "%s %s%s", bar.String(), rightText, end)
+	fprintf(stdout, "%s %s%s", bar.String(0), rightText, end)
 }
 
 func renderMultipleBars(isTTY, goBack bool, pbs []*pb.ProgressBar) string {
@@ -84,11 +84,19 @@ func renderMultipleBars(isTTY, goBack bool, pbs []*pb.ProgressBar) string {
 		lineEnd = "\x1b[K\n" // erase till end of line
 	}
 
+	var leftPad int
+	for _, pb := range pbs {
+		l := pb.Left()
+		if len(l) > leftPad {
+			leftPad = len(l)
+		}
+	}
+
 	pbsCount := len(pbs)
 	result := make([]string, pbsCount+2)
 	result[0] = lineEnd // start with an empty line
 	for i, pb := range pbs {
-		result[i+1] = pb.String() + lineEnd
+		result[i+1] = pb.String(leftPad) + lineEnd
 	}
 	if isTTY && goBack {
 		// Go back to the beginning

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -30,8 +30,12 @@ import (
 	"time"
 
 	"github.com/loadimpact/k6/core/local"
+	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/ui/pb"
 )
+
+// TODO: Make configurable
+const maxLeftLength = 30
 
 // A writer that syncs writes with a mutex and, if the output is a TTY, clears before newlines.
 type consoleWriter struct {
@@ -74,7 +78,7 @@ func printBar(bar *pb.ProgressBar, rightText string) {
 		// TODO: check for cross platform support
 		end = "\x1b[0K\r"
 	}
-	fprintf(stdout, "%s %s%s", bar.Render(0), rightText, end)
+	fprintf(stdout, "%s %s%s", bar.Render(0, 0), rightText, end)
 }
 
 func renderMultipleBars(isTTY, goBack bool, pbs []*pb.ProgressBar) string {
@@ -91,12 +95,14 @@ func renderMultipleBars(isTTY, goBack bool, pbs []*pb.ProgressBar) string {
 			leftPad = len(l)
 		}
 	}
+	// Floor padding to maximum left text length
+	leftPad = int(lib.Min(int64(leftPad), maxLeftLength))
 
 	pbsCount := len(pbs)
 	result := make([]string, pbsCount+2)
 	result[0] = lineEnd // start with an empty line
 	for i, pb := range pbs {
-		result[i+1] = pb.Render(leftPad) + lineEnd
+		result[i+1] = pb.Render(leftPad, maxLeftLength) + lineEnd
 	}
 	if isTTY && goBack {
 		// Go back to the beginning

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -29,6 +29,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/loadimpact/k6/core/local"
 	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/ui/pb"
@@ -68,7 +70,7 @@ func (w *consoleWriter) Write(p []byte) (n int, err error) {
 	return origLen, err
 }
 
-func printBar(bar *pb.ProgressBar, rightText string) {
+func printBar(bar *pb.ProgressBar, rightText string, logger *logrus.Logger) {
 	end := "\n"
 	if stdout.IsTTY {
 		// If we're in a TTY, instead of printing the bar and going to the next
@@ -78,10 +80,11 @@ func printBar(bar *pb.ProgressBar, rightText string) {
 		// TODO: check for cross platform support
 		end = "\x1b[0K\r"
 	}
-	fprintf(stdout, "%s %s%s", bar.Render(0), rightText, end)
+	fprintf(stdout, "%s %s%s", bar.Render(0, logger), rightText, end)
 }
 
-func renderMultipleBars(isTTY, goBack bool, leftMax int, pbs []*pb.ProgressBar) string {
+func renderMultipleBars(isTTY, goBack bool, leftMax int, pbs []*pb.ProgressBar,
+	logger *logrus.Logger) string {
 	lineEnd := "\n"
 	if isTTY {
 		//TODO: check for cross platform support
@@ -92,7 +95,7 @@ func renderMultipleBars(isTTY, goBack bool, leftMax int, pbs []*pb.ProgressBar) 
 	result := make([]string, pbsCount+2)
 	result[0] = lineEnd // start with an empty line
 	for i, pb := range pbs {
-		result[i+1] = pb.Render(leftMax) + lineEnd
+		result[i+1] = pb.Render(leftMax, logger) + lineEnd
 	}
 	if isTTY && goBack {
 		// Go back to the beginning
@@ -107,7 +110,10 @@ func renderMultipleBars(isTTY, goBack bool, leftMax int, pbs []*pb.ProgressBar) 
 //TODO: show other information here?
 //TODO: add a no-progress option that will disable these
 //TODO: don't use global variables...
-func showProgress(ctx context.Context, conf Config, execScheduler *local.ExecutionScheduler) {
+func showProgress(
+	ctx context.Context, conf Config, execScheduler *local.ExecutionScheduler,
+	logger *logrus.Logger,
+) {
 	if quiet || conf.HTTPDebug.Valid && conf.HTTPDebug.String != "" {
 		return
 	}
@@ -131,7 +137,7 @@ func showProgress(ctx context.Context, conf Config, execScheduler *local.Executi
 	leftLen = int(lib.Min(int64(leftLen), maxLeftLength))
 
 	// For flicker-free progressbars!
-	progressBarsLastRender := []byte(renderMultipleBars(stdoutTTY, true, leftLen, pbs))
+	progressBarsLastRender := []byte(renderMultipleBars(stdoutTTY, true, leftLen, pbs, logger))
 	progressBarsPrint := func() {
 		_, _ = stdout.Writer.Write(progressBarsLastRender)
 	}
@@ -152,7 +158,7 @@ func showProgress(ctx context.Context, conf Config, execScheduler *local.Executi
 			stderr.PersistentText = nil
 			if ctx.Err() != nil {
 				// Render a last plain-text progressbar in an error
-				progressBarsLastRender = []byte(renderMultipleBars(stdoutTTY, false, leftLen, pbs))
+				progressBarsLastRender = []byte(renderMultipleBars(stdoutTTY, false, leftLen, pbs, logger))
 				progressBarsPrint()
 			}
 			outMutex.Unlock()
@@ -164,7 +170,7 @@ func showProgress(ctx context.Context, conf Config, execScheduler *local.Executi
 	for {
 		select {
 		case <-ticker.C:
-			barText := renderMultipleBars(stdoutTTY, true, leftLen, pbs)
+			barText := renderMultipleBars(stdoutTTY, true, leftLen, pbs, logger)
 			outMutex.Lock()
 			progressBarsLastRender = []byte(barText)
 			progressBarsPrint()

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -74,7 +74,7 @@ func printBar(bar *pb.ProgressBar, rightText string) {
 		// TODO: check for cross platform support
 		end = "\x1b[0K\r"
 	}
-	fprintf(stdout, "%s %s%s", bar.String(0), rightText, end)
+	fprintf(stdout, "%s %s%s", bar.Render(0), rightText, end)
 }
 
 func renderMultipleBars(isTTY, goBack bool, pbs []*pb.ProgressBar) string {
@@ -96,7 +96,7 @@ func renderMultipleBars(isTTY, goBack bool, pbs []*pb.ProgressBar) string {
 	result := make([]string, pbsCount+2)
 	result[0] = lineEnd // start with an empty line
 	for i, pb := range pbs {
-		result[i+1] = pb.String(leftPad) + lineEnd
+		result[i+1] = pb.Render(leftPad) + lineEnd
 	}
 	if isTTY && goBack {
 		// Go back to the beginning

--- a/lib/execution.go
+++ b/lib/execution.go
@@ -29,8 +29,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/loadimpact/k6/stats"
 	"github.com/pkg/errors"
+
+	"github.com/loadimpact/k6/stats"
 )
 
 // An ExecutionScheduler is in charge of initializing executors and using them
@@ -117,7 +118,7 @@ const MaxRetriesGetPlannedVU = 5
 // races, because the Go data race detector can't detect any data races
 // involving atomics...
 //
-// The only functionality indended for synchronization is the one revolving
+// The only functionality intended for synchronization is the one revolving
 // around pausing, and uninitializedUnplannedVUs for restricting the number of
 // unplanned VUs being initialized.
 type ExecutionState struct {

--- a/lib/executor/base_executor.go
+++ b/lib/executor/base_executor.go
@@ -23,9 +23,10 @@ package executor
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/ui/pb"
-	"github.com/sirupsen/logrus"
 )
 
 // BaseExecutor is a helper struct that contains common properties and methods
@@ -39,7 +40,7 @@ type BaseExecutor struct {
 	progress       *pb.ProgressBar
 }
 
-// NewBaseExecutor just returns an initialized BaseExecutor
+// NewBaseExecutor returns an initialized BaseExecutor
 func NewBaseExecutor(config lib.ExecutorConfig, es *lib.ExecutionState, logger *logrus.Entry) *BaseExecutor {
 	return &BaseExecutor{
 		config:         config,
@@ -47,6 +48,7 @@ func NewBaseExecutor(config lib.ExecutorConfig, es *lib.ExecutionState, logger *
 		logger:         logger,
 		progress: pb.New(
 			pb.WithLeft(config.GetName),
+			pb.WithLogger(logger),
 		),
 	}
 }

--- a/lib/executor/helpers.go
+++ b/lib/executor/helpers.go
@@ -152,13 +152,13 @@ func getDurationContexts(parentCtx context.Context, regularDuration, gracefulSto
 // executor and updates its progressbar accordingly.
 func trackProgress(
 	parentCtx, maxDurationCtx, regDurationCtx context.Context,
-	sched lib.Executor, snapshot func() (float64, string),
+	exec lib.Executor, snapshot func() (float64, string),
 ) {
-	progressBar := sched.GetProgress()
-	logger := sched.GetLogger()
+	progressBar := exec.GetProgress()
+	logger := exec.GetLogger()
 
 	<-regDurationCtx.Done() // Wait for the regular context to be over
-	gracefulStop := sched.GetConfig().GetGracefulStop()
+	gracefulStop := exec.GetConfig().GetGracefulStop()
 	if parentCtx.Err() == nil && gracefulStop > 0 {
 		p, right := snapshot()
 		logger.WithField("gracefulStop", gracefulStop).Debug(

--- a/ui/pb/helpers.go
+++ b/ui/pb/helpers.go
@@ -129,3 +129,16 @@ func GetFixedLengthDuration(d, maxDuration time.Duration) (result string) {
 
 	return string(buf[i:])
 }
+
+// Clampf returns the given value, "clamped" to the range [min, max].
+// This is copied from lib/util.go to avoid circular imports.
+func Clampf(val, min, max float64) float64 {
+	switch {
+	case val < min:
+		return min
+	case val > max:
+		return max
+	default:
+		return val
+	}
+}

--- a/ui/pb/progressbar.go
+++ b/ui/pb/progressbar.go
@@ -114,10 +114,10 @@ func (pb *ProgressBar) Modify(options ...ProgressBarOption) {
 	}
 }
 
-// String locks the progressbar struct for reading and calls all of its methods
+// Render locks the progressbar struct for reading and calls all of its methods
 // to assemble the progress bar and return it as a string.
-//TODO: something prettier? paddings, right-alignment of the left column, line trimming by terminal size
-func (pb *ProgressBar) String(leftPad int) string {
+// - leftPad sets the padding between the left text and the opening square bracket.
+func (pb *ProgressBar) Render(leftPad int) string {
 	pb.mutex.RLock()
 	defer pb.mutex.RUnlock()
 

--- a/ui/pb/progressbar.go
+++ b/ui/pb/progressbar.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 
 	"github.com/fatih/color"
+	"github.com/sirupsen/logrus"
 )
 
 const defaultWidth = 40
@@ -127,7 +128,7 @@ func (pb *ProgressBar) Modify(options ...ProgressBarOption) {
 //   text, as well as the padding between the text and the opening
 //   square bracket. Characters exceeding this length will be replaced
 //   with a single ellipsis. Passing <=0 disables this.
-func (pb *ProgressBar) Render(leftMax int) string {
+func (pb *ProgressBar) Render(leftMax int, logger *logrus.Logger) string {
 	pb.mutex.RLock()
 	defer pb.mutex.RUnlock()
 
@@ -142,6 +143,13 @@ func (pb *ProgressBar) Render(leftMax int) string {
 	if pb.progress != nil {
 		progress, right = pb.progress()
 		right = " " + right
+		progressClamped := Clampf(progress, 0, 1)
+		if progress != progressClamped {
+			if logger != nil {
+				logger.Warnf("progress value %.2f exceeds valid range, clamped between 0 and 1", progress)
+			}
+			progress = progressClamped
+		}
 	}
 
 	space := pb.width - 2

--- a/ui/pb/progressbar.go
+++ b/ui/pb/progressbar.go
@@ -93,20 +93,20 @@ func (pb *ProgressBar) Left() string {
 	pb.mutex.RLock()
 	defer pb.mutex.RUnlock()
 
-	return pb.renderLeft(0, 0)
+	return pb.renderLeft(0)
 }
 
 // renderLeft renders the left part of the progressbar, applying the
 // given padding and trimming text exceeding maxLen length,
 // replacing it with an ellipsis.
-func (pb *ProgressBar) renderLeft(pad, maxLen int) string {
+func (pb *ProgressBar) renderLeft(maxLen int) string {
 	var left string
 	if pb.left != nil {
 		l := pb.left()
 		if maxLen > 0 && len(l) > maxLen {
 			l = l[:maxLen-3] + "..."
 		}
-		padFmt := fmt.Sprintf("%%-%ds", pad)
+		padFmt := fmt.Sprintf("%%-%ds", maxLen)
 		left = fmt.Sprintf(padFmt, l)
 	}
 	return left
@@ -123,12 +123,11 @@ func (pb *ProgressBar) Modify(options ...ProgressBarOption) {
 
 // Render locks the progressbar struct for reading and calls all of its methods
 // to assemble the progress bar and return it as a string.
-// - leftPad sets the padding between the left text and the opening
-//   square bracket.
-// - leftMax sets the maximum character length of the left text.
-//   Characters exceeding this length will be replaced with a single ellipsis.
-//   Passing <=0 disables trimming.
-func (pb *ProgressBar) Render(leftPad, leftMax int) string {
+// - leftMax defines the maximum character length of the left-side
+//   text, as well as the padding between the text and the opening
+//   square bracket. Characters exceeding this length will be replaced
+//   with a single ellipsis. Passing <=0 disables this.
+func (pb *ProgressBar) Render(leftMax int) string {
 	pb.mutex.RLock()
 	defer pb.mutex.RUnlock()
 
@@ -165,5 +164,5 @@ func (pb *ProgressBar) Render(leftPad, leftMax int) string {
 	}
 
 	return fmt.Sprintf("%s [%s%s%s]%s",
-		pb.renderLeft(leftPad, leftMax), filling, caret, padding, right)
+		pb.renderLeft(leftMax), filling, caret, padding, right)
 }

--- a/ui/pb/progressbar.go
+++ b/ui/pb/progressbar.go
@@ -35,9 +35,10 @@ const defaultBarColor = color.Faint
 // ProgressBar is just a simple thread-safe progressbar implementation with
 // callbacks.
 type ProgressBar struct {
-	mutex sync.RWMutex
-	width int
-	color *color.Color
+	mutex  sync.RWMutex
+	width  int
+	color  *color.Color
+	logger *logrus.Entry
 
 	left     func() string
 	progress func() (progress float64, right string)
@@ -58,6 +59,11 @@ func WithConstLeft(left string) ProgressBarOption {
 	return func(pb *ProgressBar) {
 		pb.left = func() string { return left }
 	}
+}
+
+// WithLogger modifies the logger instance
+func WithLogger(logger *logrus.Entry) ProgressBarOption {
+	return func(pb *ProgressBar) { pb.logger = logger }
 }
 
 // WithProgress modifies the progress calculation function.
@@ -128,7 +134,7 @@ func (pb *ProgressBar) Modify(options ...ProgressBarOption) {
 //   text, as well as the padding between the text and the opening
 //   square bracket. Characters exceeding this length will be replaced
 //   with a single ellipsis. Passing <=0 disables this.
-func (pb *ProgressBar) Render(leftMax int, logger *logrus.Logger) string {
+func (pb *ProgressBar) Render(leftMax int) string {
 	pb.mutex.RLock()
 	defer pb.mutex.RUnlock()
 
@@ -145,10 +151,10 @@ func (pb *ProgressBar) Render(leftMax int, logger *logrus.Logger) string {
 		right = " " + right
 		progressClamped := Clampf(progress, 0, 1)
 		if progress != progressClamped {
-			if logger != nil {
-				logger.Warnf("progress value %.2f exceeds valid range, clamped between 0 and 1", progress)
-			}
 			progress = progressClamped
+			if pb.logger != nil {
+				pb.logger.Warnf("progress value %.2f exceeds valid range, clamped between 0 and 1", progress)
+			}
 		}
 	}
 

--- a/ui/pb/progressbar_test.go
+++ b/ui/pb/progressbar_test.go
@@ -79,7 +79,7 @@ func TestProgressBarRender(t *testing.T) {
 		t.Run(tc.expected, func(t *testing.T) {
 			pbar := New(tc.options...)
 			assert.NotNil(t, pbar)
-			assert.Equal(t, tc.expected, pbar.Render(0, 0))
+			assert.Equal(t, tc.expected, pbar.Render(0))
 		})
 	}
 }
@@ -87,18 +87,15 @@ func TestProgressBarRender(t *testing.T) {
 func TestProgressBarRenderPaddingMaxLeft(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
-		padding  int
 		maxLen   int
 		left     string
 		expected string
 	}{
-		{-1, 0, "left", "left [--------------------------------------]"},
-		{0, 0, "left", "left [--------------------------------------]"},
-		{10, 0, "left", "left       [--------------------------------------]"},
-		{0, 10, "left_truncated",
+		{-1, "left", "left [--------------------------------------]"},
+		{0, "left", "left [--------------------------------------]"},
+		{10, "left", "left       [--------------------------------------]"},
+		{10, "left_truncated",
 			"left_tr... [--------------------------------------]"},
-		{20, 10, "left_truncated_padding",
-			"left_tr...           [--------------------------------------]"},
 	}
 
 	for _, tc := range testCases {
@@ -106,7 +103,7 @@ func TestProgressBarRenderPaddingMaxLeft(t *testing.T) {
 		t.Run(tc.left, func(t *testing.T) {
 			pbar := New(WithLeft(func() string { return tc.left }))
 			assert.NotNil(t, pbar)
-			assert.Equal(t, tc.expected, pbar.Render(tc.padding, tc.maxLen))
+			assert.Equal(t, tc.expected, pbar.Render(tc.maxLen))
 		})
 	}
 }

--- a/ui/pb/progressbar_test.go
+++ b/ui/pb/progressbar_test.go
@@ -21,11 +21,19 @@
 package pb
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// XXX: This introduces an import cycle: pb -> lib -> pb
+// func getTestLogger() *logger.Entry {
+// 	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.WarnLevel}}
+// 	testLog := logrus.New()
+// 	testLog.AddHook(logHook)
+// 	testLog.SetOutput(ioutil.Discard)
+// 	return logrus.NewEntry(testLog)
+// }
 
 func TestProgressBarRender(t *testing.T) {
 	t.Parallel()
@@ -57,12 +65,12 @@ func TestProgressBarRender(t *testing.T) {
 			WithLeft(func() string { return "left" }),
 			WithProgress(func() (float64, string) { return -1, "right" }),
 		},
-			"left [" + strings.Repeat("-", 76) + "] right"},
+			"left [--------------------------------------] right"},
 		{[]ProgressBarOption{
 			WithLeft(func() string { return "left" }),
 			WithProgress(func() (float64, string) { return 2, "right" }),
 		},
-			"left [" + strings.Repeat("=", 76) + "] right"},
+			"left [======================================] right"},
 		{[]ProgressBarOption{
 			WithLeft(func() string { return "left" }),
 			WithConstProgress(0.2, "constProgress"),
@@ -79,13 +87,14 @@ func TestProgressBarRender(t *testing.T) {
 		t.Run(tc.expected, func(t *testing.T) {
 			pbar := New(tc.options...)
 			assert.NotNil(t, pbar)
-			assert.Equal(t, tc.expected, pbar.Render(0))
+			assert.Equal(t, tc.expected, pbar.Render(0, nil))
 		})
 	}
 }
 
 func TestProgressBarRenderPaddingMaxLeft(t *testing.T) {
 	t.Parallel()
+
 	testCases := []struct {
 		maxLen   int
 		left     string
@@ -93,7 +102,8 @@ func TestProgressBarRenderPaddingMaxLeft(t *testing.T) {
 	}{
 		{-1, "left", "left [--------------------------------------]"},
 		{0, "left", "left [--------------------------------------]"},
-		{10, "left", "left       [--------------------------------------]"},
+		{15, "left_pad",
+			"left_pad        [--------------------------------------]"},
 		{10, "left_truncated",
 			"left_tr... [--------------------------------------]"},
 	}
@@ -103,7 +113,7 @@ func TestProgressBarRenderPaddingMaxLeft(t *testing.T) {
 		t.Run(tc.left, func(t *testing.T) {
 			pbar := New(WithLeft(func() string { return tc.left }))
 			assert.NotNil(t, pbar)
-			assert.Equal(t, tc.expected, pbar.Render(tc.maxLen))
+			assert.Equal(t, tc.expected, pbar.Render(tc.maxLen, nil))
 		})
 	}
 }

--- a/ui/pb/progressbar_test.go
+++ b/ui/pb/progressbar_test.go
@@ -20,4 +20,109 @@
 
 package pb
 
-//TODO
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProgressBarRender(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		options  []ProgressBarOption
+		expected string
+	}{
+		{[]ProgressBarOption{WithLeft(func() string { return "left" })},
+			"left [--------------------------------------]"},
+		{[]ProgressBarOption{WithConstLeft("constLeft")},
+			"constLeft [--------------------------------------]"},
+		{[]ProgressBarOption{
+			WithLeft(func() string { return "left" }),
+			WithProgress(func() (float64, string) { return 0, "right" }),
+		},
+			"left [--------------------------------------] right"},
+		{[]ProgressBarOption{
+			WithLeft(func() string { return "left" }),
+			WithProgress(func() (float64, string) { return 0.5, "right" }),
+		},
+			"left [==================>-------------------] right"},
+		{[]ProgressBarOption{
+			WithLeft(func() string { return "left" }),
+			WithProgress(func() (float64, string) { return 1.0, "right" }),
+		},
+			"left [======================================] right"},
+		{[]ProgressBarOption{
+			WithLeft(func() string { return "left" }),
+			WithProgress(func() (float64, string) { return -1, "right" }),
+		},
+			"left [" + strings.Repeat("-", 76) + "] right"},
+		{[]ProgressBarOption{
+			WithLeft(func() string { return "left" }),
+			WithProgress(func() (float64, string) { return 2, "right" }),
+		},
+			"left [" + strings.Repeat("=", 76) + "] right"},
+		{[]ProgressBarOption{
+			WithLeft(func() string { return "left" }),
+			WithConstProgress(0.2, "constProgress"),
+		},
+			"left [======>-------------------------------] constProgress"},
+		{[]ProgressBarOption{
+			WithHijack(func() string { return "progressbar hijack!" }),
+		},
+			"progressbar hijack!"},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.expected, func(t *testing.T) {
+			pbar := New(tc.options...)
+			assert.NotNil(t, pbar)
+			assert.Equal(t, tc.expected, pbar.String(0))
+		})
+	}
+}
+
+func TestProgressBarRenderPaddingLeft(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		padding  int
+		expected string
+	}{
+		{-1, "left [--------------------------------------]"},
+		{0, "left [--------------------------------------]"},
+		{10, "left       [--------------------------------------]"},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.expected, func(t *testing.T) {
+			pbar := New(WithLeft(func() string { return "left" }))
+			assert.NotNil(t, pbar)
+			assert.Equal(t, tc.expected, pbar.String(tc.padding))
+		})
+	}
+}
+
+func TestProgressBarLeft(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		left     func() string
+		expected string
+	}{
+		{nil, ""},
+		{func() string { return " left " }, " left "},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.expected, func(t *testing.T) {
+			pbar := New(WithLeft(tc.left))
+			assert.NotNil(t, pbar)
+			assert.Equal(t, tc.expected, pbar.Left())
+		})
+	}
+}

--- a/ui/pb/progressbar_test.go
+++ b/ui/pb/progressbar_test.go
@@ -79,29 +79,34 @@ func TestProgressBarRender(t *testing.T) {
 		t.Run(tc.expected, func(t *testing.T) {
 			pbar := New(tc.options...)
 			assert.NotNil(t, pbar)
-			assert.Equal(t, tc.expected, pbar.Render(0))
+			assert.Equal(t, tc.expected, pbar.Render(0, 0))
 		})
 	}
 }
 
-func TestProgressBarRenderPaddingLeft(t *testing.T) {
+func TestProgressBarRenderPaddingMaxLeft(t *testing.T) {
 	t.Parallel()
-
 	testCases := []struct {
 		padding  int
+		maxLen   int
+		left     string
 		expected string
 	}{
-		{-1, "left [--------------------------------------]"},
-		{0, "left [--------------------------------------]"},
-		{10, "left       [--------------------------------------]"},
+		{-1, 0, "left", "left [--------------------------------------]"},
+		{0, 0, "left", "left [--------------------------------------]"},
+		{10, 0, "left", "left       [--------------------------------------]"},
+		{0, 10, "left_truncated",
+			"left_tr... [--------------------------------------]"},
+		{20, 10, "left_truncated_padding",
+			"left_tr...           [--------------------------------------]"},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
-		t.Run(tc.expected, func(t *testing.T) {
-			pbar := New(WithLeft(func() string { return "left" }))
+		t.Run(tc.left, func(t *testing.T) {
+			pbar := New(WithLeft(func() string { return tc.left }))
 			assert.NotNil(t, pbar)
-			assert.Equal(t, tc.expected, pbar.Render(tc.padding))
+			assert.Equal(t, tc.expected, pbar.Render(tc.padding, tc.maxLen))
 		})
 	}
 }

--- a/ui/pb/progressbar_test.go
+++ b/ui/pb/progressbar_test.go
@@ -26,7 +26,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// XXX: This introduces an import cycle: pb -> lib -> pb
+// TODO(imiric): Consider adding logging tests for 100% pb coverage.
+// Unfortunately the following introduces an import cycle: pb -> lib -> pb
 // func getTestLogger() *logger.Entry {
 // 	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.WarnLevel}}
 // 	testLog := logrus.New()
@@ -87,7 +88,7 @@ func TestProgressBarRender(t *testing.T) {
 		t.Run(tc.expected, func(t *testing.T) {
 			pbar := New(tc.options...)
 			assert.NotNil(t, pbar)
-			assert.Equal(t, tc.expected, pbar.Render(0, nil))
+			assert.Equal(t, tc.expected, pbar.Render(0))
 		})
 	}
 }
@@ -113,7 +114,7 @@ func TestProgressBarRenderPaddingMaxLeft(t *testing.T) {
 		t.Run(tc.left, func(t *testing.T) {
 			pbar := New(WithLeft(func() string { return tc.left }))
 			assert.NotNil(t, pbar)
-			assert.Equal(t, tc.expected, pbar.Render(tc.maxLen, nil))
+			assert.Equal(t, tc.expected, pbar.Render(tc.maxLen))
 		})
 	}
 }

--- a/ui/pb/progressbar_test.go
+++ b/ui/pb/progressbar_test.go
@@ -79,7 +79,7 @@ func TestProgressBarRender(t *testing.T) {
 		t.Run(tc.expected, func(t *testing.T) {
 			pbar := New(tc.options...)
 			assert.NotNil(t, pbar)
-			assert.Equal(t, tc.expected, pbar.String(0))
+			assert.Equal(t, tc.expected, pbar.Render(0))
 		})
 	}
 }
@@ -101,7 +101,7 @@ func TestProgressBarRenderPaddingLeft(t *testing.T) {
 		t.Run(tc.expected, func(t *testing.T) {
 			pbar := New(WithLeft(func() string { return "left" }))
 			assert.NotNil(t, pbar)
-			assert.Equal(t, tc.expected, pbar.String(tc.padding))
+			assert.Equal(t, tc.expected, pbar.Render(tc.padding))
 		})
 	}
 }


### PR DESCRIPTION
This fixes a few alignment issues with the new progress bars:
- Dynamic padding-right of the left progress bar text; aligning all progress bars, making them easier to read.
- Trimming of long left progress bar text and replacing it with ellipsis. Currently fixed at 30 chars, this will be made configurable/dynamic in follow up PRs that deal with `cmd/ui`.
- Unit tests for all, so now `ui/pb` has 100% coverage! :tada:
- A few small refactors, see the commits.

Some comments:
- `ProgressBar` no longer implements `fmt.Stringer`. The interface was restricting what needed to be a more flexible `Render()` method. We can still wrap this in a `String()` method, calling it with some sane defaults, but I didn't think it was necessary, as nothing currently uses it.
- The additional locking needed in `ProgressBar.Left()` is unfortunate, but I needed a clean way of getting just the left text, to determine the padding amount. I'm not entirely happy with how it turned out, so let me know if it can be improved (removal of locking, maybe removing it from the main render loop?).

Part of #1279