### PR TITLE
Use non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk --no-cache add git
 RUN CGO_ENABLED=0 go install -a -trimpath -ldflags "-s -w -X github.com/loadimpact/k6/lib/consts.VersionDetails=$(date -u +"%FT%T%z")/$(git describe --always --long --dirty)"
 
 FROM alpine:3.10
-RUN apk add --no-cache ca-certificates curl && \
+RUN apk add --no-cache ca-certificates && \
     adduser -D -u 12345 -g 12345 k6
 COPY --from=builder /go/bin/k6 /usr/bin/k6
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ RUN apk --no-cache add git
 RUN CGO_ENABLED=0 go install -a -trimpath -ldflags "-s -w -X github.com/loadimpact/k6/lib/consts.VersionDetails=$(date -u +"%FT%T%z")/$(git describe --always --long --dirty)"
 
 FROM alpine:3.10
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates curl && \
+    adduser -D -u 12345 -g 12345 k6
 COPY --from=builder /go/bin/k6 /usr/bin/k6
+
+USER 12345
 ENTRYPOINT ["k6"]


### PR DESCRIPTION
Hey guys,

We're using k6 as part of our CI/CD system in Kubernetes, with PodSecurityPolicies enforced. This means we need all containers to run as non-root, with a numeric UID.

This PR alters the k6 Docker image to run as user "k6" (UID 12345), and also installs curl, which is helpful for interacting with the istio-proxy sidecar during job execution (https://github.com/istio/istio/issues/11659)

Cheers!
D