### PR TITLE
Add option to specify VU network interface

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -91,6 +91,7 @@ func optionFlagSet() *pflag.FlagSet {
 	flags.StringSlice("tag", nil, "add a `tag` to be applied to all samples, as `[name]=[value]`")
 	flags.String("console-output", "", "redirects the console logging to the provided output file")
 	flags.Bool("discard-response-bodies", false, "Read but don't process or save HTTP response bodies")
+	flags.StringP("nic", "n", "", "Use given network interface")
 	return flags
 }
 
@@ -114,6 +115,7 @@ func getOptions(flags *pflag.FlagSet) (lib.Options, error) {
 		MinIterationDuration:  getNullDuration(flags, "min-iteration-duration"),
 		Throw:                 getNullBool(flags, "throw"),
 		DiscardResponseBodies: getNullBool(flags, "discard-response-bodies"),
+		Nic:                   getNullString(flags, "nic"),
 		// Default values for options without CLI flags:
 		// TODO: find a saner and more dev-friendly and error-proof way to handle options
 		SetupTimeout:    types.NullDuration{Duration: types.Duration(60 * time.Second), Valid: false},

--- a/js/runner.go
+++ b/js/runner.go
@@ -31,7 +31,6 @@ import (
 	"net/http/cookiejar"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/dop251/goja"

--- a/js/runner.go
+++ b/js/runner.go
@@ -200,10 +200,10 @@ func (r *Runner) newVU(id int64, samplesOut chan<- stats.SampleContainer) (*VU, 
 			return nil, err
 		}
 
-		localTcpAddr := net.TCPAddr {
+		localTCPAddr := net.TCPAddr {
 			IP: randAddr.IP,
 		}
-		dialer.Dialer.localAddr = &localTcpAddr
+		dialer.Dialer.LocalAddr = &localTCPAddr
 	}
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: r.Bundle.Options.InsecureSkipTLSVerify.Bool,

--- a/js/runner.go
+++ b/js/runner.go
@@ -25,10 +25,13 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/http/cookiejar"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/dop251/goja"

--- a/lib/options.go
+++ b/lib/options.go
@@ -293,7 +293,7 @@ type Options struct {
 	// Redirect console logging to a file
 	ConsoleOutput null.String `json:"-" envconfig:"K6_CONSOLE_OUTPUT"`
 
-	Nic null.String `json:"nic" envconfig:"nic"`
+	Nic null.String `json:"nic,omitempty" envconfig:"K6_NIC"`
 }
 
 // Returns the result of overwriting any fields with any that are set on the argument.

--- a/lib/options.go
+++ b/lib/options.go
@@ -292,6 +292,8 @@ type Options struct {
 
 	// Redirect console logging to a file
 	ConsoleOutput null.String `json:"-" envconfig:"K6_CONSOLE_OUTPUT"`
+
+	Nic null.String `json:"nic" envconfig:"nic"`
 }
 
 // Returns the result of overwriting any fields with any that are set on the argument.
@@ -442,6 +444,9 @@ func (o Options) Apply(opts Options) Options {
 	}
 	if opts.ConsoleOutput.Valid {
 		o.ConsoleOutput = opts.ConsoleOutput
+	}
+	if opts.Nic.Valid {
+		o.Nic = opts.Nic
 	}
 
 	return o

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -386,6 +386,12 @@ func TestOptions(t *testing.T) {
 		assert.True(t, opts.DiscardResponseBodies.Valid)
 		assert.True(t, opts.DiscardResponseBodies.Bool)
 	})
+	t.Run("Nic", func(t *testing.T) {
+		opts := Options{}.Apply(Options{Nic: null.StringFrom("eth0")})
+		assert.True(t, opts.Nic.Valid)
+		assert.Equal(t, "eth0", opts.Nic.String)
+	})
+
 }
 
 func TestOptionsEnv(t *testing.T) {
@@ -460,6 +466,10 @@ func TestOptionsEnv(t *testing.T) {
 		},
 		// Thresholds
 		// External
+		{"Nic", "K6_NIC"}: {
+			"":     null.String{},
+			"eth0": null.StringFrom("eth0"),
+		},
 	}
 	for field, data := range testdata {
 		field, data := field, data


### PR DESCRIPTION
This adds a "nic" option (e.g. `k6 run --nic eth0`) which will cause the
Virtual User to use the IP address(es) assigned to the given network
interface. If the NIC has multiple IPs, they will be used by each VU at
random.

Credit for the original code goes to @ofauchon.

Closes GitHub issue loadimpact#476 and original PR loadimpact#757.