### PR TITLE
More compact progress bar status text

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -214,11 +214,12 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 		testProgress := &cloud.TestProgressResponse{}
 		percentageFmt := "[" + pb.GetFixedLengthFloatFormat(100, 2) + "%%] %s"
 		progressBar.Modify(
-			pb.WithProgress(func() (float64, string) {
+			pb.WithProgress(func() (float64, []string) {
 				if testProgress.RunStatus < lib.RunStatusRunning {
-					return 0, testProgress.RunStatusText
+					return 0, []string{testProgress.RunStatusText}
 				}
-				return testProgress.Progress, fmt.Sprintf(percentageFmt, testProgress.Progress*100, testProgress.RunStatusText)
+				return testProgress.Progress, []string{
+					fmt.Sprintf(percentageFmt, testProgress.Progress*100, testProgress.RunStatusText)}
 			}),
 		)
 

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -93,7 +93,7 @@ func renderMultipleBars(isTTY, goBack bool, leftMax int, pbs []*pb.ProgressBar) 
 	var (
 		// Maximum length of each right side column except last,
 		// used to calculate the padding between columns.
-		maxRColumnLen = make([]int, 1)
+		maxRColumnLen = make([]int, 2)
 		pbsCount      = len(pbs)
 		rendered      = make([]pb.ProgressBarRender, pbsCount)
 		result        = make([]string, pbsCount+2)

--- a/cmd/ui_test.go
+++ b/cmd/ui_test.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/loadimpact/k6/ui/pb"
+)
+
+// Return progressbars with different content lengths, to test for
+// padding.
+func createTestProgressBars(num, padding, colIdx int) []*pb.ProgressBar {
+	pbs := make([]*pb.ProgressBar, num)
+	for i := 0; i < num; i++ {
+		left := fmt.Sprintf("left %d", i)
+		rightCol1 := fmt.Sprintf("right %d", i)
+		progress := 0.0
+		status := pb.Running
+		if i == colIdx {
+			pad := strings.Repeat("+", padding)
+			left += pad
+			rightCol1 += pad
+			progress = 1.0
+			status = pb.Done
+		}
+		pbs[i] = pb.New(
+			pb.WithLeft(func() string { return left }),
+			pb.WithStatus(status),
+			pb.WithProgress(func() (float64, []string) {
+				return progress, []string{rightCol1, "000"}
+			}),
+		)
+	}
+	return pbs
+}
+
+func TestRenderMultipleBars(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		padding  int
+		expected string
+	}{
+		{"nopad", 0, `
+left 0   [--------------------------------------] right 0  000
+left 1 ✓ [======================================] right 1  000
+left 2   [--------------------------------------] right 2  000
+
+`},
+		{"pad2", 2, `
+left 0     [--------------------------------------] right 0    000
+left 1++ ✓ [======================================] right 1++  000
+left 2     [--------------------------------------] right 2    000
+
+`},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			pbs := createTestProgressBars(3, tc.padding, 1)
+			out := renderMultipleBars(false, false, 6+tc.padding, pbs)
+			assert.Equal(t, tc.expected, out)
+		})
+	}
+}

--- a/core/local/local.go
+++ b/core/local/local.go
@@ -232,10 +232,10 @@ func (e *ExecutionScheduler) Init(ctx context.Context, engineOut chan<- stats.Sa
 	initializedVUs := new(uint64)
 	vusFmt := pb.GetFixedLengthIntFormat(int64(vusToInitialize))
 	e.initProgress.Modify(
-		pb.WithProgress(func() (float64, string) {
+		pb.WithProgress(func() (float64, []string) {
 			doneVUs := atomic.LoadUint64(initializedVUs)
-			return float64(doneVUs) / float64(vusToInitialize),
-				fmt.Sprintf(vusFmt+"/%d VUs initialized", doneVUs, vusToInitialize)
+			right := fmt.Sprintf(vusFmt+"/%d VUs initialized", doneVUs, vusToInitialize)
+			return float64(doneVUs) / float64(vusToInitialize), []string{right}
 		}),
 	)
 
@@ -293,9 +293,9 @@ func (e *ExecutionScheduler) runExecutor(
 		startTime := time.Now()
 		executorProgress.Modify(
 			pb.WithStatus(pb.Waiting),
-			pb.WithProgress(func() (float64, string) {
+			pb.WithProgress(func() (float64, []string) {
 				remWait := (executorStartTime - time.Since(startTime))
-				return 0, fmt.Sprintf("waiting %s", pb.GetFixedLengthDuration(remWait, executorStartTime))
+				return 0, []string{"waiting", pb.GetFixedLengthDuration(remWait, executorStartTime)}
 			}),
 		)
 

--- a/lib/executor/constant_looping_vus.go
+++ b/lib/executor/constant_looping_vus.go
@@ -26,12 +26,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
+	null "gopkg.in/guregu/null.v3"
+
 	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/stats"
 	"github.com/loadimpact/k6/ui/pb"
-	"github.com/sirupsen/logrus"
-	null "gopkg.in/guregu/null.v3"
 )
 
 const constantLoopingVUsType = "constant-looping-vus"
@@ -158,10 +159,10 @@ func (clv ConstantLoopingVUs) Run(ctx context.Context, out chan<- stats.SampleCo
 	progresFn := func() (float64, string) {
 		spent := time.Since(startTime)
 		if spent > duration {
-			return 1, fmt.Sprintf("constant looping %d VUs for %s", numVUs, duration)
+			return 1, fmt.Sprintf("%d VUs\t%s", numVUs, duration)
 		}
 		return float64(spent) / float64(duration), fmt.Sprintf(
-			"constant looping %d VUs, %s/%s", numVUs, pb.GetFixedLengthDuration(spent, duration), duration,
+			"%d VUs\t%s/%s", numVUs, pb.GetFixedLengthDuration(spent, duration), duration,
 		)
 	}
 	clv.progress.Modify(pb.WithProgress(progresFn))

--- a/lib/executor/constant_looping_vus.go
+++ b/lib/executor/constant_looping_vus.go
@@ -156,14 +156,16 @@ func (clv ConstantLoopingVUs) Run(ctx context.Context, out chan<- stats.SampleCo
 		logrus.Fields{"vus": numVUs, "duration": duration, "type": clv.config.GetType()},
 	).Debug("Starting executor run...")
 
-	progresFn := func() (float64, string) {
+	progresFn := func() (float64, []string) {
 		spent := time.Since(startTime)
+		right := []string{fmt.Sprintf("%d VUs", numVUs)}
 		if spent > duration {
-			return 1, fmt.Sprintf("%d VUs\t%s", numVUs, duration)
+			right = append(right, duration.String())
+			return 1, right
 		}
-		return float64(spent) / float64(duration), fmt.Sprintf(
-			"%d VUs\t%s/%s", numVUs, pb.GetFixedLengthDuration(spent, duration), duration,
-		)
+		right = append(right, fmt.Sprintf("%s/%s",
+			pb.GetFixedLengthDuration(spent, duration), duration))
+		return float64(spent) / float64(duration), right
 	}
 	clv.progress.Modify(pb.WithProgress(progresFn))
 	go trackProgress(ctx, maxDurationCtx, regDurationCtx, clv, progresFn)

--- a/lib/executor/externally_controlled.go
+++ b/lib/executor/externally_controlled.go
@@ -394,7 +394,7 @@ func (rs *externallyControlledRunState) retrieveStartMaxVUs() error {
 	return nil
 }
 
-func (rs *externallyControlledRunState) progresFn() (float64, string) {
+func (rs *externallyControlledRunState) progresFn() (float64, []string) {
 	spent := rs.executor.executionState.GetCurrentTestRunDuration()
 	progress := 0.0
 	if rs.duration > 0 {
@@ -404,10 +404,9 @@ func (rs *externallyControlledRunState) progresFn() (float64, string) {
 	currentActiveVUs := atomic.LoadInt64(rs.activeVUsCount)
 	currentMaxVUs := atomic.LoadInt64(rs.maxVUs)
 	vusFmt := pb.GetFixedLengthIntFormat(currentMaxVUs)
-	return progress, fmt.Sprintf(
-		vusFmt+"/"+vusFmt+" VUs\t%s/%s", currentActiveVUs, currentMaxVUs,
-		pb.GetFixedLengthDuration(spent, rs.duration), rs.duration,
-	)
+	progVUs := fmt.Sprintf(vusFmt+"/"+vusFmt+" VUs", currentActiveVUs, currentMaxVUs)
+	progDur := fmt.Sprintf("%s/%s", pb.GetFixedLengthDuration(spent, rs.duration), rs.duration)
+	return progress, []string{progVUs, progDur}
 }
 
 func (rs *externallyControlledRunState) handleConfigChange(oldCfg, newCfg ExternallyControlledConfigParams) error {

--- a/lib/executor/externally_controlled.go
+++ b/lib/executor/externally_controlled.go
@@ -405,7 +405,7 @@ func (rs *externallyControlledRunState) progresFn() (float64, string) {
 	currentMaxVUs := atomic.LoadInt64(rs.maxVUs)
 	vusFmt := pb.GetFixedLengthIntFormat(currentMaxVUs)
 	return progress, fmt.Sprintf(
-		"currently "+vusFmt+" out of "+vusFmt+" active looping VUs, %s/%s", currentActiveVUs, currentMaxVUs,
+		vusFmt+"/"+vusFmt+" VUs\t%s/%s", currentActiveVUs, currentMaxVUs,
 		pb.GetFixedLengthDuration(spent, rs.duration), rs.duration,
 	)
 }

--- a/lib/executor/helpers.go
+++ b/lib/executor/helpers.go
@@ -178,7 +178,11 @@ func trackProgress(
 	case <-parentCtx.Done():
 		progressBar.Modify(pb.WithStatus(pb.Interrupted), constProg)
 	default:
-		progressBar.Modify(pb.WithStatus(pb.Done), constProg)
+		status := pb.WithStatus(pb.Done)
+		if p < 1 {
+			status = pb.WithStatus(pb.Interrupted)
+		}
+		progressBar.Modify(status, constProg)
 	}
 }
 

--- a/lib/executor/per_vu_iterations.go
+++ b/lib/executor/per_vu_iterations.go
@@ -168,14 +168,15 @@ func (pvi PerVUIterations) Run(ctx context.Context, out chan<- stats.SampleConta
 	totalIters := uint64(numVUs * iterations)
 	doneIters := new(uint64)
 
-	vusFmt := pb.GetFixedLengthIntFormat(int64(numVUs))
+	vusFmt := pb.GetFixedLengthIntFormat(numVUs)
 	itersFmt := pb.GetFixedLengthIntFormat(int64(totalIters))
-	fmtStr := vusFmt + " VUs\t" + itersFmt + "/" + itersFmt + " iters, %d per VU"
-	progresFn := func() (float64, string) {
+	progresFn := func() (float64, []string) {
 		currentDoneIters := atomic.LoadUint64(doneIters)
-		return float64(currentDoneIters) / float64(totalIters), fmt.Sprintf(
-			fmtStr, numVUs, currentDoneIters, totalIters, iterations,
-		)
+		return float64(currentDoneIters) / float64(totalIters), []string{
+			fmt.Sprintf(vusFmt+" VUs", numVUs),
+			fmt.Sprintf(itersFmt+"/"+itersFmt+" iters, %d per VU",
+				currentDoneIters, totalIters, iterations),
+		}
 	}
 	pvi.progress.Modify(pb.WithProgress(progresFn))
 	go trackProgress(ctx, maxDurationCtx, regDurationCtx, pvi, progresFn)

--- a/lib/executor/per_vu_iterations.go
+++ b/lib/executor/per_vu_iterations.go
@@ -27,12 +27,13 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/sirupsen/logrus"
+	null "gopkg.in/guregu/null.v3"
+
 	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/stats"
 	"github.com/loadimpact/k6/ui/pb"
-	"github.com/sirupsen/logrus"
-	null "gopkg.in/guregu/null.v3"
 )
 
 const perVUIterationsType = "per-vu-iterations"
@@ -166,11 +167,14 @@ func (pvi PerVUIterations) Run(ctx context.Context, out chan<- stats.SampleConta
 
 	totalIters := uint64(numVUs * iterations)
 	doneIters := new(uint64)
-	fmtStr := pb.GetFixedLengthIntFormat(int64(totalIters)) + "/%d iters, %d from each of %d VUs"
+
+	vusFmt := pb.GetFixedLengthIntFormat(int64(numVUs))
+	itersFmt := pb.GetFixedLengthIntFormat(int64(totalIters))
+	fmtStr := vusFmt + " VUs\t" + itersFmt + "/" + itersFmt + " iters, %d per VU"
 	progresFn := func() (float64, string) {
 		currentDoneIters := atomic.LoadUint64(doneIters)
 		return float64(currentDoneIters) / float64(totalIters), fmt.Sprintf(
-			fmtStr, currentDoneIters, totalIters, iterations, numVUs,
+			fmtStr, numVUs, currentDoneIters, totalIters, iterations,
 		)
 	}
 	pvi.progress.Modify(pb.WithProgress(progresFn))

--- a/lib/executor/shared_iterations.go
+++ b/lib/executor/shared_iterations.go
@@ -172,14 +172,15 @@ func (si SharedIterations) Run(ctx context.Context, out chan<- stats.SampleConta
 
 	totalIters := uint64(iterations)
 	doneIters := new(uint64)
-	vusFmt := pb.GetFixedLengthIntFormat(int64(numVUs))
+	vusFmt := pb.GetFixedLengthIntFormat(numVUs)
 	itersFmt := pb.GetFixedLengthIntFormat(int64(totalIters))
-	fmtStr := vusFmt + " VUs\t" + itersFmt + "/" + itersFmt + " shared iters"
-	progresFn := func() (float64, string) {
+	progresFn := func() (float64, []string) {
 		currentDoneIters := atomic.LoadUint64(doneIters)
-		return float64(currentDoneIters) / float64(totalIters), fmt.Sprintf(
-			fmtStr, numVUs, currentDoneIters, totalIters,
-		)
+		return float64(currentDoneIters) / float64(totalIters), []string{
+			fmt.Sprintf(vusFmt+" VUs", numVUs),
+			fmt.Sprintf(itersFmt+"/"+itersFmt+" shared iters",
+				currentDoneIters, totalIters),
+		}
 	}
 	si.progress.Modify(pb.WithProgress(progresFn))
 	go trackProgress(ctx, maxDurationCtx, regDurationCtx, si, progresFn)

--- a/lib/executor/shared_iterations.go
+++ b/lib/executor/shared_iterations.go
@@ -172,11 +172,13 @@ func (si SharedIterations) Run(ctx context.Context, out chan<- stats.SampleConta
 
 	totalIters := uint64(iterations)
 	doneIters := new(uint64)
-	fmtStr := pb.GetFixedLengthIntFormat(int64(totalIters)) + "/%d shared iters among %d VUs"
+	vusFmt := pb.GetFixedLengthIntFormat(int64(numVUs))
+	itersFmt := pb.GetFixedLengthIntFormat(int64(totalIters))
+	fmtStr := vusFmt + " VUs\t" + itersFmt + "/" + itersFmt + " shared iters"
 	progresFn := func() (float64, string) {
 		currentDoneIters := atomic.LoadUint64(doneIters)
 		return float64(currentDoneIters) / float64(totalIters), fmt.Sprintf(
-			fmtStr, currentDoneIters, totalIters, numVUs,
+			fmtStr, numVUs, currentDoneIters, totalIters,
 		)
 	}
 	si.progress.Modify(pb.WithProgress(progresFn))

--- a/lib/executor/variable_looping_vus.go
+++ b/lib/executor/variable_looping_vus.go
@@ -512,12 +512,12 @@ func (vlv VariableLoopingVUs) Run(ctx context.Context, out chan<- stats.SampleCo
 	vusFmt := pb.GetFixedLengthIntFormat(int64(maxVUs))
 	progresFn := func() (float64, string) {
 		spent := time.Since(startTime)
-		if spent > regularDuration {
-			return 1, fmt.Sprintf("variable looping VUs for %s", regularDuration)
-		}
 		currentlyActiveVUs := atomic.LoadInt64(activeVUsCount)
+		if spent > regularDuration {
+			return 1, fmt.Sprintf(vusFmt+"/"+vusFmt+" VUs\t%s", currentlyActiveVUs, maxVUs, regularDuration)
+		}
 		return float64(spent) / float64(regularDuration), fmt.Sprintf(
-			"currently "+vusFmt+" active looping VUs, %s/%s", currentlyActiveVUs,
+			vusFmt+"/"+vusFmt+" VUs\t%s/%s", currentlyActiveVUs, maxVUs,
 			pb.GetFixedLengthDuration(spent, regularDuration), regularDuration,
 		)
 	}

--- a/ui/pb/progressbar.go
+++ b/ui/pb/progressbar.go
@@ -60,7 +60,7 @@ type ProgressBar struct {
 	status Status
 
 	left     func() string
-	progress func() (progress float64, right string)
+	progress func() (progress float64, right []string)
 	hijack   func() string
 }
 
@@ -68,12 +68,12 @@ type ProgressBar struct {
 // parameters, either in the constructor or via the Modify() method.
 type ProgressBarOption func(*ProgressBar)
 
-// WithLeft modifies the function that returns the left progressbar padding.
+// WithLeft modifies the function that returns the left progressbar value.
 func WithLeft(left func() string) ProgressBarOption {
 	return func(pb *ProgressBar) { pb.left = left }
 }
 
-// WithConstLeft sets the left progressbar padding to the supplied const.
+// WithConstLeft sets the left progressbar value to the supplied const.
 func WithConstLeft(left string) ProgressBarOption {
 	return func(pb *ProgressBar) {
 		pb.left = func() string { return left }
@@ -86,7 +86,7 @@ func WithLogger(logger *logrus.Entry) ProgressBarOption {
 }
 
 // WithProgress modifies the progress calculation function.
-func WithProgress(progress func() (float64, string)) ProgressBarOption {
+func WithProgress(progress func() (float64, []string)) ProgressBarOption {
 	return func(pb *ProgressBar) { pb.progress = progress }
 }
 
@@ -95,14 +95,14 @@ func WithStatus(status Status) ProgressBarOption {
 	return func(pb *ProgressBar) { pb.status = status }
 }
 
-// WithConstProgress sets the progress and right padding to the supplied consts.
-func WithConstProgress(progress float64, right string) ProgressBarOption {
+// WithConstProgress sets the progress and right values to the supplied consts.
+func WithConstProgress(progress float64, right ...string) ProgressBarOption {
 	return func(pb *ProgressBar) {
-		pb.progress = func() (float64, string) { return progress, right }
+		pb.progress = func() (float64, []string) { return progress, right }
 	}
 }
 
-// WithHijack replaces the progressbar String function with the argument.
+// WithHijack replaces the progressbar Render function with the argument.
 func WithHijack(hijack func() string) ProgressBarOption {
 	return func(pb *ProgressBar) { pb.hijack = hijack }
 }
@@ -127,9 +127,8 @@ func (pb *ProgressBar) Left() string {
 	return pb.renderLeft(0)
 }
 
-// renderLeft renders the left part of the progressbar, applying the
-// given padding and trimming text exceeding maxLen length,
-// replacing it with an ellipsis.
+// renderLeft renders the left part of the progressbar, replacing text
+// exceeding maxLen with an ellipsis.
 func (pb *ProgressBar) renderLeft(maxLen int) string {
 	var left string
 	if pb.left != nil {
@@ -137,8 +136,7 @@ func (pb *ProgressBar) renderLeft(maxLen int) string {
 		if maxLen > 0 && len(l) > maxLen {
 			l = l[:maxLen-3] + "..."
 		}
-		padFmt := fmt.Sprintf("%%-%ds", maxLen)
-		left = fmt.Sprintf(padFmt, l)
+		left = l
 	}
 	return left
 }
@@ -152,27 +150,45 @@ func (pb *ProgressBar) Modify(options ...ProgressBarOption) {
 	}
 }
 
-// Render locks the progressbar struct for reading and calls all of its methods
-// to assemble the progress bar and return it as a string.
+// ProgressBarRender stores the different rendered parts of the
+// progress bar UI.
+type ProgressBarRender struct {
+	Left, Status, Progress, Hijack string
+	Right                          []string
+}
+
+func (pbr ProgressBarRender) String() string {
+	if pbr.Hijack != "" {
+		return pbr.Hijack
+	}
+	var right string
+	if len(pbr.Right) > 0 {
+		right = " " + strings.Join(pbr.Right, "  ")
+	}
+	return fmt.Sprintf("%s %-1s %s%s",
+		pbr.Left, pbr.Status, pbr.Progress, right)
+}
+
+// Render locks the progressbar struct for reading and calls all of
+// its methods to return the final output. A struct is returned over a
+// plain string to allow dynamic padding and positioning of elements
+// depending on other elements on the screen.
 // - leftMax defines the maximum character length of the left-side
-//   text, as well as the padding between the text and the opening
-//   square bracket. Characters exceeding this length will be replaced
-//   with a single ellipsis. Passing <=0 disables this.
-func (pb *ProgressBar) Render(leftMax int) string {
+//   text. Characters exceeding this length will be replaced with a
+//   single ellipsis. Passing <=0 disables this.
+func (pb *ProgressBar) Render(leftMax int) ProgressBarRender {
 	pb.mutex.RLock()
 	defer pb.mutex.RUnlock()
 
+	var out ProgressBarRender
 	if pb.hijack != nil {
-		return pb.hijack()
+		out.Hijack = pb.hijack()
+		return out
 	}
 
-	var (
-		progress float64
-		right    string
-	)
+	var progress float64
 	if pb.progress != nil {
-		progress, right = pb.progress()
-		right = " " + right
+		progress, out.Right = pb.progress()
 		progressClamped := Clampf(progress, 0, 1)
 		if progress != progressClamped {
 			progress = progressClamped
@@ -201,6 +217,13 @@ func (pb *ProgressBar) Render(leftMax int) string {
 		padding = pb.color.Sprint(strings.Repeat("-", space-filled))
 	}
 
-	return fmt.Sprintf("%s%2s [%s%s%s]%s",
-		pb.renderLeft(leftMax), pb.status, filling, caret, padding, right)
+	out.Left = pb.renderLeft(leftMax)
+	status := string(pb.status)
+	if c, ok := statusColors[pb.status]; ok {
+		status = c.Sprint(pb.status)
+	}
+	out.Status = fmt.Sprintf("%-1s", status)
+	out.Progress = fmt.Sprintf("[%s%s%s]", filling, caret, padding)
+
+	return out
 }

--- a/ui/pb/progressbar.go
+++ b/ui/pb/progressbar.go
@@ -48,6 +48,7 @@ const (
 var statusColors = map[Status]*color.Color{
 	Interrupted: color.New(color.FgRed),
 	Done:        color.New(color.FgGreen),
+	Waiting:     color.New(defaultBarColor),
 }
 
 // ProgressBar is a simple thread-safe progressbar implementation with

--- a/ui/pb/progressbar.go
+++ b/ui/pb/progressbar.go
@@ -33,15 +33,15 @@ const defaultWidth = 40
 const defaultBarColor = color.Faint
 
 // Status of the progress bar
-type Status string
+type Status rune
 
 // Progress bar status symbols
 const (
-	Running     Status = " "
-	Waiting     Status = "•"
-	Stopping    Status = "↓"
-	Interrupted Status = "✗"
-	Done        Status = "✓"
+	Running     Status = ' '
+	Waiting     Status = '•'
+	Stopping    Status = '↓'
+	Interrupted Status = '✗'
+	Done        Status = '✓'
 )
 
 //nolint:gochecknoglobals
@@ -219,11 +219,16 @@ func (pb *ProgressBar) Render(leftMax int) ProgressBarRender {
 	}
 
 	out.Left = pb.renderLeft(leftMax)
-	status := string(pb.status)
-	if c, ok := statusColors[pb.status]; ok {
-		status = c.Sprint(pb.status)
+
+	switch c, ok := statusColors[pb.status]; {
+	case ok:
+		out.Status = c.Sprint(string(pb.status))
+	case pb.status > 0:
+		out.Status = string(pb.status)
+	default:
+		out.Status = " "
 	}
-	out.Status = fmt.Sprintf("%-1s", status)
+
 	out.Progress = fmt.Sprintf("[%s%s%s]", filling, caret, padding)
 
 	return out

--- a/ui/pb/progressbar.go
+++ b/ui/pb/progressbar.go
@@ -32,13 +32,32 @@ import (
 const defaultWidth = 40
 const defaultBarColor = color.Faint
 
-// ProgressBar is just a simple thread-safe progressbar implementation with
+// Status of the progress bar
+type Status string
+
+// Progress bar status symbols
+const (
+	Running     Status = " "
+	Waiting     Status = "•"
+	Stopping    Status = "↓"
+	Interrupted Status = "✗"
+	Done        Status = "✓"
+)
+
+//nolint:gochecknoglobals
+var statusColors = map[Status]*color.Color{
+	Interrupted: color.New(color.FgRed),
+	Done:        color.New(color.FgGreen),
+}
+
+// ProgressBar is a simple thread-safe progressbar implementation with
 // callbacks.
 type ProgressBar struct {
 	mutex  sync.RWMutex
 	width  int
 	color  *color.Color
 	logger *logrus.Entry
+	status Status
 
 	left     func() string
 	progress func() (progress float64, right string)
@@ -69,6 +88,11 @@ func WithLogger(logger *logrus.Entry) ProgressBarOption {
 // WithProgress modifies the progress calculation function.
 func WithProgress(progress func() (float64, string)) ProgressBarOption {
 	return func(pb *ProgressBar) { pb.progress = progress }
+}
+
+// WithStatus modifies the progressbar status
+func WithStatus(status Status) ProgressBarOption {
+	return func(pb *ProgressBar) { pb.status = status }
 }
 
 // WithConstProgress sets the progress and right padding to the supplied consts.
@@ -177,6 +201,6 @@ func (pb *ProgressBar) Render(leftMax int) string {
 		padding = pb.color.Sprint(strings.Repeat("-", space-filled))
 	}
 
-	return fmt.Sprintf("%s [%s%s%s]%s",
-		pb.renderLeft(leftMax), filling, caret, padding, right)
+	return fmt.Sprintf("%s%2s [%s%s%s]%s",
+		pb.renderLeft(leftMax), pb.status, filling, caret, padding, right)
 }

--- a/ui/pb/progressbar.go
+++ b/ui/pb/progressbar.go
@@ -166,8 +166,7 @@ func (pbr ProgressBarRender) String() string {
 	if len(pbr.Right) > 0 {
 		right = " " + strings.Join(pbr.Right, "  ")
 	}
-	return fmt.Sprintf("%s %-1s %s%s",
-		pbr.Left, pbr.Status, pbr.Progress, right)
+	return pbr.Left + " " + pbr.Status + " " + pbr.Progress + right
 }
 
 // Render locks the progressbar struct for reading and calls all of

--- a/ui/pb/progressbar_test.go
+++ b/ui/pb/progressbar_test.go
@@ -44,39 +44,44 @@ func TestProgressBarRender(t *testing.T) {
 		expected string
 	}{
 		{[]ProgressBarOption{WithLeft(func() string { return "left" })},
-			"left [--------------------------------------]"},
+			"left   [--------------------------------------]"},
 		{[]ProgressBarOption{WithConstLeft("constLeft")},
-			"constLeft [--------------------------------------]"},
+			"constLeft   [--------------------------------------]"},
 		{[]ProgressBarOption{
 			WithLeft(func() string { return "left" }),
-			WithProgress(func() (float64, string) { return 0, "right" }),
+			WithStatus(Done),
 		},
-			"left [--------------------------------------] right"},
+			"left ✓ [--------------------------------------]"},
 		{[]ProgressBarOption{
 			WithLeft(func() string { return "left" }),
-			WithProgress(func() (float64, string) { return 0.5, "right" }),
+			WithProgress(func() (float64, []string) { return 0, []string{"right"} }),
 		},
-			"left [==================>-------------------] right"},
+			"left   [--------------------------------------] right"},
 		{[]ProgressBarOption{
 			WithLeft(func() string { return "left" }),
-			WithProgress(func() (float64, string) { return 1.0, "right" }),
+			WithProgress(func() (float64, []string) { return 0.5, []string{"right"} }),
 		},
-			"left [======================================] right"},
+			"left   [==================>-------------------] right"},
 		{[]ProgressBarOption{
 			WithLeft(func() string { return "left" }),
-			WithProgress(func() (float64, string) { return -1, "right" }),
+			WithProgress(func() (float64, []string) { return 1.0, []string{"right"} }),
 		},
-			"left [--------------------------------------] right"},
+			"left   [======================================] right"},
 		{[]ProgressBarOption{
 			WithLeft(func() string { return "left" }),
-			WithProgress(func() (float64, string) { return 2, "right" }),
+			WithProgress(func() (float64, []string) { return -1, []string{"right"} }),
 		},
-			"left [======================================] right"},
+			"left   [--------------------------------------] right"},
+		{[]ProgressBarOption{
+			WithLeft(func() string { return "left" }),
+			WithProgress(func() (float64, []string) { return 2, []string{"right"} }),
+		},
+			"left   [======================================] right"},
 		{[]ProgressBarOption{
 			WithLeft(func() string { return "left" }),
 			WithConstProgress(0.2, "constProgress"),
 		},
-			"left [======>-------------------------------] constProgress"},
+			"left   [======>-------------------------------] constProgress"},
 		{[]ProgressBarOption{
 			WithHijack(func() string { return "progressbar hijack!" }),
 		},
@@ -88,7 +93,7 @@ func TestProgressBarRender(t *testing.T) {
 		t.Run(tc.expected, func(t *testing.T) {
 			pbar := New(tc.options...)
 			assert.NotNil(t, pbar)
-			assert.Equal(t, tc.expected, pbar.Render(0))
+			assert.Equal(t, tc.expected, pbar.Render(0).String())
 		})
 	}
 }
@@ -101,12 +106,10 @@ func TestProgressBarRenderPaddingMaxLeft(t *testing.T) {
 		left     string
 		expected string
 	}{
-		{-1, "left", "left [--------------------------------------]"},
-		{0, "left", "left [--------------------------------------]"},
-		{15, "left_pad",
-			"left_pad        [--------------------------------------]"},
+		{-1, "left", "left   [--------------------------------------]"},
+		{0, "left", "left   [--------------------------------------]"},
 		{10, "left_truncated",
-			"left_tr... [--------------------------------------]"},
+			"left_tr...   [--------------------------------------]"},
 	}
 
 	for _, tc := range testCases {
@@ -114,7 +117,7 @@ func TestProgressBarRenderPaddingMaxLeft(t *testing.T) {
 		t.Run(tc.left, func(t *testing.T) {
 			pbar := New(WithLeft(func() string { return tc.left }))
 			assert.NotNil(t, pbar)
-			assert.Equal(t, tc.expected, pbar.Render(tc.maxLen))
+			assert.Equal(t, tc.expected, pbar.Render(tc.maxLen).String())
 		})
 	}
 }


### PR DESCRIPTION
This implements a couple of features discussed in #1279:

- General cleanup of the right-side progress bar text: shorter, split into two columns, correct alignment. Initially I experimented with tabwriter to achieve this simply with tabs, but there would always be an edge case that would unexpectedly cause columns to shift further right, so tabs weren't reliable. The alignments done manually here with `fmt` padding unfortunately complicate the render code quite a bit, so let me know if it can be simplified. I still think it's worth it as columns make the progress much easier to follow, even though they don't strictly contain homogeneous elements.
- Adding a "status" column and field to `ProgressBar` to indicate when the executor is stopping, done, etc. This is shown after the executor name, for lack of a better place, and takes up a fixed 2 chars. There's a minor bug in that the interrupted status is sometimes not rendered when pressing `^C`. Some kind of race condition... Related to this, should we wait for `max(gracefulStop)` before exiting, and force-exit with another `^C`? I think that would be better UX.

Here's what it looks like currently:
![2020-01-16-174117_983x298_scrot](https://user-images.githubusercontent.com/1009277/72552998-3b578f80-3898-11ea-9751-ad63abcdd2f0.png)