### PR TITLE
Fix progress bar panic for empty segment

### DIFF
--- a/ui/pb/progressbar.go
+++ b/ui/pb/progressbar.go
@@ -124,18 +124,18 @@ func (pb *ProgressBar) String() string {
 
 	filling := ""
 	caret := ""
+	padding := ""
+	// pb.progress() can make progress become NaN, cause filled overflow.
+	// So only do calculation when filled is a safe value.
 	if filled > 0 {
+		filling = strings.Repeat("=", filled)
 		if filled < space {
 			filling = strings.Repeat("=", filled-1)
 			caret = ">"
-		} else {
-			filling = strings.Repeat("=", filled)
 		}
-	}
-
-	padding := ""
-	if space > filled {
-		padding = pb.color.Sprint(strings.Repeat("-", space-filled))
+		if space > filled {
+			padding = pb.color.Sprint(strings.Repeat("-", space-filled))
+		}
 	}
 
 	return fmt.Sprintf("%s[%s%s%s]%s", left, filling, caret, padding, right)

--- a/ui/pb/progressbar_test.go
+++ b/ui/pb/progressbar_test.go
@@ -20,4 +20,21 @@
 
 package pb
 
-//TODO
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// See https://github.com/loadimpact/k6/issues/1295 for details.
+func TestProgressBarStringShouldNotPanic(t *testing.T) {
+	fmtStr := GetFixedLengthIntFormat(int64(0)) + "/%d shared iters among %d VUs"
+	progresFn := func() (float64, string) {
+		val := atomic.LoadUint64(new(uint64))
+		return float64(val) / float64(0), fmt.Sprintf(fmtStr, val, 0, 0)
+	}
+	pb := &ProgressBar{progress: progresFn, width: 40}
+	assert.NotPanics(t, func() { _ = pb.String() })
+}


### PR DESCRIPTION
For an empty segment, we currently do nothing. But the goroutine spawned
to track progress bar still run, with an invalid progress information
passed to ProgressBar.

It causes the calculation in ProgressBar.String becomes invalid due to
overflow.

To fix this, we only do calculation when we have a valid filled value.

Fixes #1295