### PR TITLE
add ExportBytes allowing use of Uint8Array for binary requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,10 +8,10 @@ labels: bug
 
 ## Environment
 <!--- Provide as much information about your environment as possible: output from `k6 version`,
-      OCI runtime and image information if using containers, etc. -->
+      OCI runtime and image information if using containers, cloud execution environment, etc. -->
 - k6 version:
 - OS and version:
-- Docker version and image:
+- Docker version and image, if applicable:
 
 
 ## Expected Behavior

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Use this template for reporting bugs. Please search existing issues first.
+labels: bug
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Environment
+<!--- Output from `k6 version`, e.g. `k6 v0.26.0-dev (dev build, go1.13.4, linux/amd64)` -->
+- k6 version:
+
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+
+## Actual Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+
+
+## Steps to Reproduce the Problem
+<!--- Provide the exact commands, environment variables and relevant script(s) to reproduce this bug. -->
+
+1.
+2.
+3.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,8 +7,11 @@ labels: bug
 <!--- Provide a general summary of the issue in the Title above -->
 
 ## Environment
-<!--- Output from `k6 version`, e.g. `k6 v0.26.0-dev (dev build, go1.13.4, linux/amd64)` -->
+<!--- Provide as much information about your environment as possible: output from `k6 version`,
+      OCI runtime and image information if using containers, etc. -->
 - k6 version:
+- OS and version:
+- Docker version and image:
 
 
 ## Expected Behavior

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: k6 Community Forum
+    url: https://community.k6.io/
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/feat_req.md
+++ b/.github/ISSUE_TEMPLATE/feat_req.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Use this template for suggesting new features.
+labels: feature
+---
+
+<!--- Provide a general summary of the feature in the Title above -->
+
+## Feature Description
+<!--- Describe the feature in detail: what benefits it would have, which problem it would solve, use cases, examples, etc. -->
+
+
+## Suggested Solution (optional)
+<!--- Any implementation suggestions you might have: technical details, design tradeoffs, API proposals, etc. -->

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk --no-cache add git
 RUN CGO_ENABLED=0 go install -a -trimpath -ldflags "-s -w -X github.com/loadimpact/k6/lib/consts.VersionDetails=$(date -u +"%FT%T%z")/$(git describe --always --long --dirty)"
 
 FROM alpine:3.10
-RUN apk add --no-cache ca-certificates curl && \
+RUN apk add --no-cache ca-certificates && \
     adduser -D -u 12345 -g 12345 k6
 COPY --from=builder /go/bin/k6 /usr/bin/k6
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ RUN apk --no-cache add git
 RUN CGO_ENABLED=0 go install -a -trimpath -ldflags "-s -w -X github.com/loadimpact/k6/lib/consts.VersionDetails=$(date -u +"%FT%T%z")/$(git describe --always --long --dirty)"
 
 FROM alpine:3.10
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates curl && \
+    adduser -D -u 12345 -g 12345 k6
 COPY --from=builder /go/bin/k6 /usr/bin/k6
+
+USER 12345
 ENTRYPOINT ["k6"]

--- a/README.md
+++ b/README.md
@@ -344,18 +344,13 @@ k6 comes with several built-in modules for things like making (and measuring) [H
 You can, of course, also write your own ES6 modules and `import` them in your scripts, potentially reusing code across an organization. The situation with importing JavaScript libraries is a bit more complicated. You can potentially use **some** JS libraries in k6, even ones intended for Node.js if you use browserify, though if they depend on network/OS-related APIs, they likely won't work. You can find more details and instructions about writing or importing JS modules [here](https://docs.k6.io/docs/modules).
 
 
-Need help or want to contribute?
---------------------------------
+Support
+-------
 
-Types of questions and where to ask:
+To get help about usage, report bugs, suggest features, and discuss k6 with other users see [SUPPORT.md](SUPPORT.md).
 
-- How do I? -- [Stack Overflow](https://stackoverflow.com/questions/tagged/k6) (use tags: k6, javascript, load-testing) or the Discourse forum at [community.k6.io](https://community.k6.io/)
-- I got this error, why? -- [Stack Overflow](https://stackoverflow.com/questions/tagged/k6) or [community.k6.io](https://community.k6.io/)
-- I got this error and I'm sure it's a bug -- [file an issue](https://github.com/loadimpact/k6/issues)
-- I have an idea/request -- [file an issue](https://github.com/loadimpact/k6/issues)
-- Why do you? -- [Slack](https://k6.io/slack)
-- When will you? -- [Slack](https://k6.io/slack)
 
-If your questions are about any of the commercial Load Impact services like managed cloud execution and Load Impact Insights, you can contact <support@loadimpact.com> or write in the `#loadimpact` channel in [Slack](https://k6.io/slack).
+Contributing
+------------
 
 If you want to contribute or help with the development of k6, start by reading [CONTRIBUTING.md](https://github.com/loadimpact/k6/blob/master/CONTRIBUTING.md). Before you start coding, especially when it comes to big changes and features, it might be a good idea to first discuss your plans and implementation details with the k6 maintainers. You can do this either in the [github issue](https://github.com/loadimpact/k6/issues) for the problem you're solving (create one if it doesn't exist) or in the `#developers` channel on [Slack](https://k6.io/slack).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,12 @@
+# Support
+
+Types of questions and where to ask:
+
+- How do I? -- the Discourse forum at [community.k6.io](https://community.k6.io/) or [Stack Overflow](https://stackoverflow.com/questions/tagged/k6) (use tags: k6, javascript, load-testing)
+- I got this error, why? -- [community.k6.io](https://community.k6.io/) or [Stack Overflow](https://stackoverflow.com/questions/tagged/k6)
+- I got this error and I'm sure it's a bug -- [file an issue](https://github.com/loadimpact/k6/issues)
+- I have an idea/request -- [file an issue](https://github.com/loadimpact/k6/issues)
+- Why do you? -- [Slack](https://k6.io/slack)
+- When will you? -- [Slack](https://k6.io/slack)
+
+If your questions are about any of the commercial Load Impact services like managed cloud execution and Load Impact Insights, you can contact <support@loadimpact.com> or write in the `#loadimpact` channel in [Slack](https://k6.io/slack).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,9 +4,9 @@ Types of questions and where to ask:
 
 - How do I? -- the Discourse forum at [community.k6.io](https://community.k6.io/) or [Stack Overflow](https://stackoverflow.com/questions/tagged/k6) (use tags: k6, javascript, load-testing)
 - I got this error, why? -- [community.k6.io](https://community.k6.io/) or [Stack Overflow](https://stackoverflow.com/questions/tagged/k6)
-- I got this error and I'm sure it's a bug -- [file an issue](https://github.com/loadimpact/k6/issues)
-- I have an idea/request -- [file an issue](https://github.com/loadimpact/k6/issues)
-- Why do you? -- [Slack](https://k6.io/slack)
-- When will you? -- [Slack](https://k6.io/slack)
+- I got this error and I'm sure it's a bug -- [open a new issue](https://github.com/loadimpact/k6/issues), if there isn't one for this specific bug already
+- I have an idea/request -- search the [GitHub issues](https://github.com/loadimpact/k6/issues) to see if it wasn't requested already - give the issue a :+1: if it was, create a new one if it wasn't
+- Why do you? -- [community.k6.io](https://community.k6.io/) or [Slack](https://k6.io/slack)
+- When will you? -- [community.k6.io](https://community.k6.io/) or [Slack](https://k6.io/slack)
 
 If your questions are about any of the commercial Load Impact services like managed cloud execution and Load Impact Insights, you can contact <support@loadimpact.com> or write in the `#loadimpact` channel in [Slack](https://k6.io/slack).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -5,7 +5,7 @@ Types of questions and where to ask:
 - How do I? -- the Discourse forum at [community.k6.io](https://community.k6.io/) or [Stack Overflow](https://stackoverflow.com/questions/tagged/k6) (use tags: k6, javascript, load-testing)
 - I got this error, why? -- [community.k6.io](https://community.k6.io/) or [Stack Overflow](https://stackoverflow.com/questions/tagged/k6)
 - I got this error and I'm sure it's a bug -- [open a new issue](https://github.com/loadimpact/k6/issues), if there isn't one for this specific bug already
-- I have an idea/request -- search the [GitHub issues](https://github.com/loadimpact/k6/issues) to see if it wasn't requested already - give the issue a :+1: if it was, create a new one if it wasn't
+- I have an idea/request -- search the [GitHub issues](https://github.com/loadimpact/k6/issues) to see if it was already requested and give the issue a :+1: if so. If it wasn't, search [community.k6.io](https://community.k6.io/) or post a forum thread to discuss the idea with the developers before creating a GitHub issue.
 - Why do you? -- [community.k6.io](https://community.k6.io/) or [Slack](https://k6.io/slack)
 - When will you? -- [community.k6.io](https://community.k6.io/) or [Slack](https://k6.io/slack)
 

--- a/js/common/export.go
+++ b/js/common/export.go
@@ -1,0 +1,87 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2016 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package common
+
+import (
+	"github.com/dop251/goja"
+)
+
+func ExportBytes(rt *goja.Runtime, val goja.Value) interface {} {
+	// Inspect val to see if it is a Uint8Array. If along the way anything doesn't look right, bail out
+	// with val.Export().
+	if val == nil {
+		return val
+	}
+	obj, isObj := val.(*goja.Object)
+	if !isObj {
+		return val.Export()
+	}
+	// fmt.Printf("ClassName: %s\n", obj.ClassName())
+	constructor := obj.Get("constructor")
+	if constructor == nil {
+		return val.Export()
+	}
+	consObj := constructor.ToObject(rt)
+	if consObj == nil {
+		return val.Export()
+	}
+	consName := consObj.Get("name")
+	if consName == nil {
+		return val.Export()
+	}
+	consNameToStr := consName.ToString()
+	if consNameToStr == nil {
+		return val.Export()
+	}
+	consNameStr := consNameToStr.String()
+	if consNameStr != "Uint8Array" {
+		return val.Export()
+	}
+	byteLengthVal := obj.Get("byteLength")
+	forEachVal := obj.Get("forEach")
+	if byteLengthVal == nil || forEachVal == nil {
+		return val.Export()
+	}
+
+	// Setup a buffer and associated accumulator callback, then invoke obj.forEach to accumulate the bytes.
+	buf := make([]byte, byteLengthVal.ToInteger())
+	forEachFunc, goodForEach := forEachVal.Export().(func(goja.FunctionCall) goja.Value)
+	if !goodForEach {
+		return val.Export()
+	}
+	accumulatorIndex := 0
+	accumulator := func(call goja.FunctionCall) goja.Value {
+		buf[accumulatorIndex] = byte(call.Argument(0).ToInteger())
+		accumulatorIndex++
+		return nil
+	}
+	forEachFunc(goja.FunctionCall{
+		This:      obj,
+		Arguments: []goja.Value{rt.ToValue(accumulator)},
+	})
+
+	// alternative implementation without forEach
+	// for i:=0; i< len(buf); i++ {
+	// 	buf[i] = byte(obj.Get(strconv.Itoa(i)).ToInteger())
+	// }
+	return buf
+}
+

--- a/js/common/export_test.go
+++ b/js/common/export_test.go
@@ -223,6 +223,18 @@ func BenchmarkExportBytes(b *testing.B) {
 			assert.NoError(b, err)
 		}
 	})
+	b.Run("allocate ArrayBuffer(1000)", func(b *testing.B) {
+		jsSrc := `
+			var asdf = new ArrayBuffer(1000);
+			`
+		pgm, err := goja.Compile("testing", jsSrc, true)
+		assert.NoError(b, err)
+		b.ResetTimer()
+		for i:= 0; i<b.N; i++ {
+			_, err = rt.RunProgram(pgm)
+			assert.NoError(b, err)
+		}
+	})
 	b.Run("call example.byteSlice(1000)", func(b *testing.B) {
 		jsSrc := `
 			var asdf = example.byteSlice(1000);

--- a/js/common/export_test.go
+++ b/js/common/export_test.go
@@ -1,0 +1,286 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2016 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package common
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/dop251/goja"
+	jslib "github.com/loadimpact/k6/js/lib"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExportBytes(t *testing.T) {
+	nativeTests := []struct {
+		name string
+		arg  interface{}
+	}{
+		{
+			name: "native call - []byte",
+			arg:  []byte{1, 2, 3, 4, 5},
+		},
+		{
+			name: "native call - string",
+			arg:  "test",
+		},
+	}
+	for _, tt := range nativeTests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := goja.New()
+			val := rt.ToValue(tt.arg)
+			if got := ExportBytes(rt, val); !reflect.DeepEqual(got, tt.arg) {
+				t.Errorf("ExportBytes() = %v, want %v", got, tt.arg)
+			}
+		})
+	}
+
+	jsTests := []struct {
+		name    string
+		jsCode  string
+		jsVarName string
+		want    interface{}
+	}{
+		{
+			name:    "empty Uint8Array",
+			jsCode:  `var buf = new Uint8Array(0);`,
+			jsVarName: "buf",
+			want:    []byte{},
+		},
+		{
+			name:    "uninitialized Uint8Array",
+			jsCode:  `var buf = new Uint8Array(3);`,
+			jsVarName: "buf",
+			want:    []byte{0,0,0},
+		},
+		{
+			name:    "initialized Uint8Array",
+			jsCode:  `var buf = new Uint8Array(3); buf[0]=0; buf[1]=1; buf[2]=2;`,
+			jsVarName: "buf",
+			want:    []byte{0,1,2},
+		},
+		{
+			name:    "js string",
+			jsCode:  `var buf = "abc";`,
+			jsVarName: "buf",
+			want:    "abc",
+		},
+		{
+			name:    "js object",
+			jsCode:  `var buf = new Object();`,
+			jsVarName: "buf",
+			want:    make(map[string]interface{}),
+		},
+	}
+
+	for _, tt := range jsTests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := goja.New()
+			// need core js for Uint8Array
+			_, err := rt.RunProgram(jslib.GetCoreJS())
+			assert.NoError(t, err)
+			_, err = rt.RunString(tt.jsCode)
+			assert.NoError(t, err)
+			jsVal := rt.Get(tt.jsVarName)
+			got := ExportBytes(rt, jsVal)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ExportBytes() = %v, want %v", got, tt.want)
+			}
+		})
+
+	}
+}
+
+type example struct {}
+func (*example) ByteSlice(ctx context.Context, size int) (goja.Value, error) {
+	b := make([]byte, size)
+	return GetRuntime(ctx).ToValue(b), nil
+}
+
+// example results from benchmark:
+// BenchmarkExportBytes/string_baseline_Export-8                            34433214           33.7 ns/op
+// BenchmarkExportBytes/string(1)-8                                         36619372           35.4 ns/op
+// BenchmarkExportBytes/Uint8Array(1)-8                                        97584        11225 ns/op
+// BenchmarkExportBytes/Uint8Array(1000)-8                                       225      5303649 ns/op
+// BenchmarkExportBytes/Uint8Array(1000000)-8                                      2    578171708 ns/op
+// BenchmarkExportBytes/[]byte(1)-8                                          5297571          228 ns/op
+// BenchmarkExportBytes/[]byte(1000)-8                                       5516696          255 ns/op
+// BenchmarkExportBytes/largeByteSliceAllocatedViaByteSlice-8                5299710          249 ns/op
+// BenchmarkExportBytes/allocate_Uint8Array(1)-8                               40939        31815 ns/op
+// BenchmarkExportBytes/allocate_Uint8Array(1000)-8                              205      5887581 ns/op
+// BenchmarkExportBytes/call_example.byteSlice(1000)-8                        213500         5635 ns/op
+// BenchmarkExportBytes/forEach_Uint8Array(1000)_to_Uint8Array(1000)-8           117     10801693 ns/op
+// BenchmarkExportBytes/forEach_Uint8Array(1000)_to_[]byte(1000)-8               220      5712987 ns/op
+// BenchmarkExportBytes/[]byte(1000)_set_bytes-8                                1910       568346 ns/op
+// BenchmarkExportBytes/example.byteSlice(1000)_set_bytes-8                     1934       568199 ns/op
+
+func BenchmarkExportBytes(b *testing.B) {
+	rt := goja.New()
+	rt.SetFieldNameMapper(FieldNameMapper{})
+	ctx := context.Background()
+	ctx = WithRuntime(ctx, rt)
+	rt.Set("example", Bind(rt, &example{}, &ctx))
+	_, err := rt.RunProgram(jslib.GetCoreJS())
+	assert.NoError(b, err)
+	_, err = rt.RunString(`
+		var str = "1";
+		var smallArray = new Uint8Array(1);
+		var largeArray = new Uint8Array(1000);
+		var largeArray2 = new Uint8Array(largeArray.byteLength);
+		var mbArray = new Uint8Array(100000);
+		var largeByteSliceAllocatedViaByteSlice = example.byteSlice(1000);
+	`)
+	assert.NoError(b, err)
+	rt.Set("smallByteSlice", make([]byte, 1))
+	rt.Set("largeByteSlice", make([]byte, 1000))
+	smallArray := rt.Get("smallArray")
+	str := rt.Get("str")
+	largeArray := rt.Get("largeArray")
+	mbArray := rt.Get("mbArray")
+	largeByteSliceAllocatedViaByteSlice := rt.Get("largeByteSliceAllocatedViaByteSlice")
+	smallByteSlice := rt.Get("smallByteSlice")
+	largeByteSlice := rt.Get("largeByteSlice")
+	b.Run("string baseline Export", func(b *testing.B) {
+		for i:= 0; i<b.N; i++ {
+			_ = str.Export()
+		}
+	})
+	b.Run("string(1)", func(b *testing.B) {
+		for i:= 0; i<b.N; i++ {
+			_ = ExportBytes(rt, str)
+		}
+	})
+	b.Run("Uint8Array(1)", func(b *testing.B) {
+		for i:= 0; i<b.N; i++ {
+			_ = ExportBytes(rt, smallArray)
+		}
+	})
+	b.Run("Uint8Array(1000)", func(b *testing.B) {
+		for i:= 0; i<b.N; i++ {
+			_ = ExportBytes(rt, largeArray)
+		}
+	})
+	b.Run("Uint8Array(1000000)", func(b *testing.B) {
+		for i:= 0; i<b.N; i++ {
+			_ = ExportBytes(rt, mbArray)
+		}
+	})
+	b.Run("[]byte(1)", func(b *testing.B) {
+		for i:= 0; i<b.N; i++ {
+			_ = ExportBytes(rt, smallByteSlice)
+		}
+	})
+	b.Run("[]byte(1000)", func(b *testing.B) {
+		for i:= 0; i<b.N; i++ {
+			_ = ExportBytes(rt, largeByteSlice)
+		}
+	})
+	b.Run("largeByteSliceAllocatedViaByteSlice", func(b *testing.B) {
+		for i:= 0; i<b.N; i++ {
+			_ = ExportBytes(rt, largeByteSliceAllocatedViaByteSlice)
+		}
+	})
+	b.Run("allocate Uint8Array(1)", func(b *testing.B) {
+		jsSrc := `
+			var asdf = new Uint8Array(1);
+			`
+		pgm, err := goja.Compile("testing", jsSrc, true)
+		assert.NoError(b, err)
+		b.ResetTimer()
+		for i:= 0; i<b.N; i++ {
+			_, err = rt.RunProgram(pgm)
+			assert.NoError(b, err)
+		}
+	})
+	b.Run("allocate Uint8Array(1000)", func(b *testing.B) {
+		jsSrc := `
+			var asdf = new Uint8Array(1000);
+			`
+		pgm, err := goja.Compile("testing", jsSrc, true)
+		assert.NoError(b, err)
+		b.ResetTimer()
+		for i:= 0; i<b.N; i++ {
+			_, err = rt.RunProgram(pgm)
+			assert.NoError(b, err)
+		}
+	})
+	b.Run("call example.byteSlice(1000)", func(b *testing.B) {
+		jsSrc := `
+			var asdf = example.byteSlice(1000);
+			`
+		pgm, err := goja.Compile("testing", jsSrc, true)
+		assert.NoError(b, err)
+		b.ResetTimer()
+		for i:= 0; i<b.N; i++ {
+			_, err = rt.RunProgram(pgm)
+			assert.NoError(b, err)
+		}
+	})
+	b.Run("forEach Uint8Array(1000) to Uint8Array(1000)", func(b *testing.B) {
+		jsSrc := `
+			largeArray.forEach(function(x,i) { largeArray2[i] = x; });
+			`
+		pgm, err := goja.Compile("testing", jsSrc, true)
+		assert.NoError(b, err)
+		b.ResetTimer()
+		for i:= 0; i<b.N; i++ {
+			_, err = rt.RunProgram(pgm)
+			assert.NoError(b, err)
+		}
+	})
+	b.Run("forEach Uint8Array(1000) to []byte(1000)", func(b *testing.B) {
+		jsSrc := `
+			largeArray.forEach(function(x,i) { largeByteSlice[i] = x; });
+			`
+		pgm, err := goja.Compile("testing", jsSrc, true)
+		assert.NoError(b, err)
+		b.ResetTimer()
+		for i:= 0; i<b.N; i++ {
+			_, err = rt.RunProgram(pgm)
+			assert.NoError(b, err)
+		}
+	})
+	b.Run("[]byte(1000) set bytes", func(b *testing.B) {
+		jsSrc := `
+			for (var x=0; x<1000; x++) { largeByteSlice[x] = x; }
+		`
+		pgm, err := goja.Compile("testing", jsSrc, true)
+		assert.NoError(b, err)
+		b.ResetTimer()
+		for i:= 0; i<b.N; i++ {
+			_, err = rt.RunProgram(pgm)
+			assert.NoError(b, err)
+		}
+	})
+	b.Run("example.byteSlice(1000) set bytes", func(b *testing.B) {
+		jsSrc := `
+			for (var x=0; x<1000; x++) { largeByteSliceAllocatedViaByteSlice[x] = x; }
+		`
+		pgm, err := goja.Compile("testing", jsSrc, true)
+		assert.NoError(b, err)
+		b.ResetTimer()
+		for i:= 0; i<b.N; i++ {
+			_, err = rt.RunProgram(pgm)
+			assert.NoError(b, err)
+		}
+	})
+}

--- a/js/modules/k6/http/request.go
+++ b/js/modules/k6/http/request.go
@@ -96,7 +96,7 @@ func (h *HTTP) Request(ctx context.Context, method string, url goja.Value, args 
 	var params goja.Value
 
 	if len(args) > 0 {
-		body = args[0].Export()
+		body = common.ExportBytes(common.GetRuntime(ctx), args[0])
 	}
 	if len(args) > 1 {
 		params = args[1]


### PR DESCRIPTION
This PR is a starting point for discussion. (See https://github.com/loadimpact/k6/issues/1020). I implemented support for using core-js `Uint8Array`s as request body so that binary data can be sent in requests.  The caveat is that the core-js `Uint8Array` implementation is _slow_ (compared to golang byte slices).  See `BenchmarkExportBytes` where I benchmarked a few different scenarios.  If the JavaScript author just needs an array-like object that can be used for binary data, then I think k6 could proved a JS call to allocate a golang byte slice that is usable in JS (see `example.ByteSlice` func.)  This is _much_ faster than using `Uint8Array`.  The `ExportByte` function (used by `func (h *HTTP) Request()`) as it stands now supports Uint8Array but also supports []byte as well.