### PR TITLE
Exclude no work executor

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -228,17 +228,17 @@ a commandline interface for interacting with it.`,
 			fprintf(stdout, "\n")
 
 			plan := execScheduler.GetExecutionPlan()
-			executors := execScheduler.GetExecutors()
+			executorConfigs := execScheduler.GetExecutorConfigs()
 			maxDuration, _ := lib.GetEndOffset(plan)
 
 			fprintf(stdout, "  execution: %s\n", ui.ValueColor.Sprintf(
-				"(%.2f%%) %d executors, %d max VUs, %s max duration (incl. graceful stop):",
-				conf.ExecutionSegment.FloatLength()*100, len(executors),
+				"(%.2f%%) %d executorConfigs, %d max VUs, %s max duration (incl. graceful stop):",
+				conf.ExecutionSegment.FloatLength()*100, len(executorConfigs),
 				lib.GetMaxPossibleVUs(plan), maxDuration),
 			)
-			for _, sched := range executors {
+			for _, ec := range executorConfigs {
 				fprintf(stdout, "           * %s: %s\n",
-					sched.GetConfig().GetName(), sched.GetConfig().GetDescription(conf.ExecutionSegment))
+					ec.GetName(), ec.GetDescription(conf.ExecutionSegment))
 			}
 			fprintf(stdout, "\n")
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -232,7 +232,7 @@ a commandline interface for interacting with it.`,
 			maxDuration, _ := lib.GetEndOffset(plan)
 
 			fprintf(stdout, "  execution: %s\n", ui.ValueColor.Sprintf(
-				"(%.2f%%) %d executorConfigs, %d max VUs, %s max duration (incl. graceful stop):",
+				"(%.2f%%) %d executors, %d max VUs, %s max duration (incl. graceful stop):",
 				conf.ExecutionSegment.FloatLength()*100, len(executorConfigs),
 				lib.GetMaxPossibleVUs(plan), maxDuration),
 			)

--- a/core/local/local.go
+++ b/core/local/local.go
@@ -68,7 +68,7 @@ func NewExecutionScheduler(runner lib.Runner, logger *logrus.Logger) (*Execution
 
 	executorConfigs := options.Execution.GetSortedConfigs()
 	executors := make([]lib.Executor, len(executorConfigs))
-	// Only take executor which has works.
+	// Only take executors which have work.
 	n := 0
 	for _, sc := range executorConfigs {
 		if !sc.HasWork(executionState.Options.ExecutionSegment) {
@@ -118,13 +118,14 @@ func (e *ExecutionScheduler) GetState() *lib.ExecutionState {
 	return e.state
 }
 
-// GetExecutors returns the slice of configured executor instances, sorted by
-// their (startTime, name) in an ascending order.
+// GetExecutors returns the slice of configured executor instances which
+// have work, sorted by their (startTime, name) in an ascending order.
 func (e *ExecutionScheduler) GetExecutors() []lib.Executor {
 	return e.executors
 }
 
-// GetExecutorConfigs returns the slice of executor configs.
+// GetExecutorConfigs returns the slice of all executor configs, sorted by
+// their (startTime, name) in an ascending order.
 func (e *ExecutionScheduler) GetExecutorConfigs() []lib.ExecutorConfig {
 	return e.executorConfigs
 }

--- a/core/local/local.go
+++ b/core/local/local.go
@@ -70,7 +70,11 @@ func NewExecutionScheduler(runner lib.Runner, logger *logrus.Logger) (*Execution
 	executors := make([]lib.Executor, 0, len(executorConfigs))
 	// Only take executors which have work.
 	for _, sc := range executorConfigs {
-		if !sc.HasWork(executionState.Options.ExecutionSegment) {
+		if !sc.HasWork(options.ExecutionSegment) {
+			logger.Warnf(
+				"Executor '%s' is disabled for segment %s due to lack of work!",
+				sc.GetName(), options.ExecutionSegment,
+			)
 			continue
 		}
 		s, err := sc.NewExecutor(executionState, logger.WithField("executor", sc.GetName()))

--- a/core/local/local.go
+++ b/core/local/local.go
@@ -67,9 +67,8 @@ func NewExecutionScheduler(runner lib.Runner, logger *logrus.Logger) (*Execution
 	maxDuration, _ := lib.GetEndOffset(executionPlan) // we don't care if the end offset is final
 
 	executorConfigs := options.Execution.GetSortedConfigs()
-	executors := make([]lib.Executor, len(executorConfigs))
+	executors := make([]lib.Executor, 0, len(executorConfigs))
 	// Only take executors which have work.
-	n := 0
 	for _, sc := range executorConfigs {
 		if !sc.HasWork(executionState.Options.ExecutionSegment) {
 			continue
@@ -78,10 +77,8 @@ func NewExecutionScheduler(runner lib.Runner, logger *logrus.Logger) (*Execution
 		if err != nil {
 			return nil, err
 		}
-		executors[n] = s
-		n++
+		executors = append(executors, s)
 	}
-	executors = executors[:n]
 
 	if options.Paused.Bool {
 		if err := executionState.Pause(); err != nil {

--- a/core/local/local.go
+++ b/core/local/local.go
@@ -41,8 +41,8 @@ type ExecutionScheduler struct {
 	logger  *logrus.Logger
 
 	initProgress    *pb.ProgressBar
-	executors       []lib.Executor // sorted by (startTime, ID)
-	executorConfigs []lib.ExecutorConfig
+	executorConfigs []lib.ExecutorConfig // sorted by (startTime, ID)
+	executors       []lib.Executor       // sorted by (startTime, ID), excludes executors with no work
 	executionPlan   []lib.ExecutionStep
 	maxDuration     time.Duration // cached value derived from the execution plan
 	maxPossibleVUs  uint64        // cached value derived from the execution plan

--- a/core/local/local_test.go
+++ b/core/local/local_test.go
@@ -732,35 +732,36 @@ func TestSetPaused(t *testing.T) {
 func TestNewExecutionSchedulerHasWork(t *testing.T) {
 	t.Parallel()
 	script := []byte(`
-import http from 'k6/http';
-
-export let options = {
-    executionSegment: "2/4:3/4",
-    execution: {
-        shared_iters1: {
-            type: "shared-iterations",
-            vus: 3,
-            iterations: 3,
-        },
-        shared_iters2: {
-            type: "shared-iterations",
-            vus: 4,
-            iterations: 4,
-        },
-        constant_arr_rate: {
-            type: "constant-arrival-rate",
-            rate: 3,
-            timeUnit: "1s",
-            duration: "20s",
-            preAllocatedVUs: 4,
-            maxVUs: 4,
-        },
-    },
-};
-
-export default function() {
-  const response = http.get("http://test.loadimpact.com");
-};`)
+		import http from 'k6/http';
+		
+		export let options = {
+                    executionSegment: "2/4:3/4",
+		    execution: {
+			shared_iters1: {
+			    type: "shared-iterations",
+			    vus: 3,
+			    iterations: 3,
+			},
+			shared_iters2: {
+			    type: "shared-iterations",
+			    vus: 4,
+			    iterations: 4,
+			},
+			constant_arr_rate: {
+			    type: "constant-arrival-rate",
+			    rate: 3,
+			    timeUnit: "1s",
+			    duration: "20s",
+			    preAllocatedVUs: 4,
+			    maxVUs: 4,
+			},
+		    },
+		};
+		
+		export default function() {
+		  const response = http.get("http://test.loadimpact.com");
+		};
+`)
 
 	runner, err := js.New(
 		&loader.SourceData{

--- a/core/local/local_test.go
+++ b/core/local/local_test.go
@@ -733,33 +733,33 @@ func TestNewExecutionSchedulerHasWork(t *testing.T) {
 	t.Parallel()
 	script := []byte(`
 		import http from 'k6/http';
-		
+
 		export let options = {
-                    executionSegment: "2/4:3/4",
-		    execution: {
-			shared_iters1: {
-			    type: "shared-iterations",
-			    vus: 3,
-			    iterations: 3,
-			},
-			shared_iters2: {
-			    type: "shared-iterations",
-			    vus: 4,
-			    iterations: 4,
-			},
-			constant_arr_rate: {
-			    type: "constant-arrival-rate",
-			    rate: 3,
-			    timeUnit: "1s",
-			    duration: "20s",
-			    preAllocatedVUs: 4,
-			    maxVUs: 4,
-			},
+			executionSegment: "2/4:3/4",
+			execution: {
+				shared_iters1: {
+					type: "shared-iterations",
+					vus: 3,
+					iterations: 3,
+				},
+				shared_iters2: {
+					type: "shared-iterations",
+					vus: 4,
+					iterations: 4,
+				},
+				constant_arr_rate: {
+					type: "constant-arrival-rate",
+					rate: 3,
+					timeUnit: "1s",
+					duration: "20s",
+					preAllocatedVUs: 4,
+					maxVUs: 4,
+				},
 		    },
 		};
-		
+
 		export default function() {
-		  const response = http.get("http://test.loadimpact.com");
+			const response = http.get("http://test.loadimpact.com");
 		};
 `)
 

--- a/core/local/local_test.go
+++ b/core/local/local_test.go
@@ -728,3 +728,56 @@ func TestSetPaused(t *testing.T) {
 		require.Contains(t, err.Error(), "doesn't support pause and resume operations after its start")
 	})
 }
+
+func TestNewExecutionSchedulerHasWork(t *testing.T) {
+	t.Parallel()
+	script := []byte(`
+import http from 'k6/http';
+
+export let options = {
+    executionSegment: "2/4:3/4",
+    execution: {
+        shared_iters1: {
+            type: "shared-iterations",
+            vus: 3,
+            iterations: 3,
+        },
+        shared_iters2: {
+            type: "shared-iterations",
+            vus: 4,
+            iterations: 4,
+        },
+        constant_arr_rate: {
+            type: "constant-arrival-rate",
+            rate: 3,
+            timeUnit: "1s",
+            duration: "20s",
+            preAllocatedVUs: 4,
+            maxVUs: 4,
+        },
+    },
+};
+
+export default function() {
+  const response = http.get("http://test.loadimpact.com");
+};`)
+
+	runner, err := js.New(
+		&loader.SourceData{
+			URL:  &url.URL{Path: "/script.js"},
+			Data: script,
+		},
+		nil,
+		lib.RuntimeOptions{},
+	)
+	require.NoError(t, err)
+
+	logger := logrus.New()
+	logger.SetOutput(testutils.NewTestOutput(t))
+
+	execScheduler, err := NewExecutionScheduler(runner, logger)
+	require.NoError(t, err)
+
+	assert.Len(t, execScheduler.executors, 2)
+	assert.Len(t, execScheduler.executorConfigs, 3)
+}

--- a/lib/executor/constant_arrival_rate.go
+++ b/lib/executor/constant_arrival_rate.go
@@ -164,6 +164,11 @@ func (carc ConstantArrivalRateConfig) NewExecutor(
 	}, nil
 }
 
+// HasWork reports whether there is any works for give execution segment.
+func (carc ConstantArrivalRateConfig) HasWork(es *lib.ExecutionSegment) bool {
+	return carc.GetMaxVUs(es) > 0
+}
+
 // ConstantArrivalRate tries to execute a specific number of iterations for a
 // specific period.
 type ConstantArrivalRate struct {

--- a/lib/executor/constant_arrival_rate.go
+++ b/lib/executor/constant_arrival_rate.go
@@ -164,7 +164,7 @@ func (carc ConstantArrivalRateConfig) NewExecutor(
 	}, nil
 }
 
-// HasWork reports whether there is any works for give execution segment.
+// HasWork reports whether there is any work to be done for the given execution segment.
 func (carc ConstantArrivalRateConfig) HasWork(es *lib.ExecutionSegment) bool {
 	return carc.GetMaxVUs(es) > 0
 }

--- a/lib/executor/constant_looping_vus.go
+++ b/lib/executor/constant_looping_vus.go
@@ -116,7 +116,7 @@ func (clvc ConstantLoopingVUsConfig) GetExecutionRequirements(es *lib.ExecutionS
 	}
 }
 
-// HasWork reports whether there is any works for give execution segment.
+// HasWork reports whether there is any work to be done for the given execution segment.
 func (clvc ConstantLoopingVUsConfig) HasWork(es *lib.ExecutionSegment) bool {
 	return clvc.GetVUs(es) > 0
 }

--- a/lib/executor/constant_looping_vus.go
+++ b/lib/executor/constant_looping_vus.go
@@ -116,6 +116,11 @@ func (clvc ConstantLoopingVUsConfig) GetExecutionRequirements(es *lib.ExecutionS
 	}
 }
 
+// HasWork reports whether there is any works for give execution segment.
+func (clvc ConstantLoopingVUsConfig) HasWork(es *lib.ExecutionSegment) bool {
+	return clvc.GetVUs(es) > 0
+}
+
 // NewExecutor creates a new ConstantLoopingVUs executor
 func (clvc ConstantLoopingVUsConfig) NewExecutor(es *lib.ExecutionState, logger *logrus.Entry) (lib.Executor, error) {
 	return ConstantLoopingVUs{

--- a/lib/executor/externally_controlled.go
+++ b/lib/executor/externally_controlled.go
@@ -180,9 +180,10 @@ func (mec ExternallyControlledConfig) NewExecutor(es *lib.ExecutionState, logger
 	}, nil
 }
 
-// HasWork reports whether there is any works for give execution segment.
+// HasWork reports whether there is any work to be done for the given execution segment.
 func (mec ExternallyControlledConfig) HasWork(es *lib.ExecutionSegment) bool {
-	return es.Scale(mec.MaxVUs.Int64) > 0
+	// We can always initialize new VUs via the REST API, so return true.
+	return true
 }
 
 type pauseEvent struct {

--- a/lib/executor/externally_controlled.go
+++ b/lib/executor/externally_controlled.go
@@ -180,6 +180,11 @@ func (mec ExternallyControlledConfig) NewExecutor(es *lib.ExecutionState, logger
 	}, nil
 }
 
+// HasWork reports whether there is any works for give execution segment.
+func (mec ExternallyControlledConfig) HasWork(es *lib.ExecutionSegment) bool {
+	return es.Scale(mec.MaxVUs.Int64) > 0
+}
+
 type pauseEvent struct {
 	isPaused bool
 	err      chan error

--- a/lib/executor/per_vu_iterations.go
+++ b/lib/executor/per_vu_iterations.go
@@ -134,6 +134,11 @@ func (pvic PerVUIterationsConfig) NewExecutor(
 	}, nil
 }
 
+// HasWork reports whether there is any works for give execution segment.
+func (pvic PerVUIterationsConfig) HasWork(es *lib.ExecutionSegment) bool {
+	return pvic.GetVUs(es) > 0 && pvic.GetIterations() > 0
+}
+
 // PerVUIterations executes a specific number of iterations with each VU.
 type PerVUIterations struct {
 	*BaseExecutor

--- a/lib/executor/per_vu_iterations.go
+++ b/lib/executor/per_vu_iterations.go
@@ -134,7 +134,7 @@ func (pvic PerVUIterationsConfig) NewExecutor(
 	}, nil
 }
 
-// HasWork reports whether there is any works for give execution segment.
+// HasWork reports whether there is any work to be done for the given execution segment.
 func (pvic PerVUIterationsConfig) HasWork(es *lib.ExecutionSegment) bool {
 	return pvic.GetVUs(es) > 0 && pvic.GetIterations() > 0
 }

--- a/lib/executor/shared_iterations.go
+++ b/lib/executor/shared_iterations.go
@@ -148,7 +148,7 @@ type SharedIterations struct {
 // Make sure we implement the lib.Executor interface.
 var _ lib.Executor = &SharedIterations{}
 
-// HasWork reports whether there is any works for give execution segment.
+// HasWork reports whether there is any work to be done for the given execution segment.
 func (sic SharedIterationsConfig) HasWork(es *lib.ExecutionSegment) bool {
 	return sic.GetVUs(es) > 0 && sic.GetIterations(es) > 0
 }

--- a/lib/executor/shared_iterations.go
+++ b/lib/executor/shared_iterations.go
@@ -148,6 +148,11 @@ type SharedIterations struct {
 // Make sure we implement the lib.Executor interface.
 var _ lib.Executor = &SharedIterations{}
 
+// HasWork reports whether there is any works for give execution segment.
+func (sic SharedIterationsConfig) HasWork(es *lib.ExecutionSegment) bool {
+	return sic.GetVUs(es) > 0 && sic.GetIterations(es) > 0
+}
+
 // Run executes a specific total number of iterations, which are all shared by
 // the configured VUs.
 func (si SharedIterations) Run(ctx context.Context, out chan<- stats.SampleContainer) (err error) {

--- a/lib/executor/variable_arrival_rate.go
+++ b/lib/executor/variable_arrival_rate.go
@@ -260,7 +260,7 @@ func (varc VariableArrivalRateConfig) NewExecutor(
 	}, nil
 }
 
-// HasWork reports whether there is any works for give execution segment.
+// HasWork reports whether there is any work to be done for the given execution segment.
 func (varc VariableArrivalRateConfig) HasWork(es *lib.ExecutionSegment) bool {
 	return varc.GetMaxVUs(es) > 0
 }

--- a/lib/executor/variable_arrival_rate.go
+++ b/lib/executor/variable_arrival_rate.go
@@ -260,6 +260,11 @@ func (varc VariableArrivalRateConfig) NewExecutor(
 	}, nil
 }
 
+// HasWork reports whether there is any works for give execution segment.
+func (varc VariableArrivalRateConfig) HasWork(es *lib.ExecutionSegment) bool {
+	return varc.GetMaxVUs(es) > 0
+}
+
 // VariableArrivalRate tries to execute a specific number of iterations for a
 // specific period.
 //TODO: combine with the ConstantArrivalRate?

--- a/lib/executor/variable_looping_vus.go
+++ b/lib/executor/variable_looping_vus.go
@@ -460,7 +460,7 @@ func (vlvc VariableLoopingVUsConfig) NewExecutor(es *lib.ExecutionState, logger 
 	}, nil
 }
 
-// HasWork reports whether there is any works for give execution segment.
+// HasWork reports whether there is any work to be done for the given execution segment.
 func (vlvc VariableLoopingVUsConfig) HasWork(es *lib.ExecutionSegment) bool {
 	return lib.GetMaxPlannedVUs(vlvc.GetExecutionRequirements(es)) > 0
 }

--- a/lib/executor/variable_looping_vus.go
+++ b/lib/executor/variable_looping_vus.go
@@ -460,6 +460,11 @@ func (vlvc VariableLoopingVUsConfig) NewExecutor(es *lib.ExecutionState, logger 
 	}, nil
 }
 
+// HasWork reports whether there is any works for give execution segment.
+func (vlvc VariableLoopingVUsConfig) HasWork(es *lib.ExecutionSegment) bool {
+	return lib.GetMaxPlannedVUs(vlvc.GetExecutionRequirements(es)) > 0
+}
+
 // VariableLoopingVUs handles the old "stages" execution configuration - it
 // loops iterations with a variable number of VUs for the sum of all of the
 // specified stages' duration.

--- a/lib/executors.go
+++ b/lib/executors.go
@@ -104,7 +104,7 @@ type ExecutorConfig interface {
 
 	NewExecutor(*ExecutionState, *logrus.Entry) (Executor, error)
 
-	// HasWork reports whether there is any work to do with given segment.
+	// HasWork reports whether there is any work for the executor to do with a given segment.
 	HasWork(*ExecutionSegment) bool
 }
 

--- a/lib/executors.go
+++ b/lib/executors.go
@@ -103,6 +103,9 @@ type ExecutorConfig interface {
 	GetDescription(es *ExecutionSegment) string
 
 	NewExecutor(*ExecutionState, *logrus.Entry) (Executor, error)
+
+	// HasWork reports whether there is any work to do with given segment.
+	HasWork(*ExecutionSegment) bool
 }
 
 // InitVUFunc is just a shorthand so we don't have to type the function


### PR DESCRIPTION
For executor which has nothing to do in a given segment, we should not
include it in the list of executors.

To do it, add new method HasWork to ExecutorConfig. By filtering out no
work executor when creating new schedulter, we can prevents any un-necessary
works and provide better UX.

Fixes #1295