### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,10 +8,10 @@ labels: bug
 
 ## Environment
 <!--- Provide as much information about your environment as possible: output from `k6 version`,
-      OCI runtime and image information if using containers, etc. -->
+      OCI runtime and image information if using containers, cloud execution environment, etc. -->
 - k6 version:
 - OS and version:
-- Docker version and image:
+- Docker version and image, if applicable:
 
 
 ## Expected Behavior

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Use this template for reporting bugs. Please search existing issues first.
+labels: bug
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Environment
+<!--- Output from `k6 version`, e.g. `k6 v0.26.0-dev (dev build, go1.13.4, linux/amd64)` -->
+- k6 version:
+
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+
+## Actual Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+
+
+## Steps to Reproduce the Problem
+<!--- Provide the exact commands, environment variables and relevant script(s) to reproduce this bug. -->
+
+1.
+2.
+3.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,8 +7,11 @@ labels: bug
 <!--- Provide a general summary of the issue in the Title above -->
 
 ## Environment
-<!--- Output from `k6 version`, e.g. `k6 v0.26.0-dev (dev build, go1.13.4, linux/amd64)` -->
+<!--- Provide as much information about your environment as possible: output from `k6 version`,
+      OCI runtime and image information if using containers, etc. -->
 - k6 version:
+- OS and version:
+- Docker version and image:
 
 
 ## Expected Behavior

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: k6 Community Forum
+    url: https://community.k6.io/
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/feat_req.md
+++ b/.github/ISSUE_TEMPLATE/feat_req.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Use this template for suggesting new features.
+labels: feature
+---
+
+<!--- Provide a general summary of the feature in the Title above -->
+
+## Feature Description
+<!--- Describe the feature in detail: what benefits it would have, which problem it would solve, use cases, examples, etc. -->
+
+
+## Suggested Solution (optional)
+<!--- Any implementation suggestions you might have: technical details, design tradeoffs, API proposals, etc. -->

--- a/README.md
+++ b/README.md
@@ -344,18 +344,13 @@ k6 comes with several built-in modules for things like making (and measuring) [H
 You can, of course, also write your own ES6 modules and `import` them in your scripts, potentially reusing code across an organization. The situation with importing JavaScript libraries is a bit more complicated. You can potentially use **some** JS libraries in k6, even ones intended for Node.js if you use browserify, though if they depend on network/OS-related APIs, they likely won't work. You can find more details and instructions about writing or importing JS modules [here](https://docs.k6.io/docs/modules).
 
 
-Need help or want to contribute?
---------------------------------
+Support
+-------
 
-Types of questions and where to ask:
+To get help about usage, report bugs, suggest features, and discuss k6 with other users see [SUPPORT.md](SUPPORT.md).
 
-- How do I? -- [Stack Overflow](https://stackoverflow.com/questions/tagged/k6) (use tags: k6, javascript, load-testing) or the Discourse forum at [community.k6.io](https://community.k6.io/)
-- I got this error, why? -- [Stack Overflow](https://stackoverflow.com/questions/tagged/k6) or [community.k6.io](https://community.k6.io/)
-- I got this error and I'm sure it's a bug -- [file an issue](https://github.com/loadimpact/k6/issues)
-- I have an idea/request -- [file an issue](https://github.com/loadimpact/k6/issues)
-- Why do you? -- [Slack](https://k6.io/slack)
-- When will you? -- [Slack](https://k6.io/slack)
 
-If your questions are about any of the commercial Load Impact services like managed cloud execution and Load Impact Insights, you can contact <support@loadimpact.com> or write in the `#loadimpact` channel in [Slack](https://k6.io/slack).
+Contributing
+------------
 
 If you want to contribute or help with the development of k6, start by reading [CONTRIBUTING.md](https://github.com/loadimpact/k6/blob/master/CONTRIBUTING.md). Before you start coding, especially when it comes to big changes and features, it might be a good idea to first discuss your plans and implementation details with the k6 maintainers. You can do this either in the [github issue](https://github.com/loadimpact/k6/issues) for the problem you're solving (create one if it doesn't exist) or in the `#developers` channel on [Slack](https://k6.io/slack).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,12 @@
+# Support
+
+Types of questions and where to ask:
+
+- How do I? -- the Discourse forum at [community.k6.io](https://community.k6.io/) or [Stack Overflow](https://stackoverflow.com/questions/tagged/k6) (use tags: k6, javascript, load-testing)
+- I got this error, why? -- [community.k6.io](https://community.k6.io/) or [Stack Overflow](https://stackoverflow.com/questions/tagged/k6)
+- I got this error and I'm sure it's a bug -- [file an issue](https://github.com/loadimpact/k6/issues)
+- I have an idea/request -- [file an issue](https://github.com/loadimpact/k6/issues)
+- Why do you? -- [Slack](https://k6.io/slack)
+- When will you? -- [Slack](https://k6.io/slack)
+
+If your questions are about any of the commercial Load Impact services like managed cloud execution and Load Impact Insights, you can contact <support@loadimpact.com> or write in the `#loadimpact` channel in [Slack](https://k6.io/slack).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,9 +4,9 @@ Types of questions and where to ask:
 
 - How do I? -- the Discourse forum at [community.k6.io](https://community.k6.io/) or [Stack Overflow](https://stackoverflow.com/questions/tagged/k6) (use tags: k6, javascript, load-testing)
 - I got this error, why? -- [community.k6.io](https://community.k6.io/) or [Stack Overflow](https://stackoverflow.com/questions/tagged/k6)
-- I got this error and I'm sure it's a bug -- [file an issue](https://github.com/loadimpact/k6/issues)
-- I have an idea/request -- [file an issue](https://github.com/loadimpact/k6/issues)
-- Why do you? -- [Slack](https://k6.io/slack)
-- When will you? -- [Slack](https://k6.io/slack)
+- I got this error and I'm sure it's a bug -- [open a new issue](https://github.com/loadimpact/k6/issues), if there isn't one for this specific bug already
+- I have an idea/request -- search the [GitHub issues](https://github.com/loadimpact/k6/issues) to see if it wasn't requested already - give the issue a :+1: if it was, create a new one if it wasn't
+- Why do you? -- [community.k6.io](https://community.k6.io/) or [Slack](https://k6.io/slack)
+- When will you? -- [community.k6.io](https://community.k6.io/) or [Slack](https://k6.io/slack)
 
 If your questions are about any of the commercial Load Impact services like managed cloud execution and Load Impact Insights, you can contact <support@loadimpact.com> or write in the `#loadimpact` channel in [Slack](https://k6.io/slack).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -5,7 +5,7 @@ Types of questions and where to ask:
 - How do I? -- the Discourse forum at [community.k6.io](https://community.k6.io/) or [Stack Overflow](https://stackoverflow.com/questions/tagged/k6) (use tags: k6, javascript, load-testing)
 - I got this error, why? -- [community.k6.io](https://community.k6.io/) or [Stack Overflow](https://stackoverflow.com/questions/tagged/k6)
 - I got this error and I'm sure it's a bug -- [open a new issue](https://github.com/loadimpact/k6/issues), if there isn't one for this specific bug already
-- I have an idea/request -- search the [GitHub issues](https://github.com/loadimpact/k6/issues) to see if it wasn't requested already - give the issue a :+1: if it was, create a new one if it wasn't
+- I have an idea/request -- search the [GitHub issues](https://github.com/loadimpact/k6/issues) to see if it was already requested and give the issue a :+1: if so. If it wasn't, search [community.k6.io](https://community.k6.io/) or post a forum thread to discuss the idea with the developers before creating a GitHub issue.
 - Why do you? -- [community.k6.io](https://community.k6.io/) or [Slack](https://k6.io/slack)
 - When will you? -- [community.k6.io](https://community.k6.io/) or [Slack](https://k6.io/slack)
 


### PR DESCRIPTION
I don't have access to the repo Settings where these [can be created and previewed directly](https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository), but it's standard Markdown so it should render fine.

Someone will still have to configure and select these files in the Settings. :)

Let me know if anything should be changed. I don't think we need a PR template as well, right?

Partially fixes #1063