### PR TITLE
Refactoring lib.VU and lib.Runner

### DIFF
--- a/js/console_test.go
+++ b/js/console_test.go
@@ -123,14 +123,14 @@ func TestConsole(t *testing.T) {
 					assert.NoError(t, err)
 
 					samples := make(chan stats.SampleContainer, 100)
-					vu, err := r.newVU(samples)
+					vu, err := r.newVU(0, samples)
 					assert.NoError(t, err)
 
 					logger, hook := logtest.NewNullLogger()
 					logger.Level = logrus.DebugLevel
 					vu.Console.Logger = logger
 
-					err = vu.RunOnce(context.Background())
+					err = vu.Activate(&lib.VUActivationParams{Ctx: context.Background()}).RunOnce()
 					assert.NoError(t, err)
 
 					entry := hook.LastEntry()
@@ -215,13 +215,13 @@ func TestFileConsole(t *testing.T) {
 							assert.NoError(t, err)
 
 							samples := make(chan stats.SampleContainer, 100)
-							vu, err := r.newVU(samples)
+							vu, err := r.newVU(0, samples)
 							assert.NoError(t, err)
 
 							vu.Console.Logger.Level = logrus.DebugLevel
 							hook := logtest.NewLocal(vu.Console.Logger)
 
-							err = vu.RunOnce(context.Background())
+							err = vu.Activate(&lib.VUActivationParams{Ctx: context.Background()}).RunOnce()
 							assert.NoError(t, err)
 
 							// Test if the file was created.

--- a/js/http_bench_test.go
+++ b/js/http_bench_test.go
@@ -40,13 +40,13 @@ func BenchmarkHTTPRequests(b *testing.B) {
 			<-ch
 		}
 	}()
-	vu, err := r.NewVU(ch)
+	vu, err := r.NewVU(context.Background(), 0, ch)
 	if !assert.NoError(b, err) {
 		return
 	}
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		err = vu.RunOnce(context.Background())
+		err = vu.Activate(&lib.VUActivationParams{Ctx: context.Background()}).RunOnce()
 		assert.NoError(b, err)
 	}
 }

--- a/js/module_loading_test.go
+++ b/js/module_loading_test.go
@@ -111,9 +111,9 @@ func TestLoadOnceGlobalVars(t *testing.T) {
 				t.Run(name, func(t *testing.T) {
 					ch := newDevNullSampleChannel()
 					defer close(ch)
-					vu, err := r.NewVU(ch)
+					vu, err := r.NewVU(context.Background(), 0, ch)
 					require.NoError(t, err)
-					err = vu.RunOnce(context.Background())
+					err = vu.Activate(&lib.VUActivationParams{Ctx: context.Background()}).RunOnce()
 					require.NoError(t, err)
 				})
 			}
@@ -156,9 +156,9 @@ func TestLoadExportsIsUsableInModule(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ch := newDevNullSampleChannel()
 			defer close(ch)
-			vu, err := r.NewVU(ch)
+			vu, err := r.NewVU(context.Background(), 0, ch)
 			require.NoError(t, err)
-			err = vu.RunOnce(context.Background())
+			err = vu.Activate(&lib.VUActivationParams{Ctx: context.Background()}).RunOnce()
 			require.NoError(t, err)
 		})
 	}
@@ -200,9 +200,9 @@ func TestLoadDoesntBreakHTTPGet(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ch := newDevNullSampleChannel()
 			defer close(ch)
-			vu, err := r.NewVU(ch)
+			vu, err := r.NewVU(context.Background(), 0, ch)
 			require.NoError(t, err)
-			err = vu.RunOnce(context.Background())
+			err = vu.Activate(&lib.VUActivationParams{Ctx: context.Background()}).RunOnce()
 			require.NoError(t, err)
 		})
 	}
@@ -241,15 +241,15 @@ func TestLoadGlobalVarsAreNotSharedBetweenVUs(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ch := newDevNullSampleChannel()
 			defer close(ch)
-			vu, err := r.NewVU(ch)
+			vu, err := r.NewVU(context.Background(), 0, ch)
 			require.NoError(t, err)
-			err = vu.RunOnce(context.Background())
+			err = vu.Activate(&lib.VUActivationParams{Ctx: context.Background()}).RunOnce()
 			require.NoError(t, err)
 
 			// run a second VU
-			vu, err = r.NewVU(ch)
+			vu, err = r.NewVU(context.Background(), 0, ch)
 			require.NoError(t, err)
-			err = vu.RunOnce(context.Background())
+			err = vu.Activate(&lib.VUActivationParams{Ctx: context.Background()}).RunOnce()
 			require.NoError(t, err)
 		})
 	}
@@ -298,9 +298,9 @@ func TestLoadCycle(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ch := newDevNullSampleChannel()
 			defer close(ch)
-			vu, err := r.NewVU(ch)
+			vu, err := r.NewVU(context.Background(), 0, ch)
 			require.NoError(t, err)
-			err = vu.RunOnce(context.Background())
+			err = vu.Activate(&lib.VUActivationParams{Ctx: context.Background()}).RunOnce()
 			require.NoError(t, err)
 		})
 	}
@@ -357,9 +357,9 @@ func TestLoadCycleBinding(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ch := newDevNullSampleChannel()
 			defer close(ch)
-			vu, err := r.NewVU(ch)
+			vu, err := r.NewVU(context.Background(), 0, ch)
 			require.NoError(t, err)
-			err = vu.RunOnce(context.Background())
+			err = vu.Activate(&lib.VUActivationParams{Ctx: context.Background()}).RunOnce()
 			require.NoError(t, err)
 		})
 	}
@@ -418,9 +418,9 @@ func TestBrowserified(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ch := make(chan stats.SampleContainer, 100)
 			defer close(ch)
-			vu, err := r.NewVU(ch)
+			vu, err := r.NewVU(context.Background(), 0, ch)
 			require.NoError(t, err)
-			err = vu.RunOnce(context.Background())
+			err = vu.Activate(&lib.VUActivationParams{Ctx: context.Background()}).RunOnce()
 			require.NoError(t, err)
 		})
 	}
@@ -456,9 +456,9 @@ func TestLoadingUnexistingModuleDoesntPanic(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ch := newDevNullSampleChannel()
 			defer close(ch)
-			vu, err := r.NewVU(ch)
+			vu, err := r.NewVU(context.Background(), 0, ch)
 			require.NoError(t, err)
-			err = vu.RunOnce(context.Background())
+			err = vu.Activate(&lib.VUActivationParams{Ctx: context.Background()}).RunOnce()
 			require.NoError(t, err)
 		})
 	}

--- a/js/modules/k6/marshalling_test.go
+++ b/js/modules/k6/marshalling_test.go
@@ -134,9 +134,9 @@ func TestSetupDataMarshalling(t *testing.T) {
 	if !assert.NoError(t, runner.Setup(context.Background(), samples)) {
 		return
 	}
-	vu, err := runner.NewVU(samples)
+	vu, err := runner.NewVU(context.Background(), 0, samples)
 	if assert.NoError(t, err) {
-		err := vu.RunOnce(context.Background())
+		err := vu.Activate(&lib.VUActivationParams{Ctx: context.Background()}).RunOnce()
 		assert.NoError(t, err)
 	}
 }

--- a/js/runner.go
+++ b/js/runner.go
@@ -28,7 +28,6 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/dop251/goja"
@@ -114,15 +113,17 @@ func (r *Runner) MakeArchive() *lib.Archive {
 	return r.Bundle.makeArchive()
 }
 
-func (r *Runner) NewVU(samplesOut chan<- stats.SampleContainer) (lib.VU, error) {
-	vu, err := r.newVU(samplesOut)
+// NewVU returns a initialized VU, which is ready for work.
+func (r *Runner) NewVU(_ context.Context, id int64, samples chan<- stats.SampleContainer) (lib.InitializedVU, error) {
+	vu, err := r.newVU(id, samples)
 	if err != nil {
 		return nil, err
 	}
-	return lib.VU(vu), nil
+	return lib.InitializedVU(vu), nil
 }
 
-func (r *Runner) newVU(samplesOut chan<- stats.SampleContainer) (*VU, error) {
+//nolint: lll, funclen
+func (r *Runner) newVU(id int64, samples chan<- stats.SampleContainer) (*VU, error) {
 	// Instantiate a new bundle, make a VU out of it.
 	bi, err := r.Bundle.Instantiate()
 	if err != nil {
@@ -185,6 +186,8 @@ func (r *Runner) newVU(samplesOut chan<- stats.SampleContainer) (*VU, error) {
 	}
 
 	vu := &VU{
+		ID:             id,
+		Iteration:      0,
 		BundleInstance: *bi,
 		Runner:         r,
 		Transport:      transport,
@@ -193,8 +196,7 @@ func (r *Runner) newVU(samplesOut chan<- stats.SampleContainer) (*VU, error) {
 		TLSConfig:      tlsConfig,
 		Console:        r.console,
 		BPool:          bpool.NewBufferPool(100),
-		Samples:        samplesOut,
-		m:              &sync.Mutex{},
+		Samples:        samples,
 	}
 	vu.Runtime.Set("console", common.Bind(vu.Runtime, vu.Console, vu.Context))
 	common.BindToGlobal(vu.Runtime, map[string]interface{}{
@@ -203,10 +205,7 @@ func (r *Runner) newVU(samplesOut chan<- stats.SampleContainer) (*VU, error) {
 		},
 	})
 
-	// Give the VU an initial sense of identity.
-	if err := vu.Reconfigure(0); err != nil {
-		return nil, err
-	}
+	vu.Runtime.Set("__VU", vu.ID)
 
 	return vu, nil
 }
@@ -261,6 +260,7 @@ func (r *Runner) Teardown(ctx context.Context, out chan<- stats.SampleContainer)
 	} else {
 		data = goja.Undefined()
 	}
+
 	_, err := r.runPart(teardownCtx, out, stageTeardown, data)
 	return err
 }
@@ -298,7 +298,7 @@ func (r *Runner) SetOptions(opts lib.Options) error {
 // Runs an exported function in its own temporary VU, optionally with an argument. Execution is
 // interrupted if the context expires. No error is returned if the part does not exist.
 func (r *Runner) runPart(ctx context.Context, out chan<- stats.SampleContainer, name string, arg interface{}) (goja.Value, error) {
-	vu, err := r.newVU(out)
+	vu, err := r.newVU(0, out)
 	if err != nil {
 		return goja.Undefined(), err
 	}
@@ -368,50 +368,33 @@ type VU struct {
 
 	setupData goja.Value
 
-	// A VU will track the last context it was called with for cancellation.
-	// Note that interruptTrackedCtx is the context that is currently being tracked, while
-	// interruptCancel cancels an unrelated context that terminates the tracking goroutine
-	// without triggering an interrupt (for if the context changes).
-	// There are cleaner ways of handling the interruption problem, but this is a hot path that
-	// needs to be called thousands of times per second, which rules out anything that spawns a
-	// goroutine per call.
-	interruptTrackedCtx context.Context
-	interruptCancel     context.CancelFunc
-
-	m *sync.Mutex
+	activeCtx context.Context
 }
 
 // Verify that VU implements lib.VU
-var _ lib.VU = &VU{}
+var _ lib.InitializedVU = &VU{}
+var _ lib.ActiveVU = &VU{}
 
-func (u *VU) Reconfigure(id int64) error {
-	u.ID = id
+// Activate actives an initialized VU, return an active VU, which is ready to do the work.
+// It's the caller responsibility to pass context via lib.VUActivationParams.
+func (u *VU) Activate(params *lib.VUActivationParams) lib.ActiveVU {
 	u.Iteration = 0
-	u.Runtime.Set("__VU", u.ID)
-	return nil
+	u.activeCtx = params.Ctx
+
+	go func() {
+		<-params.Ctx.Done()
+		u.Runtime.Interrupt(errInterrupt)
+
+		if params.DeactivateCallback != nil {
+			params.DeactivateCallback()
+		}
+	}()
+
+	return u
 }
 
-func (u *VU) RunOnce(ctx context.Context) error {
-	u.m.Lock()
-	defer u.m.Unlock()
-	// Track the context and interrupt JS execution if it's cancelled.
-	if u.interruptTrackedCtx != ctx {
-		interCtx, interCancel := context.WithCancel(context.Background())
-		if u.interruptCancel != nil {
-			u.interruptCancel()
-		}
-		u.interruptCancel = interCancel
-		u.interruptTrackedCtx = ctx
-		defer interCancel()
-		go func() {
-			select {
-			case <-interCtx.Done():
-			case <-ctx.Done():
-				u.Runtime.Interrupt(errInterrupt)
-			}
-		}()
-	}
-
+// RunOnce runs the VU once.
+func (u *VU) RunOnce() error {
 	// Unmarshall the setupData only the first time for each VU so that VUs are isolated but we
 	// still don't use too much CPU in the middle test
 	if u.setupData == nil {
@@ -427,7 +410,9 @@ func (u *VU) RunOnce(ctx context.Context) error {
 	}
 
 	// Call the default function.
-	_, isFullIteration, totalTime, err := u.runFn(ctx, u.Runner.defaultGroup, true, u.Default, u.setupData)
+	_, isFullIteration, totalTime, err := u.runFn(
+		u.activeCtx, u.Runner.defaultGroup, true, u.Default, u.setupData,
+	)
 
 	// If MinIterationDuration is specified and the iteration wasn't cancelled
 	// and was less than it, sleep for the remainder
@@ -442,7 +427,11 @@ func (u *VU) RunOnce(ctx context.Context) error {
 }
 
 func (u *VU) runFn(
-	ctx context.Context, group *lib.Group, isDefault bool, fn goja.Callable, args ...goja.Value,
+	ctx context.Context,
+	group *lib.Group,
+	isDefault bool,
+	fn goja.Callable,
+	args ...goja.Value,
 ) (goja.Value, bool, time.Duration, error) {
 	cookieJar := u.CookieJar
 	if !u.Runner.Bundle.Options.NoCookiesReset.ValueOrZero() {

--- a/lib/executor/common_test.go
+++ b/lib/executor/common_test.go
@@ -33,8 +33,8 @@ func setupExecutor(t *testing.T, config lib.ExecutorConfig, runner lib.Runner) (
 	logEntry := logrus.NewEntry(testLog)
 	es := lib.NewExecutionState(lib.Options{}, 10, 50)
 
-	es.SetInitVUFunc(func(_ context.Context, logger *logrus.Entry) (lib.VU, error) {
-		return runner.NewVU(engineOut)
+	es.SetInitVUFunc(func(ctx context.Context, logger *logrus.Entry) (lib.InitializedVU, error) {
+		return runner.NewVU(ctx, 0, engineOut)
 	})
 
 	initializeVUs(ctx, t, logEntry, es, 10)
@@ -55,7 +55,7 @@ func initializeVUs(
 		vu, err := es.InitializeNewVU(ctx, logEntry)
 		require.NoError(t, err)
 		require.EqualValues(t, i+1, es.GetInitializedVUsCount())
-		es.ReturnVU(vu, false)
+		es.ReturnVU(vu)
 		require.EqualValues(t, 0, es.GetCurrentlyActiveVUsCount())
 		require.EqualValues(t, i+1, es.GetInitializedVUsCount())
 	}

--- a/lib/executor/execution_test.go
+++ b/lib/executor/execution_test.go
@@ -82,7 +82,7 @@ func TestExecutionStateGettingVUs(t *testing.T) {
 	logEntry := logrus.NewEntry(testLog)
 
 	es := lib.NewExecutionState(lib.Options{}, 10, 20)
-	es.SetInitVUFunc(func(_ context.Context, _ *logrus.Entry) (lib.VU, error) {
+	es.SetInitVUFunc(func(_ context.Context, _ *logrus.Entry) (lib.InitializedVU, error) {
 		return &testutils.MiniRunnerVU{}, nil
 	})
 
@@ -91,7 +91,7 @@ func TestExecutionStateGettingVUs(t *testing.T) {
 		vu, err := es.InitializeNewVU(context.Background(), logEntry)
 		require.NoError(t, err)
 		require.EqualValues(t, i+1, es.GetInitializedVUsCount())
-		es.ReturnVU(vu, false)
+		es.ReturnVU(vu)
 		require.EqualValues(t, 0, es.GetCurrentlyActiveVUsCount())
 		require.EqualValues(t, i+1, es.GetInitializedVUsCount())
 	}

--- a/lib/executor/helpers.go
+++ b/lib/executor/helpers.go
@@ -81,9 +81,9 @@ func validateStages(stages []Stage) []error {
 // TODO: emit the end-of-test iteration metrics here (https://github.com/loadimpact/k6/issues/1250)
 func getIterationRunner(
 	executionState *lib.ExecutionState, logger *logrus.Entry, _ chan<- stats.SampleContainer,
-) func(context.Context, lib.VU) {
-	return func(ctx context.Context, vu lib.VU) {
-		err := vu.RunOnce(ctx)
+) func(context.Context, lib.ActiveVU) {
+	return func(ctx context.Context, vu lib.ActiveVU) {
+		err := vu.RunOnce()
 
 		//TODO: track (non-ramp-down) errors from script iterations as a metric,
 		// and have a default threshold that will abort the script when the error
@@ -95,12 +95,11 @@ func getIterationRunner(
 			executionState.AddInterruptedIterations(1)
 		default:
 			if err != nil {
+				msg := err.Error()
 				if s, ok := err.(fmt.Stringer); ok {
-					logger.Error(s.String())
-				} else {
-					logger.Error(err.Error())
+					msg = s.String()
 				}
-				//TODO: investigate context cancelled errors
+				logger.Error(msg)
 			}
 
 			//TODO: move emission of end-of-iteration metrics here?

--- a/lib/executor/variable_looping_vus.go
+++ b/lib/executor/variable_looping_vus.go
@@ -525,7 +525,7 @@ func (vlv VariableLoopingVUs) Run(ctx context.Context, out chan<- stats.SampleCo
 	defer activeVUs.Wait()
 
 	runIteration := getIterationRunner(vlv.executionState, vlv.logger, out)
-	getVU := func() (lib.VU, error) {
+	getVU := func() (lib.InitializedVU, error) {
 		vu, err := vlv.executionState.GetPlannedVU(vlv.logger, true)
 		if err != nil {
 			cancel()
@@ -535,8 +535,8 @@ func (vlv VariableLoopingVUs) Run(ctx context.Context, out chan<- stats.SampleCo
 		}
 		return vu, err
 	}
-	returnVU := func(vu lib.VU) {
-		vlv.executionState.ReturnVU(vu, true)
+	returnVU := func(vu lib.InitializedVU) {
+		vlv.executionState.ReturnVU(vu)
 		atomic.AddInt64(activeVUsCount, -1)
 		activeVUs.Done()
 	}

--- a/lib/executors.go
+++ b/lib/executors.go
@@ -107,7 +107,7 @@ type ExecutorConfig interface {
 
 // InitVUFunc is just a shorthand so we don't have to type the function
 // signature every time.
-type InitVUFunc func(context.Context, *logrus.Entry) (VU, error)
+type InitVUFunc func(context.Context, *logrus.Entry) (InitializedVU, error)
 
 // Executor is the interface all executors should implement
 type Executor interface {


### PR DESCRIPTION
The complicated handling of context in RunOnce is not necessary. Each
of the new executors handles contexts and VUs very deliberately and
precisely. We can separate the context handling to interrupt goja
runtime and the actual running user's code.

This PR introduces two new interfaces, "InitializedVU" annd "ActiveVU".

InitializedVU is what Runner.NewVU will return, and is stored in
ExecutionState.vus buffer. Whenever a InitializedVU is pull from the
buffer, caller can call InitializedVU.Activate with VUActivationParams
argument. This will return an ActiveVU, which will actually run the
user's code.

The InitializedVU.Activate will spawn a goroutine to track the context
for interrupting script execution, and calling the callback function and
return the VU to the buffer.

Fixes #889
Fixes #1283