### PR TITLE
Implement GetStripedOffsets

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -54,6 +54,7 @@ func optionFlagSet() *pflag.FlagSet {
 	flags.Int64P("iterations", "i", 0, "script total iteration limit (among all VUs)")
 	flags.StringSliceP("stage", "s", nil, "add a `stage`, as `[duration]:[target]`")
 	flags.String("execution-segment", "", "limit execution to the specified segment, e.g. 10%, 1/3, 0.2:2/3")
+	flags.String("execution-segment-sequence", "", "the execution segment sequence") // TODO better description
 	flags.BoolP("paused", "p", false, "start the test in a paused state")
 	flags.Bool("no-setup", false, "don't run setup()")
 	flags.Bool("no-teardown", false, "don't run teardown()")
@@ -150,6 +151,19 @@ func getOptions(flags *pflag.FlagSet) (lib.Options, error) {
 			return opts, err
 		}
 		opts.ExecutionSegment = segment
+	}
+
+	if flags.Changed("execution-segment-sequence") {
+		executionSegmentSequenceStr, err := flags.GetString("execution-segment-sequence")
+		if err != nil {
+			return opts, err
+		}
+		segmentSequence := new(lib.ExecutionSegmentSequence)
+		err = segmentSequence.UnmarshalText([]byte(executionSegmentSequenceStr))
+		if err != nil {
+			return opts, err
+		}
+		opts.ESS = segmentSequence
 	}
 	if flags.Changed("system-tags") {
 		systemTagList, err := flags.GetStringSlice("system-tags")

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -163,8 +163,9 @@ func getOptions(flags *pflag.FlagSet) (lib.Options, error) {
 		if err != nil {
 			return opts, err
 		}
-		opts.ESS = segmentSequence
+		opts.ExecutionSegmentSequence = segmentSequence
 	}
+
 	if flags.Changed("system-tags") {
 		systemTagList, err := flags.GetStringSlice("system-tags")
 		if err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -241,7 +241,7 @@ a commandline interface for interacting with it.`,
 			)
 			for _, ec := range executorConfigs {
 				fprintf(stdout, "           * %s: %s\n",
-					ec.GetName(), ec.GetDescription(conf.ExecutionSegment))
+					ec.GetName(), ec.GetDescription(execScheduler.GetState().ExecutionTuple))
 			}
 			fprintf(stdout, "\n")
 		}

--- a/core/local/local.go
+++ b/core/local/local.go
@@ -59,7 +59,6 @@ var _ lib.ExecutionScheduler = &ExecutionScheduler{}
 // doesn't initialize the executors and it doesn't initialize or run VUs.
 func NewExecutionScheduler(runner lib.Runner, logger *logrus.Logger) (*ExecutionScheduler, error) {
 	options := runner.GetOptions()
-	// TODO figure out a way to give it to executionStage that is not terrible
 	et, err := lib.NewExecutionTuple(options.ExecutionSegment, options.ExecutionSegmentSequence)
 	if err != nil {
 		return nil, err

--- a/core/local/local.go
+++ b/core/local/local.go
@@ -60,12 +60,15 @@ var _ lib.ExecutionScheduler = &ExecutionScheduler{}
 func NewExecutionScheduler(runner lib.Runner, logger *logrus.Logger) (*ExecutionScheduler, error) {
 	options := runner.GetOptions()
 	// TODO figure out a way to give it to executionStage that is not terrible
-	et := lib.NewExecutionTuple(options.ExecutionSegment, options.ExecutionSegmentSequence)
+	et, err := lib.NewExecutionTuple(options.ExecutionSegment, options.ExecutionSegmentSequence)
+	if err != nil {
+		return nil, err
+	}
 	executionPlan := options.Execution.GetFullExecutionRequirements(et)
 	maxPlannedVUs := lib.GetMaxPlannedVUs(executionPlan)
 	maxPossibleVUs := lib.GetMaxPossibleVUs(executionPlan)
 
-	executionState := lib.NewExecutionState(options, maxPlannedVUs, maxPossibleVUs)
+	executionState := lib.NewExecutionState(options, et, maxPlannedVUs, maxPossibleVUs)
 	maxDuration, _ := lib.GetEndOffset(executionPlan) // we don't care if the end offset is final
 
 	executorConfigs := options.Execution.GetSortedConfigs()

--- a/core/local/local.go
+++ b/core/local/local.go
@@ -59,8 +59,9 @@ var _ lib.ExecutionScheduler = &ExecutionScheduler{}
 // doesn't initialize the executors and it doesn't initialize or run VUs.
 func NewExecutionScheduler(runner lib.Runner, logger *logrus.Logger) (*ExecutionScheduler, error) {
 	options := runner.GetOptions()
-
-	executionPlan := options.Execution.GetFullExecutionRequirements(options.ExecutionSegment)
+	// TODO figure out a way to give it to executionStage that is not terrible
+	et := lib.NewExecutionTuple(options.ExecutionSegment, options.ExecutionSegmentSequence)
+	executionPlan := options.Execution.GetFullExecutionRequirements(et)
 	maxPlannedVUs := lib.GetMaxPlannedVUs(executionPlan)
 	maxPossibleVUs := lib.GetMaxPossibleVUs(executionPlan)
 
@@ -71,7 +72,7 @@ func NewExecutionScheduler(runner lib.Runner, logger *logrus.Logger) (*Execution
 	executors := make([]lib.Executor, 0, len(executorConfigs))
 	// Only take executors which have work.
 	for _, sc := range executorConfigs {
-		if !sc.HasWork(options.ExecutionSegment) {
+		if !sc.HasWork(et) {
 			logger.Warnf(
 				"Executor '%s' is disabled for segment %s due to lack of work!",
 				sc.GetName(), options.ExecutionSegment,

--- a/lib/execution.go
+++ b/lib/execution.go
@@ -272,7 +272,7 @@ type ExecutionState struct {
 // NewExecutionState initializes all of the pointers in the ExecutionState
 // with zeros. It also makes sure that the initial state is unpaused, by
 // setting resumeNotify to an already closed channel.
-func NewExecutionState(options Options, maxPlannedVUs, maxPossibleVUs uint64) *ExecutionState {
+func NewExecutionState(options Options, et *ExecutionTuple, maxPlannedVUs, maxPossibleVUs uint64) *ExecutionState {
 	resumeNotify := make(chan struct{})
 	close(resumeNotify) // By default the ExecutionState starts unpaused
 
@@ -295,10 +295,7 @@ func NewExecutionState(options Options, maxPlannedVUs, maxPossibleVUs uint64) *E
 		pauseStateLock:             sync.RWMutex{},
 		totalPausedDuration:        0, // Accessed only behind the pauseStateLock
 		resumeNotify:               resumeNotify,
-		ExecutionTuple: NewExecutionTuple(
-			options.ExecutionSegment,
-			options.ExecutionSegmentSequence,
-		),
+		ExecutionTuple:             et,
 	}
 }
 

--- a/lib/execution.go
+++ b/lib/execution.go
@@ -150,6 +150,8 @@ type ExecutionState struct {
 	// via the Go type system...
 	Options Options
 
+	ExecutionTuple *ExecutionTuple // TODO Rename, possibly move
+
 	// vus is the shared channel buffer that contains all of the VUs that have
 	// been initialized and aren't currently being used by a executor.
 	//
@@ -293,6 +295,10 @@ func NewExecutionState(options Options, maxPlannedVUs, maxPossibleVUs uint64) *E
 		pauseStateLock:             sync.RWMutex{},
 		totalPausedDuration:        0, // Accessed only behind the pauseStateLock
 		resumeNotify:               resumeNotify,
+		ExecutionTuple: NewExecutionTuple(
+			options.ExecutionSegment,
+			options.ExecutionSegmentSequence,
+		),
 	}
 }
 

--- a/lib/execution_segment.go
+++ b/lib/execution_segment.go
@@ -395,20 +395,33 @@ func (ess ExecutionSegmentSequence) String() string {
 	return strings.Join(result, ",")
 }
 
-// lowest common denominator based on https://rosettacode.org/wiki/Least_common_multiple#Go
+// lowest common denominator
+// https://en.wikipedia.org/wiki/Least_common_multiple#Using_the_greatest_common_divisor
 func (ess ExecutionSegmentSequence) lcd() int64 {
-	var m, n, z big.Int
-	z = *ess[0].length.Denom()
+	var acc = ess[0].length.Denom().Int64()
+	var n int64
 	for _, seg := range ess[1:] {
-		m = z
-		n = *seg.length.Denom()
-		if m.Cmp(&n) == 0 {
+		n = seg.length.Denom().Int64()
+		if acc == n || acc%n == 0 { // short circuit
 			continue
 		}
-		z.Mul(z.Div(&m, z.GCD(nil, nil, &m, &n)), &n)
+		acc = acc * n / gcd(acc, n)
 	}
 
-	return z.Int64()
+	return acc
+}
+
+// Greatest common divisor
+// https://en.wikipedia.org/wiki/Euclidean_algorithm
+func gcd(a, b int64) int64 {
+	for a != b {
+		if a > b {
+			a -= b
+		} else {
+			b -= a
+		}
+	}
+	return a
 }
 
 // GetStripedOffsets returns everything that you need in order to execute only

--- a/lib/execution_segment.go
+++ b/lib/execution_segment.go
@@ -418,35 +418,34 @@ func (ess ExecutionSegmentSequence) lcd() int64 {
 // TODO: basically https://docs.google.com/spreadsheets/d/1V_ivN2xuaMJIgOf1HkpOw1ex8QOhxp960itGGiRrNzo/edit
 func (ess ExecutionSegmentSequence) GetStripedOffsets(segment *ExecutionSegment) (int64, []int64, int64, error) {
 	// TODO check if ExecutionSegmentSequence actually starts from 0 and goes to 1 ?
-	var matchingSegment *ExecutionSegment
-	for _, seg := range ess {
-		if seg.Equal(segment) {
-			matchingSegment = seg
-			break
-		}
-	}
-	if matchingSegment == nil {
-		return -1, nil, -1, fmt.Errorf("missing segment %s inside segment sequence %s", segment, ess)
-	}
-
-	ess = append([]*ExecutionSegment{}, ess...)
-	sort.SliceStable(ess,
-		func(i, j int) bool {
-			// Yes this Less is actually More, but we want it sorted in descending order and the alternative is to reverse it after sort
-			return ess[i].length.Cmp(ess[j].length) > 0
-		})
+	ess = append([]*ExecutionSegment{}, ess...) // copy the original sequence
 
 	var numerators = make([]int64, len(ess))
-	var numeratorChanges = make([]*big.Rat, len(ess))
+	var steps = make([]*big.Rat, len(ess))
 	var soonest = make([]*big.Rat, len(ess))
 	var lcd = ess.lcd()
 
 	for i := range ess {
 		numerators[i] = ess[i].length.Num().Int64() * (lcd / ess[i].length.Denom().Int64())
 		soonest[i] = big.NewRat(0, 1)
-		numeratorChanges[i] = big.NewRat(lcd, numerators[i])
+		steps[i] = big.NewRat(lcd, numerators[i])
 	}
 
+	sort.Stable(sortInterfaceWrapper{
+		numerators: numerators,
+		steps:      steps,
+		ess:        ess,
+	})
+	var segmentIndex = -1
+	for i, seg := range ess {
+		if seg.Equal(segment) {
+			segmentIndex = i
+			break
+		}
+	}
+	if segmentIndex == -1 {
+		return -1, nil, -1, fmt.Errorf("missing segment %s inside segment sequence %s", segment, ess)
+	}
 	start := int64(-1)
 	var offsets []int64 // TODO we can preallocate this
 
@@ -455,8 +454,8 @@ OUTER:
 		for index, value := range soonest {
 			num, denom := value.Num().Int64(), value.Denom().Int64()
 			if i > num/denom || (i == num/denom && num%denom == 0) {
-				value.Add(value, numeratorChanges[index])
-				if ess[index] == matchingSegment {
+				value.Add(value, steps[index])
+				if index == segmentIndex {
 					// TODO: this can be done for all segments and then we only get what we care about
 					if start < 0 {
 						start = i
@@ -477,4 +476,30 @@ OUTER:
 	}
 
 	return start, offsets, lcd, nil
+}
+
+// This is only needed in order to sort all three at the same time
+type sortInterfaceWrapper struct { // TODO: rename ?
+	numerators []int64
+	steps      []*big.Rat
+	ess        ExecutionSegmentSequence
+}
+
+// Len is the number of elements in the collection.
+func (e sortInterfaceWrapper) Len() int {
+	return len(e.numerators)
+}
+
+// Less reports whether the element with
+// index i should sort before the element with index j.
+func (e sortInterfaceWrapper) Less(i, j int) bool {
+	// Yes this Less is actually More, but we want it sorted in descending order
+	return e.numerators[i] > e.numerators[j]
+}
+
+// Swap swaps the elements with indexes i and j.
+func (e sortInterfaceWrapper) Swap(i, j int) {
+	e.numerators[i], e.numerators[j] = e.numerators[j], e.numerators[i]
+	e.steps[i], e.steps[j] = e.steps[j], e.steps[i]
+	e.ess[i], e.ess[j] = e.ess[j], e.ess[i]
 }

--- a/lib/execution_segment.go
+++ b/lib/execution_segment.go
@@ -434,12 +434,14 @@ func (ess ExecutionSegmentSequence) GetStripedOffsets(segment *ExecutionSegment)
 		})
 
 	var numerators = make([]int64, len(ess))
+	var numeratorChanges = make([]*big.Rat, len(ess))
 	var soonest = make([]*big.Rat, len(ess))
 	var lcd = ess.lcd()
 
 	for i := range ess {
 		numerators[i] = ess[i].length.Num().Int64() * (lcd / ess[i].length.Denom().Int64())
 		soonest[i] = big.NewRat(0, 1)
+		numeratorChanges[i] = big.NewRat(lcd, numerators[i])
 	}
 
 	start := int64(-1)
@@ -449,7 +451,7 @@ func (ess ExecutionSegmentSequence) GetStripedOffsets(segment *ExecutionSegment)
 		var iRat = big.NewRat(i, 1)
 		for index, value := range soonest {
 			if iRat.Cmp(value) >= 0 {
-				value.Add(value, big.NewRat(lcd, numerators[index]))
+				value.Add(value, numeratorChanges[index])
 				if ess[index] == matchingSegment {
 					// TODO: this can be done for all segments and then we only get what we care about
 					if start < 0 {

--- a/lib/execution_segment.go
+++ b/lib/execution_segment.go
@@ -395,21 +395,6 @@ func (ess ExecutionSegmentSequence) String() string {
 	return strings.Join(result, ",")
 }
 
-func (ess ExecutionSegmentSequence) Len() int {
-	return len(ess)
-}
-
-func (ess ExecutionSegmentSequence) Less(i, j int) bool {
-	// Yes this Less is actually More, but we want it sorted in descending order and the alternative is to reverse it after sort
-	return ess[i].length.Cmp(ess[j].length) > 0
-}
-
-func (ess ExecutionSegmentSequence) Swap(i, j int) {
-	ess[i], ess[j] = ess[j], ess[i]
-}
-
-var _ sort.Interface = ExecutionSegmentSequence{}
-
 // lowest common denominator based on https://rosettacode.org/wiki/Least_common_multiple#Go
 func (ess ExecutionSegmentSequence) lcd() int64 {
 	var m, n, z big.Int
@@ -440,7 +425,13 @@ func (ess ExecutionSegmentSequence) GetStripedOffsets(segment *ExecutionSegment)
 	if matchingSegment == nil {
 		return -1, nil, fmt.Errorf("missing segment %s inside segment sequence %s", segment, ess) // TODO: make a seperate error ?
 	}
-	sort.Stable(ess) // TODO: Use Stable ? copy the sequence ?
+
+	ess = append([]*ExecutionSegment{}, ess...)
+	sort.SliceStable(ess,
+		func(i, j int) bool {
+			// Yes this Less is actually More, but we want it sorted in descending order and the alternative is to reverse it after sort
+			return ess[i].length.Cmp(ess[j].length) > 0
+		})
 
 	var numerators = make([]int64, len(ess))
 	var soonest = make([]*big.Rat, len(ess))

--- a/lib/execution_segment.go
+++ b/lib/execution_segment.go
@@ -549,7 +549,7 @@ func NewExecutionTuple(segment *ExecutionSegment, sequence *ExecutionSegmentSequ
 
 	et.esIndex = et.find(segment)
 	if et.esIndex == -1 {
-		return nil, fmt.Errorf("coulnd't find segment %s in sequence %s", segment, sequence)
+		return nil, fmt.Errorf("couldn't find segment %s in sequence %s", segment, sequence)
 	}
 	return &et, nil
 }

--- a/lib/execution_segment.go
+++ b/lib/execution_segment.go
@@ -402,6 +402,9 @@ func (ess ExecutionSegmentSequence) lcd() int64 {
 	for _, seg := range ess[1:] {
 		m = z
 		n = *seg.length.Denom()
+		if m.Cmp(&n) == 0 {
+			continue
+		}
 		z.Mul(z.Div(&m, z.GCD(nil, nil, &m, &n)), &n)
 	}
 

--- a/lib/execution_segment.go
+++ b/lib/execution_segment.go
@@ -576,6 +576,9 @@ func (et *ExecutionTuple) ScaleInt64(value int64) int64 {
 	if et.esIndex == -1 {
 		return 0
 	}
+	if len(et.sequence) == 1 {
+		return value
+	}
 	et.once.Do(et.fillCache)
 	offsets := et.offsetsCache[et.esIndex]
 	return scaleInt64(value, offsets[0], offsets[1:], et.lcd)
@@ -583,7 +586,7 @@ func (et *ExecutionTuple) ScaleInt64(value int64) int64 {
 
 // scaleInt64With scales the provided value based on the ExecutionTuples'
 // sequence and the segment provided
-func (et *ExecutionTuple) scaleInt64With(value int64, es *ExecutionSegment) int64 {
+func (et *ExecutionTuple) scaleInt64With(value int64, es *ExecutionSegment) int64 { //nolint:unused
 	start, offsets, lcd := et.GetStripedOffsets(es)
 	return scaleInt64(value, start, offsets, lcd)
 }

--- a/lib/execution_segment.go
+++ b/lib/execution_segment.go
@@ -413,7 +413,7 @@ func (ess ExecutionSegmentSequence) lcd() int64 {
 //
 // TODO: add a more detailed algorithm description
 // TODO: basically https://docs.google.com/spreadsheets/d/1V_ivN2xuaMJIgOf1HkpOw1ex8QOhxp960itGGiRrNzo/edit
-func (ess ExecutionSegmentSequence) GetStripedOffsets(segment *ExecutionSegment) (int64, []int64, error) {
+func (ess ExecutionSegmentSequence) GetStripedOffsets(segment *ExecutionSegment) (int64, []int64, int64, error) {
 	// TODO check if ExecutionSegmentSequence actually starts from 0 and goes to 1 ?
 	var matchingSegment *ExecutionSegment
 	for _, seg := range ess {
@@ -423,7 +423,7 @@ func (ess ExecutionSegmentSequence) GetStripedOffsets(segment *ExecutionSegment)
 		}
 	}
 	if matchingSegment == nil {
-		return -1, nil, fmt.Errorf("missing segment %s inside segment sequence %s", segment, ess) // TODO: make a seperate error ?
+		return -1, nil, -1, fmt.Errorf("missing segment %s inside segment sequence %s", segment, ess)
 	}
 
 	ess = append([]*ExecutionSegment{}, ess...)
@@ -457,7 +457,11 @@ func (ess ExecutionSegmentSequence) GetStripedOffsets(segment *ExecutionSegment)
 					if start < 0 {
 						start = i
 					} else {
-						offsets = append(offsets, i)
+						prev := start
+						if len(offsets) > 0 {
+							prev = offsets[len(offsets)-1]
+						}
+						offsets = append(offsets, i-prev)
 					}
 					// we can stop iterating the moment len(offsets) + 1 = numerator and we have set start ...
 				}
@@ -466,5 +470,5 @@ func (ess ExecutionSegmentSequence) GetStripedOffsets(segment *ExecutionSegment)
 		}
 	}
 
-	return start, offsets, nil
+	return start, offsets, lcd, nil
 }

--- a/lib/execution_segment.go
+++ b/lib/execution_segment.go
@@ -26,6 +26,7 @@ import (
 	"math/big"
 	"sort"
 	"strings"
+	"sync"
 )
 
 // ExecutionSegment represents a (start, end] partition of the total execution
@@ -405,7 +406,7 @@ func (ess ExecutionSegmentSequence) lcd() int64 {
 		if acc == n || acc%n == 0 { // short circuit
 			continue
 		}
-		acc = acc * n / gcd(acc, n)
+		acc *= (n / gcd(acc, n))
 	}
 
 	return acc
@@ -424,122 +425,246 @@ func gcd(a, b int64) int64 {
 	return a
 }
 
-// GetStripedOffsets returns everything that you need in order to execute only
-// the iterations that belong to the supplied segment...
-//
-// TODO: add a more detailed algorithm description
-// TODO: basically https://docs.google.com/spreadsheets/d/1V_ivN2xuaMJIgOf1HkpOw1ex8QOhxp960itGGiRrNzo/edit
-func (ess *ExecutionSegmentSequence) GetStripedOffsets(segment *ExecutionSegment) (int64, []int64, int64, error) {
-	if segment == nil || segment.length.Cmp(oneRat) == 0 {
-		return 0, []int64{1}, 1, nil
+type sortInterfaceWrapper struct { // TODO: rename ? delete ? and replace ?
+	slice []struct { // TODO better name ? maybe  a type of it's own ?
+		numerator     int64
+		originalIndex int
 	}
-
-	// we will copy the sequnce to this in order to sort it :)
-	var copyESS ExecutionSegmentSequence
-	// Here we fix the problem with having no sequence
-	// No filling up is required as the algorithm will accommodate for it
-	// through just going through the iterations that need to be in the values will fill up
-	// this has the consequence that if this is ran without sequence,
-	// but with segments: 0:1/3 and 1/3:2/3 it will get the same results instead
-	// of 1/3:2/3 to get start=1 and offset={3} it will get as 0:1/3 will start=0 and offsets={3}
-	// if the above behaviour is desired this will definitely need to be outside of this function.
-	if ess == nil || len(*ess) == 0 {
-		copyESS = []*ExecutionSegment{segment}
-	} else {
-		copyESS = append([]*ExecutionSegment{}, *ess...) // copy the original sequence
-	}
-	var wrapper = newWrapper(copyESS)
-
-	var segmentIndex = wrapper.indexOf(segment)
-	if segmentIndex == -1 {
-		return -1, nil, -1, fmt.Errorf("missing segment %s inside segment sequence %s", segment, ess)
-	}
-	start, offsets := wrapper.strippedOffsetsFor(segmentIndex)
-	return start, offsets, wrapper.lcd, nil
-}
-
-// This is only needed in order to sort all three at the same time
-type sortInterfaceWrapper struct { // TODO: rename ?
-	ess        ExecutionSegmentSequence
-	numerators []int64
-	lcd        int64
+	lcd int64
 }
 
 func newWrapper(ess ExecutionSegmentSequence) sortInterfaceWrapper {
 	var result = sortInterfaceWrapper{
-		ess:        ess,
-		numerators: make([]int64, len(ess)),
-		lcd:        ess.lcd(),
+		slice: make([]struct {
+			numerator     int64
+			originalIndex int
+		}, len(ess)),
+		lcd: ess.lcd(),
 	}
 
 	for i := range ess {
-		result.numerators[i] = ess[i].length.Num().Int64() * (result.lcd / ess[i].length.Denom().Int64())
+		result.slice[i].numerator = ess[i].length.Num().Int64() * (result.lcd / ess[i].length.Denom().Int64())
+		result.slice[i].originalIndex = i
 	}
 
-	sort.Stable(result)
+	sort.SliceStable(result.slice, func(i, j int) bool {
+		return result.slice[i].numerator > result.slice[j].numerator
+	})
 	return result
 }
 
-func (e sortInterfaceWrapper) indexOf(segment *ExecutionSegment) int {
-	for i, seg := range e.ess {
-		if seg.Equal(segment) {
-			return i
-		}
-	}
+// Imagine you have a number of rational numbers which all add up to 1 (or less) and call them
+// segments.
+// If you want each to get proportional amount of anything you need to give them their numerator
+// count of elements for each denominator amount from the original elements. So for 1/3 you give 1
+// element for each 3 elements. For 3/5 - 3 elements for each 5.
+// If you have for example a sequence of with element with length 3/5 and 1/3 in order to know how
+// to distribute it accurately you need to get the LCD(lowest common denominitor) in this case
+// between 3 and 5 this is 15 and then to transform the numbers to have the same, LCD equal,
+// denominator. So 3/5 becomes 9/15 and 1/3 becomes 5/15. So now for each 15 elements 9 need to go
+// to the 3/5, and 5 need to go to 1/3.
+//
+// We use the below algorithm to split elements between ExecutionSegments by using their length as
+// the rational number. As we would like to get non sequential elements we try to get the maximum
+// distance between them. That is the number of elements divided by the number of elements for any
+// given segment, which concidently is the length of the segment reversed.
+// The algorithm below does the following:
+// 1. Goes through the elements from 0 to the lcd-1
+// 2. For each of element goes through the segments and looks if the amount of already taken
+// elements by the given segment multiplied by that segment length inverted is equal to or less to
+// the current element index. if it is give that element to that segment if not continue with the
+// next element.
+//
+// The code below specifically avoids using big.Rat which complicates the code somewhat.
+// As additional note the sorting of the segments from biggest to smallest helps with the fact that
+// the biggest elements will need to take the most elements and for them it will be the hardest to
+// not get sequential elements.
+func (e sortInterfaceWrapper) stripingAlgorithm(saveIndex func(iteration int64, index int, numerator int64) bool) {
+	var chosenCounts = make([]int64, len(e.slice))
 
-	return -1
-}
-
-func (e sortInterfaceWrapper) strippedOffsetsFor(segmentIndex int) (int64, []int64) {
-	var offsets = make([]int64, 0, e.numerators[segmentIndex]+1)
-	var chosenCounts = make([]int64, len(e.ess))
-	// Here instead of calculating steps which need to be big.Rat, we use the fact that
-	// the steps are always the length of the segment inverted which also is lcd/numerator
-	// So instead of creating and adding up big.Rat we just multiply the step by the amount
-	// of times given segment has been chosen which is count * lcd / numerator and use that
-	// this both saves on a lot of big.Rat allocations and also on a lot of unneeded calculations
-	// with them.
-
+outer:
 	for i := int64(0); i < e.lcd; i++ {
 		for index, chosenCount := range chosenCounts {
 			num := chosenCount * e.lcd
-			denom := e.numerators[index]
+			denom := e.slice[index].numerator
 			if i > num/denom || (i == num/denom && num%denom == 0) {
 				chosenCounts[index]++
-				if index == segmentIndex {
-					prev := int64(0)
-					if len(offsets) > 0 {
-						prev = offsets[len(offsets)-1]
-					}
-					offsets = append(offsets, i-prev)
-					if int64(len(offsets)) == e.numerators[index] {
-						offsets = append(offsets, offsets[0]+e.lcd-i)
-						return offsets[0], offsets[1:]
-					}
+				if saveIndex(i, e.slice[index].originalIndex, denom) {
+					break outer
 				}
 				break
 			}
 		}
 	}
-
-	// TODO return some error if we get to here
-	return offsets[0], offsets[1:]
 }
 
-// Len is the number of elements in the collection.
-func (e sortInterfaceWrapper) Len() int {
-	return len(e.numerators)
+// ExecutionTuple is here to represent the combination of ExecutionSegmentSequence and
+// ExecutionSegment and to give easy access to a couple of algorithms based on them in a way that is
+// somewhat perfomant for which it generally needs to cache the results
+type ExecutionTuple struct { // TODO rename
+	ES *ExecutionSegment // TODO unexport this as well?
+
+	// TODO: have the index of the segment, cached?
+	sequence     ExecutionSegmentSequence
+	offsetsCache [][]int64
+	lcd          int64
+	// TODO discuss if we just don't want to fillCache in the constructor and not need to use pointer receivers everywhere
+	once *sync.Once
 }
 
-// Less reports whether the element with
-// index i should sort before the element with index j.
-func (e sortInterfaceWrapper) Less(i, j int) bool {
-	// Yes this Less is actually More, but we want it sorted in descending order
-	return e.numerators[i] > e.numerators[j]
+func fillSequence(sequence ExecutionSegmentSequence) ExecutionSegmentSequence {
+	// TODO: discuss if we want to get the lcd of the sequence and fill with it elements of length 1/lcd ?
+	if sequence[0].from.Cmp(zeroRat) != 0 {
+		es, err := NewExecutionSegment(zeroRat, sequence[0].from)
+		if err != nil {
+			panic(err) // this really can't happen
+		}
+
+		sequence = append(ExecutionSegmentSequence{es}, sequence...)
+	}
+
+	if sequence[len(sequence)-1].to.Cmp(oneRat) != 0 {
+		es, err := NewExecutionSegment(sequence[len(sequence)-1].to, oneRat)
+		if err != nil {
+			panic(err) // this really can't happen
+		}
+
+		sequence = append(sequence, es)
+	}
+	return sequence
 }
 
-// Swap swaps the elements with indexes i and j.
-func (e sortInterfaceWrapper) Swap(i, j int) {
-	e.numerators[i], e.numerators[j] = e.numerators[j], e.numerators[i]
-	e.ess[i], e.ess[j] = e.ess[j], e.ess[i]
+// NewExecutionTuple returns a new ExecutionTuple for the provided segment and sequence
+func NewExecutionTuple(segment *ExecutionSegment, sequence *ExecutionSegmentSequence) *ExecutionTuple {
+	if segment == nil { // TODO: try to do something better, maybe have bool flag in the ExecutionTuple or something
+		// this is needed in order to know that a segment == nil means that after
+		// GetNewExecutionTupleBasedOnValues the original segment scaled to 0 length one and as such
+		// should it be used it should always get 0 as values
+		segment, _ = NewExecutionSegmentFromString("0:1")
+	}
+	et := ExecutionTuple{
+		once: new(sync.Once),
+		ES:   segment,
+	}
+	if sequence == nil || len(*sequence) == 0 {
+		if segment == nil || segment.length.Cmp(oneRat) == 0 {
+			et.sequence = ExecutionSegmentSequence{segment}
+		} else {
+			et.sequence = fillSequence(ExecutionSegmentSequence{segment})
+		}
+	} else {
+		et.sequence = fillSequence(*sequence)
+	}
+	return &et
+}
+
+func (et *ExecutionTuple) find(segment *ExecutionSegment) int {
+	index := sort.Search(len(et.sequence), func(i int) bool {
+		return et.sequence[i].from.Cmp(segment.from) >= 0
+	})
+
+	if index < 0 || index >= len(et.sequence) || !et.sequence[index].Equal(segment) {
+		return -1
+	}
+	return index
+}
+
+// ScaleInt64 scales the provided value based on the ExecutionTuple
+func (et *ExecutionTuple) ScaleInt64(value int64) int64 {
+	return et.scaleInt64With(value, et.ES)
+}
+
+// scaleInt64With scales the provided value based on the ExecutionTuples'
+// sequence and the segment provided
+func (et *ExecutionTuple) scaleInt64With(value int64, es *ExecutionSegment) int64 {
+	if es == nil {
+		return 0
+	}
+	start, offsets, lcd := et.GetStripedOffsets(es)
+	return scaleInt64(value, start, offsets, lcd)
+}
+
+func scaleInt64(value, start int64, offsets []int64, lcd int64) int64 {
+	endValue := (value / lcd) * int64(len(offsets))
+	for gi, i := 0, start; i < value%lcd; gi, i = gi+1, i+offsets[gi] {
+		endValue++
+	}
+	return endValue
+}
+
+func (et *ExecutionTuple) fillCache() {
+	var wrapper = newWrapper(et.sequence)
+
+	et.offsetsCache = make([][]int64, len(et.sequence))
+	for i := range et.offsetsCache {
+		et.offsetsCache[i] = make([]int64, 0, wrapper.slice[i].numerator)
+	}
+
+	var prev = make([]int64, len(et.sequence))
+	var saveIndex = func(iteration int64, index int, numerator int64) bool {
+		et.offsetsCache[index] = append(et.offsetsCache[index], iteration-prev[index])
+		prev[index] = iteration
+		if int64(len(et.offsetsCache[index])) == numerator {
+			et.offsetsCache[index] = append(et.offsetsCache[index], et.offsetsCache[index][0]+wrapper.lcd-iteration)
+		}
+		return false
+	}
+
+	wrapper.stripingAlgorithm(saveIndex)
+	et.lcd = wrapper.lcd
+}
+
+// GetStripedOffsets returns the stripped offsets for the given segment
+// the returned values are as follows in order:
+// - start: the first value that is for the segment
+// - offsets: a list of offsets from the previous value for the segment. This are only the offsets
+//            to from the start to the next start if we chunk the elements we are going to strip
+//            into lcd sized chunks
+// - lcd: the LCD of the lengths of all segments in the sequence. This is also the number of
+//        elements after which the algorithm starts to loop and give the same values
+func (et *ExecutionTuple) GetStripedOffsets(segment *ExecutionSegment) (int64, []int64, int64) {
+	et.once.Do(et.fillCache)
+	index := et.find(segment)
+	if index == -1 {
+		return -1, nil, et.lcd
+	}
+	offsets := et.offsetsCache[index]
+	return offsets[0], offsets[1:], et.lcd
+}
+
+// GetNewExecutionTupleBasedOnValue uses the value provided, splits it using the striping offsets
+// between all the segments in the sequence and returns a new ExecutionTuple with a new sequence and
+// segments, such that each new segment in the new sequence has length `Scale(value)/value` while
+// keeping the order. The main segment in the new ExecutionTuple is the correspoding one from the
+// original, if that segmetn would've been with length 0 then it is nil, and obviously isn't part of
+// the sequence.
+func (et *ExecutionTuple) GetNewExecutionTupleBasedOnValue(value int64) *ExecutionTuple {
+	var (
+		newESS = make(ExecutionSegmentSequence, 0, len(et.sequence)) // this can be smaller
+		newES  *ExecutionSegment
+	)
+	et.once.Do(et.fillCache)
+	var prev int64
+	for i, es := range et.sequence {
+		offsets := et.offsetsCache[i]
+		newValue := scaleInt64(value, offsets[0], offsets[1:], et.lcd)
+		// TODO optimize this, somewhat
+		if newValue == 0 {
+			continue
+		}
+		var currentES, err = NewExecutionSegmentFromString(fmt.Sprintf("%d/%d:%d/%d", prev, value, prev+newValue, value))
+		if err != nil {
+			panic(err) // TODO this really can't happen but during the optimization it will probably disappear
+		}
+		prev += newValue
+		if es.Equal(et.ES) {
+			newES = currentES
+		}
+		newESS = append(newESS, currentES)
+	}
+	return &ExecutionTuple{
+		ES:       newES, // in case newES is nil we want to keep it that way
+		sequence: newESS,
+		once:     new(sync.Once),
+	}
 }

--- a/lib/execution_segment.go
+++ b/lib/execution_segment.go
@@ -447,6 +447,7 @@ func (ess ExecutionSegmentSequence) GetStripedOffsets(segment *ExecutionSegment)
 	start := int64(-1)
 	var offsets []int64 // TODO we can preallocate this
 
+OUTER:
 	for i := int64(0); i < lcd; i++ {
 		var iRat = big.NewRat(i, 1)
 		for index, value := range soonest {
@@ -463,7 +464,9 @@ func (ess ExecutionSegmentSequence) GetStripedOffsets(segment *ExecutionSegment)
 						}
 						offsets = append(offsets, i-prev)
 					}
-					// we can stop iterating the moment len(offsets) + 1 = numerator and we have set start ...
+					if int64(len(offsets)) == numerators[index]-1 {
+						break OUTER
+					}
 				}
 				break
 			}

--- a/lib/execution_segment.go
+++ b/lib/execution_segment.go
@@ -450,7 +450,8 @@ func (ess ExecutionSegmentSequence) GetStripedOffsets(segment *ExecutionSegment)
 		for index, value := range soonest {
 			if iRat.Cmp(value) >= 0 {
 				value.Add(value, big.NewRat(lcd, numerators[index]))
-				if ess[index] == matchingSegment { // TODO: this can be done for all segments and then we only get what we care about
+				if ess[index] == matchingSegment {
+					// TODO: this can be done for all segments and then we only get what we care about
 					if start < 0 {
 						start = i
 					} else {

--- a/lib/execution_segment.go
+++ b/lib/execution_segment.go
@@ -452,9 +452,9 @@ func (ess ExecutionSegmentSequence) GetStripedOffsets(segment *ExecutionSegment)
 
 OUTER:
 	for i := int64(0); i < lcd; i++ {
-		var iRat = big.NewRat(i, 1)
 		for index, value := range soonest {
-			if iRat.Cmp(value) >= 0 {
+			num, denom := value.Num().Int64(), value.Denom().Int64()
+			if i > num/denom || (i == num/denom && num%denom == 0) {
 				value.Add(value, numeratorChanges[index])
 				if ess[index] == matchingSegment {
 					// TODO: this can be done for all segments and then we only get what we care about

--- a/lib/execution_segment_test.go
+++ b/lib/execution_segment_test.go
@@ -212,24 +212,28 @@ func TestExecutionTupleScale(t *testing.T) {
 	t.Parallel()
 	es := new(ExecutionSegment)
 	require.NoError(t, es.UnmarshalText([]byte("0.5")))
-	et := NewExecutionTuple(es, nil)
+	et, err := NewExecutionTuple(es, nil)
+	require.NoError(t, err)
 	require.Equal(t, int64(1), et.ScaleInt64(2))
 	require.Equal(t, int64(2), et.ScaleInt64(3))
 
 	require.NoError(t, es.UnmarshalText([]byte("0.5:1.0")))
-	et = NewExecutionTuple(es, nil)
+	et, err = NewExecutionTuple(es, nil)
+	require.NoError(t, err)
 	require.Equal(t, int64(1), et.ScaleInt64(2))
 	require.Equal(t, int64(1), et.ScaleInt64(3))
 
 	ess, err := NewExecutionSegmentSequenceFromString("0,0.5,1")
 	require.NoError(t, err)
 	require.NoError(t, es.UnmarshalText([]byte("0.5")))
-	et = NewExecutionTuple(es, &ess)
+	et, err = NewExecutionTuple(es, &ess)
+	require.NoError(t, err)
 	require.Equal(t, int64(1), et.ScaleInt64(2))
 	require.Equal(t, int64(2), et.ScaleInt64(3))
 
 	require.NoError(t, es.UnmarshalText([]byte("0.5:1.0")))
-	et = NewExecutionTuple(es, &ess)
+	et, err = NewExecutionTuple(es, &ess)
+	require.NoError(t, err)
 	require.Equal(t, int64(1), et.ScaleInt64(2))
 	require.Equal(t, int64(1), et.ScaleInt64(3))
 }
@@ -238,7 +242,8 @@ func TestBigScale(t *testing.T) {
 	ess, err := NewExecutionSegmentSequenceFromString("0,7/20,7/10,1")
 	require.NoError(t, err)
 	require.NoError(t, es.UnmarshalText([]byte("0:7/20")))
-	et := NewExecutionTuple(es, &ess)
+	et, err := NewExecutionTuple(es, &ess)
+	require.NoError(t, err)
 	require.Equal(t, int64(18), et.ScaleInt64(50))
 }
 
@@ -518,7 +523,9 @@ func TestGetStripedOffsets(t *testing.T) {
 			require.NoError(t, err)
 			segment, err := NewExecutionSegmentFromString(tc.seg)
 			require.NoError(t, err)
-			et := NewExecutionTuple(segment, &ess)
+			et, err := NewExecutionTuple(segment, &ess)
+			require.NoError(t, err)
+
 			start, offsets, lcd := et.GetStripedOffsets(segment)
 
 			assert.Equal(t, tc.start, start)
@@ -567,7 +574,8 @@ func BenchmarkGetStripedOffsets(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				segment := sequence[int(r.Int63())%len(sequence)]
-				et := NewExecutionTuple(segment, &sequence)
+				et, err := NewExecutionTuple(segment, &sequence)
+				require.NoError(b, err)
 				_, _, _ = et.GetStripedOffsets(segment)
 			}
 		})
@@ -602,7 +610,8 @@ func BenchmarkGetStripedOffsetsEven(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				segment := sequence[111233%len(sequence)]
-				et := NewExecutionTuple(segment, &sequence)
+				et, err := NewExecutionTuple(segment, &sequence)
+				require.NoError(b, err)
 				_, _, _ = et.GetStripedOffsets(segment)
 			}
 		})
@@ -631,7 +640,8 @@ func TestGetNewExecutionTupleBesedOnValue(t *testing.T) {
 			segment, err := NewExecutionSegmentFromString(tc.seg)
 			require.NoError(t, err)
 
-			et := NewExecutionTuple(segment, &ess)
+			et, err := NewExecutionTuple(segment, &ess)
+			require.NoError(t, err)
 			newET := et.GetNewExecutionTupleBasedOnValue(tc.value)
 			require.Equal(t, tc.expected, newET.sequence.String())
 		})
@@ -778,7 +788,8 @@ func TestNewExecutionTuple(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(fmt.Sprintf("seg:'%s',seq:'%s'", testCase.seg, testCase.seq), func(t *testing.T) {
-			et := NewExecutionTuple(testCase.seg, testCase.seq)
+			et, err := NewExecutionTuple(testCase.seg, testCase.seq)
+			require.NoError(t, err)
 			for scaleValue, result := range testCase.scaleTests {
 				require.Equal(t, result, et.ScaleInt64(scaleValue), "%d->%d", scaleValue, result)
 			}

--- a/lib/execution_segment_test.go
+++ b/lib/execution_segment_test.go
@@ -457,11 +457,11 @@ func TestGetStripedOffsets(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(fmt.Sprintf("seq:%s;segment:%s", tc.seq, tc.seg), func(t *testing.T) {
-			result, err := NewExecutionSegmentSequenceFromString(tc.seq)
+			ess, err := NewExecutionSegmentSequenceFromString(tc.seq)
 			require.NoError(t, err)
 			segment, err := NewExecutionSegmentFromString(tc.seg)
 			require.NoError(t, err)
-			start, offsets, err := result.GetStripedOffsets(segment)
+			start, offsets, err := ess.GetStripedOffsets(segment)
 			if len(tc.expError) != 0 {
 				require.Error(t, err, tc.expError)
 				require.Contains(t, err.Error(), tc.expError)
@@ -471,6 +471,10 @@ func TestGetStripedOffsets(t *testing.T) {
 
 			assert.Equal(t, tc.start, start)
 			assert.Equal(t, tc.offsets, offsets)
+
+			ess2, err := NewExecutionSegmentSequenceFromString(tc.seq)
+			require.NoError(t, err)
+			assert.Equal(t, ess, ess2)
 		})
 	}
 }

--- a/lib/execution_segment_test.go
+++ b/lib/execution_segment_test.go
@@ -497,6 +497,28 @@ func TestGetStripedOffsets(t *testing.T) {
 	}
 }
 
+func TestSequenceLCD(t *testing.T) {
+	testCases := []struct {
+		seq string
+		lcd int64
+	}{
+		{seq: "0,0.3,0.5,0.6,0.7,0.8,0.9,1", lcd: 10},
+		{seq: "0,0.1,0.5,0.6,0.7,0.8,0.9,1", lcd: 10},
+		{seq: "0,0.2,0.5,0.6,0.7,0.8,0.9,1", lcd: 10},
+		{seq: "0,1/3,5/6", lcd: 6},
+		{seq: "0,1/3,4/7", lcd: 21},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(fmt.Sprintf("seq:%s", tc.seq), func(t *testing.T) {
+			ess, err := NewExecutionSegmentSequenceFromString(tc.seq)
+			require.NoError(t, err)
+			require.Equal(t, tc.lcd, ess.lcd())
+		})
+	}
+}
+
 func BenchmarkGetStripedOffsets(b *testing.B) {
 	var lengths = [...]int64{10, 100}
 	const seed = 777

--- a/lib/execution_segment_test.go
+++ b/lib/execution_segment_test.go
@@ -906,9 +906,9 @@ func BenchmarkExecutionSegmentScale(b *testing.B) {
 
 				b.Run(fmt.Sprintf("et.Scale(%d)", value), func(b *testing.B) {
 					for i := 0; i < b.N; i++ {
-						et2, err := NewExecutionTuple(segment, &ess)
+						et, err = NewExecutionTuple(segment, &ess)
 						require.NoError(b, err)
-						et2.ScaleInt64(value)
+						et.ScaleInt64(value)
 					}
 				})
 

--- a/lib/execution_segment_test.go
+++ b/lib/execution_segment_test.go
@@ -444,15 +444,31 @@ func TestGetStripedOffsets(t *testing.T) {
 		lcd      int64
 		expError string
 	}{
+		// full sequences
 		{seq: "0,0.3,0.5,0.6,0.7,0.8,0.9,1", seg: "0:0.2", expError: "missing segment"},
-		{seq: "0,0.3,0.5,0.6,0.7,0.8,0.9,1", seg: "0:0.3", start: 0, offsets: []int64{4, 3}, lcd: 10},
-		{seq: "0,0.3,0.5,0.6,0.7,0.8,0.9,1", seg: "0.3:0.5", start: 1, offsets: []int64{4}, lcd: 10},
-		{seq: "0,0.3,0.5,0.6,0.7,0.8,0.9,1", seg: "0.5:0.6", start: 2, lcd: 10},
-		{seq: "0,0.3,0.5,0.6,0.7,0.8,0.9,1", seg: "0.6:0.7", start: 3, lcd: 10},
-		{seq: "0,0.3,0.5,0.6,0.7,0.8,0.9,1", seg: "0.8:0.9", start: 8, lcd: 10},
-		{seq: "0,0.3,0.5,0.6,0.7,0.8,0.9,1", seg: "0.9:1", start: 9, lcd: 10},
-		{seq: "0,0.2,0.5,0.6,0.7,0.8,0.9,1", seg: "0.9:1", start: 9, lcd: 10},
-		{seq: "0,0.2,0.5,0.6,0.7,0.8,0.9,1", seg: "0:0.2", start: 1, offsets: []int64{4}, lcd: 10},
+		{seq: "0,0.3,0.5,0.6,0.7,0.8,0.9,1", seg: "0:0.3", start: 0, offsets: []int64{4, 3, 3}, lcd: 10},
+		{seq: "0,0.3,0.5,0.6,0.7,0.8,0.9,1", seg: "0.3:0.5", start: 1, offsets: []int64{4, 6}, lcd: 10},
+		{seq: "0,0.3,0.5,0.6,0.7,0.8,0.9,1", seg: "0.5:0.6", start: 2, offsets: []int64{10}, lcd: 10},
+		{seq: "0,0.3,0.5,0.6,0.7,0.8,0.9,1", seg: "0.6:0.7", start: 3, offsets: []int64{10}, lcd: 10},
+		{seq: "0,0.3,0.5,0.6,0.7,0.8,0.9,1", seg: "0.8:0.9", start: 8, offsets: []int64{10}, lcd: 10},
+		{seq: "0,0.3,0.5,0.6,0.7,0.8,0.9,1", seg: "0.9:1", start: 9, offsets: []int64{10}, lcd: 10},
+		{seq: "0,0.2,0.5,0.6,0.7,0.8,0.9,1", seg: "0.9:1", start: 9, offsets: []int64{10}, lcd: 10},
+		{seq: "0,0.2,0.5,0.6,0.7,0.8,0.9,1", seg: "0:0.2", start: 1, offsets: []int64{4, 6}, lcd: 10},
+		{seq: "0,0.2,0.5,0.6,0.7,0.8,0.9,1", seg: "0.6:0.7", start: 3, offsets: []int64{10}, lcd: 10},
+		// not full sequences
+		{seq: "0,0.2,0.5", seg: "0:0.2", start: 1, offsets: []int64{4, 6}, lcd: 10},
+		{seq: "0,0.2,0.5", seg: "0.2:0.5", start: 0, offsets: []int64{4, 3, 3}, lcd: 10},
+		{seq: "0,2/5,4/5", seg: "0:2/5", start: 0, offsets: []int64{3, 2}, lcd: 5},
+		{seq: "0,2/5,4/5", seg: "2/5:4/5", start: 1, offsets: []int64{3, 2}, lcd: 5},
+		// no sequence
+		{seg: "0:0.2", start: 0, offsets: []int64{5}, lcd: 5},
+		{seg: "0:1/5", start: 0, offsets: []int64{5}, lcd: 5},
+		{seg: "0:2/10", start: 0, offsets: []int64{5}, lcd: 5},
+		{seg: "0:0.4", start: 0, offsets: []int64{3, 2}, lcd: 5},
+		{seg: "0:2/5", start: 0, offsets: []int64{3, 2}, lcd: 5},
+		{seg: "2/5:4/5", start: 0, offsets: []int64{3, 2}, lcd: 5}, // this is the same as the previous one as there is no sequence
+		{seg: "0:4/10", start: 0, offsets: []int64{3, 2}, lcd: 5},
+		{seg: "1/10:5/10", start: 0, offsets: []int64{3, 2}, lcd: 5},
 	}
 
 	for _, tc := range testCases {

--- a/lib/execution_segment_test.go
+++ b/lib/execution_segment_test.go
@@ -450,6 +450,8 @@ func TestGetStripedOffsets(t *testing.T) {
 		{seq: "0,0.3,0.5,0.6,0.7,0.8,0.9,1", seg: "0.6:0.7", start: 3},
 		{seq: "0,0.3,0.5,0.6,0.7,0.8,0.9,1", seg: "0.8:0.9", start: 8},
 		{seq: "0,0.3,0.5,0.6,0.7,0.8,0.9,1", seg: "0.9:1", start: 9},
+		{seq: "0,0.2,0.5,0.6,0.7,0.8,0.9,1", seg: "0.9:1", start: 9},
+		{seq: "0,0.2,0.5,0.6,0.7,0.8,0.9,1", seg: "0:0.2", start: 1, offsets: []int64{5}},
 	}
 
 	for _, tc := range testCases {

--- a/lib/executor/common_test.go
+++ b/lib/executor/common_test.go
@@ -58,8 +58,8 @@ func setupExecutor(t *testing.T, config lib.ExecutorConfig, es *lib.ExecutionSta
 		return runner.NewVU(engineOut)
 	})
 
-	segment := es.Options.ExecutionSegment
-	maxVUs := lib.GetMaxPossibleVUs(config.GetExecutionRequirements(segment))
+	et := lib.NewExecutionTuple(es.Options.ExecutionSegment, es.Options.ExecutionSegmentSequence)
+	maxVUs := lib.GetMaxPossibleVUs(config.GetExecutionRequirements(et))
 	initializeVUs(ctx, t, logEntry, es, maxVUs)
 
 	executor, err := config.NewExecutor(es, logEntry)

--- a/lib/executor/common_test.go
+++ b/lib/executor/common_test.go
@@ -58,7 +58,9 @@ func setupExecutor(t *testing.T, config lib.ExecutorConfig, es *lib.ExecutionSta
 		return runner.NewVU(engineOut)
 	})
 
-	et := lib.NewExecutionTuple(es.Options.ExecutionSegment, es.Options.ExecutionSegmentSequence)
+	et, err := lib.NewExecutionTuple(es.Options.ExecutionSegment, es.Options.ExecutionSegmentSequence)
+	require.NoError(t, err)
+
 	maxVUs := lib.GetMaxPossibleVUs(config.GetExecutionRequirements(et))
 	initializeVUs(ctx, t, logEntry, es, maxVUs)
 

--- a/lib/executor/constant_arrival_rate.go
+++ b/lib/executor/constant_arrival_rate.go
@@ -190,7 +190,6 @@ var _ lib.Executor = &ConstantArrivalRate{}
 // Init values needed for the execution
 func (car *ConstantArrivalRate) Init(ctx context.Context) error {
 	car.et = car.BaseExecutor.executionState.ExecutionTuple.GetNewExecutionTupleBasedOnValue(car.config.MaxVUs.Int64)
-	// TODO mvoe the preallocation of VUs here ?
 	return nil
 }
 
@@ -202,6 +201,7 @@ func (car ConstantArrivalRate) Run(ctx context.Context, out chan<- stats.SampleC
 	duration := time.Duration(car.config.Duration.Duration)
 	preAllocatedVUs := car.config.GetPreAllocatedVUs(car.executionState.ExecutionTuple)
 	maxVUs := car.config.GetMaxVUs(car.executionState.ExecutionTuple)
+	// TODO: refactor and simplify
 	arrivalRate := getScaledArrivalRate(car.et.ES, car.config.Rate.Int64, time.Duration(car.config.TimeUnit.Duration))
 	tickerPeriod := time.Duration(getTickerPeriod(arrivalRate).Duration)
 	arrivalRatePerSec, _ := getArrivalRatePerSec(arrivalRate).Float64()

--- a/lib/executor/constant_arrival_rate.go
+++ b/lib/executor/constant_arrival_rate.go
@@ -76,26 +76,31 @@ func NewConstantArrivalRateConfig(name string) ConstantArrivalRateConfig {
 var _ lib.ExecutorConfig = &ConstantArrivalRateConfig{}
 
 // GetPreAllocatedVUs is just a helper method that returns the scaled pre-allocated VUs.
-func (carc ConstantArrivalRateConfig) GetPreAllocatedVUs(es *lib.ExecutionSegment) int64 {
-	return es.Scale(carc.PreAllocatedVUs.Int64)
+func (carc ConstantArrivalRateConfig) GetPreAllocatedVUs(et *lib.ExecutionTuple) int64 {
+	return et.ScaleInt64(carc.PreAllocatedVUs.Int64)
 }
 
 // GetMaxVUs is just a helper method that returns the scaled max VUs.
-func (carc ConstantArrivalRateConfig) GetMaxVUs(es *lib.ExecutionSegment) int64 {
-	return es.Scale(carc.MaxVUs.Int64)
+func (carc ConstantArrivalRateConfig) GetMaxVUs(et *lib.ExecutionTuple) int64 {
+	return et.ScaleInt64(carc.MaxVUs.Int64)
 }
 
 // GetDescription returns a human-readable description of the executor options
-func (carc ConstantArrivalRateConfig) GetDescription(es *lib.ExecutionSegment) string {
-	preAllocatedVUs, maxVUs := carc.GetPreAllocatedVUs(es), carc.GetMaxVUs(es)
+func (carc ConstantArrivalRateConfig) GetDescription(et *lib.ExecutionTuple) string {
+	preAllocatedVUs, maxVUs := carc.GetPreAllocatedVUs(et), carc.GetMaxVUs(et)
 	maxVUsRange := fmt.Sprintf("maxVUs: %d", preAllocatedVUs)
 	if maxVUs > preAllocatedVUs {
 		maxVUsRange += fmt.Sprintf("-%d", maxVUs)
 	}
 
 	timeUnit := time.Duration(carc.TimeUnit.Duration)
-	arrRate := getScaledArrivalRate(es, carc.Rate.Int64, timeUnit)
-	arrRatePerSec, _ := getArrivalRatePerSec(arrRate).Float64()
+	var arrRatePerSec float64
+	if maxVUs != 0 { // TODO: do something better?
+		ratio := big.NewRat(maxVUs, carc.MaxVUs.Int64)
+		arrRate := big.NewRat(carc.Rate.Int64, int64(timeUnit))
+		arrRate.Mul(arrRate, ratio)
+		arrRatePerSec, _ = getArrivalRatePerSec(arrRate).Float64()
+	}
 
 	return fmt.Sprintf("%.2f iterations/s for %s%s", arrRatePerSec, carc.Duration.Duration,
 		carc.getBaseInfo(maxVUsRange))
@@ -142,12 +147,12 @@ func (carc ConstantArrivalRateConfig) Validate() []error {
 // maximum waiting time for any iterations to gracefully stop. This is used by
 // the execution scheduler in its VU reservation calculations, so it knows how
 // many VUs to pre-initialize.
-func (carc ConstantArrivalRateConfig) GetExecutionRequirements(es *lib.ExecutionSegment) []lib.ExecutionStep {
+func (carc ConstantArrivalRateConfig) GetExecutionRequirements(et *lib.ExecutionTuple) []lib.ExecutionStep {
 	return []lib.ExecutionStep{
 		{
 			TimeOffset:      0,
-			PlannedVUs:      uint64(es.Scale(carc.PreAllocatedVUs.Int64)),
-			MaxUnplannedVUs: uint64(es.Scale(carc.MaxVUs.Int64 - carc.PreAllocatedVUs.Int64)),
+			PlannedVUs:      uint64(et.ScaleInt64(carc.PreAllocatedVUs.Int64)),
+			MaxUnplannedVUs: uint64(et.ScaleInt64(carc.MaxVUs.Int64 - carc.PreAllocatedVUs.Int64)),
 		}, {
 			TimeOffset:      time.Duration(carc.Duration.Duration + carc.GracefulStop.Duration),
 			PlannedVUs:      0,
@@ -167,8 +172,8 @@ func (carc ConstantArrivalRateConfig) NewExecutor(
 }
 
 // HasWork reports whether there is any work to be done for the given execution segment.
-func (carc ConstantArrivalRateConfig) HasWork(es *lib.ExecutionSegment) bool {
-	return carc.GetMaxVUs(es) > 0
+func (carc ConstantArrivalRateConfig) HasWork(et *lib.ExecutionTuple) bool {
+	return carc.GetMaxVUs(et) > 0
 }
 
 // ConstantArrivalRate tries to execute a specific number of iterations for a
@@ -185,13 +190,12 @@ var _ lib.Executor = &ConstantArrivalRate{}
 //
 // TODO: Reuse the variable arrival rate method?
 func (car ConstantArrivalRate) Run(ctx context.Context, out chan<- stats.SampleContainer) (err error) { //nolint:funlen
-	segment := car.executionState.Options.ExecutionSegment
+	newET := car.BaseExecutor.executionState.ExecutionTuple.GetNewExecutionTupleBasedOnValue(car.config.MaxVUs.Int64)
 	gracefulStop := car.config.GetGracefulStop()
 	duration := time.Duration(car.config.Duration.Duration)
-	preAllocatedVUs := car.config.GetPreAllocatedVUs(segment)
-	maxVUs := car.config.GetMaxVUs(segment)
-
-	arrivalRate := getScaledArrivalRate(segment, car.config.Rate.Int64, time.Duration(car.config.TimeUnit.Duration))
+	preAllocatedVUs := car.config.GetPreAllocatedVUs(car.executionState.ExecutionTuple)
+	maxVUs := car.config.GetMaxVUs(car.executionState.ExecutionTuple)
+	arrivalRate := getScaledArrivalRate(newET.ES, car.config.Rate.Int64, time.Duration(car.config.TimeUnit.Duration))
 	tickerPeriod := time.Duration(getTickerPeriod(arrivalRate).Duration)
 	arrivalRatePerSec, _ := getArrivalRatePerSec(arrivalRate).Float64()
 
@@ -260,10 +264,7 @@ func (car ConstantArrivalRate) Run(ctx context.Context, out chan<- stats.SampleC
 	}
 
 	remainingUnplannedVUs := maxVUs - preAllocatedVUs
-	start, offsets, _, err := car.executionState.Options.ESS.GetStripedOffsets(segment)
-	if err != nil {
-		return err
-	}
+	start, offsets, _ := newET.GetStripedOffsets(newET.ES)
 	startTime = time.Now()
 	timer := time.NewTimer(time.Hour * 24)
 	// here the we need the not scaled one

--- a/lib/executor/constant_looping_vus.go
+++ b/lib/executor/constant_looping_vus.go
@@ -71,14 +71,14 @@ func NewConstantLoopingVUsConfig(name string) ConstantLoopingVUsConfig {
 var _ lib.ExecutorConfig = &ConstantLoopingVUsConfig{}
 
 // GetVUs returns the scaled VUs for the executor.
-func (clvc ConstantLoopingVUsConfig) GetVUs(es *lib.ExecutionSegment) int64 {
-	return es.Scale(clvc.VUs.Int64)
+func (clvc ConstantLoopingVUsConfig) GetVUs(et *lib.ExecutionTuple) int64 {
+	return et.ES.Scale(clvc.VUs.Int64)
 }
 
 // GetDescription returns a human-readable description of the executor options
-func (clvc ConstantLoopingVUsConfig) GetDescription(es *lib.ExecutionSegment) string {
+func (clvc ConstantLoopingVUsConfig) GetDescription(et *lib.ExecutionTuple) string {
 	return fmt.Sprintf("%d looping VUs for %s%s",
-		clvc.GetVUs(es), clvc.Duration.Duration, clvc.getBaseInfo())
+		clvc.GetVUs(et), clvc.Duration.Duration, clvc.getBaseInfo())
 }
 
 // Validate makes sure all options are configured and valid
@@ -104,11 +104,11 @@ func (clvc ConstantLoopingVUsConfig) Validate() []error {
 // maximum waiting time for any iterations to gracefully stop. This is used by
 // the execution scheduler in its VU reservation calculations, so it knows how
 // many VUs to pre-initialize.
-func (clvc ConstantLoopingVUsConfig) GetExecutionRequirements(es *lib.ExecutionSegment) []lib.ExecutionStep {
+func (clvc ConstantLoopingVUsConfig) GetExecutionRequirements(et *lib.ExecutionTuple) []lib.ExecutionStep {
 	return []lib.ExecutionStep{
 		{
 			TimeOffset: 0,
-			PlannedVUs: uint64(clvc.GetVUs(es)),
+			PlannedVUs: uint64(clvc.GetVUs(et)),
 		},
 		{
 			TimeOffset: time.Duration(clvc.Duration.Duration + clvc.GracefulStop.Duration),
@@ -118,8 +118,8 @@ func (clvc ConstantLoopingVUsConfig) GetExecutionRequirements(es *lib.ExecutionS
 }
 
 // HasWork reports whether there is any work to be done for the given execution segment.
-func (clvc ConstantLoopingVUsConfig) HasWork(es *lib.ExecutionSegment) bool {
-	return clvc.GetVUs(es) > 0
+func (clvc ConstantLoopingVUsConfig) HasWork(et *lib.ExecutionTuple) bool {
+	return clvc.GetVUs(et) > 0
 }
 
 // NewExecutor creates a new ConstantLoopingVUs executor
@@ -143,8 +143,7 @@ var _ lib.Executor = &ConstantLoopingVUs{}
 // Run constantly loops through as many iterations as possible on a fixed number
 // of VUs for the specified duration.
 func (clv ConstantLoopingVUs) Run(ctx context.Context, out chan<- stats.SampleContainer) (err error) {
-	segment := clv.executionState.Options.ExecutionSegment
-	numVUs := clv.config.GetVUs(segment)
+	numVUs := clv.config.GetVUs(clv.executionState.ExecutionTuple)
 	duration := time.Duration(clv.config.Duration.Duration)
 	gracefulStop := clv.config.GetGracefulStop()
 

--- a/lib/executor/constant_looping_vus_test.go
+++ b/lib/executor/constant_looping_vus_test.go
@@ -44,7 +44,9 @@ func getTestConstantLoopingVUsConfig() ConstantLoopingVUsConfig {
 func TestConstantLoopingVUsRun(t *testing.T) {
 	t.Parallel()
 	var result sync.Map
-	es := lib.NewExecutionState(lib.Options{}, 10, 50)
+	et, err := lib.NewExecutionTuple(nil, nil)
+	require.NoError(t, err)
+	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	var ctx, cancel, executor, _ = setupExecutor(
 		t, getTestConstantLoopingVUsConfig(), es,
 		simpleRunner(func(ctx context.Context) error {
@@ -56,7 +58,7 @@ func TestConstantLoopingVUsRun(t *testing.T) {
 		}),
 	)
 	defer cancel()
-	err := executor.Run(ctx, nil)
+	err = executor.Run(ctx, nil)
 	require.NoError(t, err)
 
 	var totalIters uint64

--- a/lib/executor/execution_test.go
+++ b/lib/executor/execution_test.go
@@ -38,7 +38,9 @@ import (
 
 func TestExecutionStateVUIDs(t *testing.T) {
 	t.Parallel()
-	es := lib.NewExecutionState(lib.Options{}, 0, 0)
+	et, err := lib.NewExecutionTuple(nil, nil)
+	require.NoError(t, err)
+	es := lib.NewExecutionState(lib.Options{}, et, 0, 0)
 	assert.Equal(t, uint64(1), es.GetUniqueVUIdentifier())
 	assert.Equal(t, uint64(2), es.GetUniqueVUIdentifier())
 	assert.Equal(t, uint64(3), es.GetUniqueVUIdentifier())
@@ -58,7 +60,9 @@ func TestExecutionStateVUIDs(t *testing.T) {
 
 func TestExecutionStateGettingVUsWhenNonAreAvailable(t *testing.T) {
 	t.Parallel()
-	es := lib.NewExecutionState(lib.Options{}, 0, 0)
+	et, err := lib.NewExecutionTuple(nil, nil)
+	require.NoError(t, err)
+	es := lib.NewExecutionState(lib.Options{}, et, 0, 0)
 	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.WarnLevel}}
 	testLog := logrus.New()
 	testLog.AddHook(logHook)
@@ -82,7 +86,9 @@ func TestExecutionStateGettingVUs(t *testing.T) {
 	testLog.SetOutput(ioutil.Discard)
 	logEntry := logrus.NewEntry(testLog)
 
-	es := lib.NewExecutionState(lib.Options{}, 10, 20)
+	et, err := lib.NewExecutionTuple(nil, nil)
+	require.NoError(t, err)
+	es := lib.NewExecutionState(lib.Options{}, et, 10, 20)
 	es.SetInitVUFunc(func(_ context.Context, _ *logrus.Entry) (lib.VU, error) {
 		return &minirunner.VU{}, nil
 	})
@@ -144,7 +150,9 @@ func TestExecutionStateGettingVUs(t *testing.T) {
 
 func TestMarkStartedPanicsOnSecondRun(t *testing.T) {
 	t.Parallel()
-	es := lib.NewExecutionState(lib.Options{}, 0, 0)
+	et, err := lib.NewExecutionTuple(nil, nil)
+	require.NoError(t, err)
+	es := lib.NewExecutionState(lib.Options{}, et, 0, 0)
 	require.False(t, es.HasStarted())
 	es.MarkStarted()
 	require.True(t, es.HasStarted())
@@ -153,7 +161,9 @@ func TestMarkStartedPanicsOnSecondRun(t *testing.T) {
 
 func TestMarkEnded(t *testing.T) {
 	t.Parallel()
-	es := lib.NewExecutionState(lib.Options{}, 0, 0)
+	et, err := lib.NewExecutionTuple(nil, nil)
+	require.NoError(t, err)
+	es := lib.NewExecutionState(lib.Options{}, et, 0, 0)
 	require.False(t, es.HasEnded())
 	es.MarkEnded()
 	require.True(t, es.HasEnded())

--- a/lib/executor/executors_test.go
+++ b/lib/executor/executors_test.go
@@ -87,16 +87,17 @@ var configMapTestCases = []configMapTestCase{
 			assert.Empty(t, cm["someKey"].Validate())
 			assert.Empty(t, cm.Validate())
 
-			assert.Equal(t, "10 looping VUs for 1m0s (exec: someFunc, startTime: 1m10s, gracefulStop: 10s)", cm["someKey"].GetDescription(nil))
+			et := lib.NewExecutionTuple(nil, nil)
+			assert.Equal(t, "10 looping VUs for 1m0s (exec: someFunc, startTime: 1m10s, gracefulStop: 10s)", cm["someKey"].GetDescription(et))
 
-			schedReqs := cm["someKey"].GetExecutionRequirements(nil)
+			schedReqs := cm["someKey"].GetExecutionRequirements(et)
 			endOffset, isFinal := lib.GetEndOffset(schedReqs)
 			assert.Equal(t, 70*time.Second, endOffset)
 			assert.Equal(t, true, isFinal)
 			assert.Equal(t, uint64(10), lib.GetMaxPlannedVUs(schedReqs))
 			assert.Equal(t, uint64(10), lib.GetMaxPossibleVUs(schedReqs))
 
-			totalReqs := cm.GetFullExecutionRequirements(nil)
+			totalReqs := cm.GetFullExecutionRequirements(et)
 			endOffset, isFinal = lib.GetEndOffset(totalReqs)
 			assert.Equal(t, 140*time.Second, endOffset)
 			assert.Equal(t, true, isFinal)
@@ -134,16 +135,17 @@ var configMapTestCases = []configMapTestCase{
 			assert.Empty(t, cm["varloops"].Validate())
 			assert.Empty(t, cm.Validate())
 
-			assert.Equal(t, "Up to 30 looping VUs for 3m10s over 2 stages (gracefulRampDown: 10s, startTime: 23s, gracefulStop: 15s)", cm["varloops"].GetDescription(nil))
+			et := lib.NewExecutionTuple(nil, nil)
+			assert.Equal(t, "Up to 30 looping VUs for 3m10s over 2 stages (gracefulRampDown: 10s, startTime: 23s, gracefulStop: 15s)", cm["varloops"].GetDescription(et))
 
-			schedReqs := cm["varloops"].GetExecutionRequirements(nil)
+			schedReqs := cm["varloops"].GetExecutionRequirements(et)
 			endOffset, isFinal := lib.GetEndOffset(schedReqs)
 			assert.Equal(t, 205*time.Second, endOffset)
 			assert.Equal(t, true, isFinal)
 			assert.Equal(t, uint64(30), lib.GetMaxPlannedVUs(schedReqs))
 			assert.Equal(t, uint64(30), lib.GetMaxPossibleVUs(schedReqs))
 
-			totalReqs := cm.GetFullExecutionRequirements(nil)
+			totalReqs := cm.GetFullExecutionRequirements(et)
 			endOffset, isFinal = lib.GetEndOffset(totalReqs)
 			assert.Equal(t, 228*time.Second, endOffset)
 			assert.Equal(t, true, isFinal)
@@ -157,9 +159,10 @@ var configMapTestCases = []configMapTestCase{
 			assert.Empty(t, cm["varloops"].Validate())
 			assert.Empty(t, cm.Validate())
 
-			assert.Equal(t, "Up to 10 looping VUs for 10s over 1 stages (gracefulRampDown: 10s)", cm["varloops"].GetDescription(nil))
+			et := lib.NewExecutionTuple(nil, nil)
+			assert.Equal(t, "Up to 10 looping VUs for 10s over 1 stages (gracefulRampDown: 10s)", cm["varloops"].GetDescription(et))
 
-			schedReqs := cm["varloops"].GetExecutionRequirements(nil)
+			schedReqs := cm["varloops"].GetExecutionRequirements(et)
 			assert.Equal(t, uint64(10), lib.GetMaxPlannedVUs(schedReqs))
 			assert.Equal(t, uint64(10), lib.GetMaxPossibleVUs(schedReqs))
 		}},
@@ -170,9 +173,10 @@ var configMapTestCases = []configMapTestCase{
 			assert.Empty(t, cm["varloops"].Validate())
 			assert.Empty(t, cm.Validate())
 
-			assert.Equal(t, "Up to 10 looping VUs for 20s over 3 stages (gracefulRampDown: 0s)", cm["varloops"].GetDescription(nil))
+			et := lib.NewExecutionTuple(nil, nil)
+			assert.Equal(t, "Up to 10 looping VUs for 20s over 3 stages (gracefulRampDown: 0s)", cm["varloops"].GetDescription(et))
 
-			schedReqs := cm.GetFullExecutionRequirements(nil)
+			schedReqs := cm.GetFullExecutionRequirements(et)
 			assert.Equal(t, uint64(10), lib.GetMaxPlannedVUs(schedReqs))
 			assert.Equal(t, uint64(10), lib.GetMaxPossibleVUs(schedReqs))
 		}},
@@ -183,9 +187,10 @@ var configMapTestCases = []configMapTestCase{
 			assert.Empty(t, cm["varloops"].Validate())
 			assert.Empty(t, cm.Validate())
 
-			assert.Equal(t, "Up to 11 looping VUs for 20s over 4 stages (gracefulRampDown: 0s)", cm["varloops"].GetDescription(nil))
+			et := lib.NewExecutionTuple(nil, nil)
+			assert.Equal(t, "Up to 11 looping VUs for 20s over 4 stages (gracefulRampDown: 0s)", cm["varloops"].GetDescription(et))
 
-			schedReqs := cm.GetFullExecutionRequirements(nil)
+			schedReqs := cm.GetFullExecutionRequirements(et)
 			assert.Equal(t, uint64(11), lib.GetMaxPlannedVUs(schedReqs))
 			assert.Equal(t, uint64(11), lib.GetMaxPossibleVUs(schedReqs))
 		}},
@@ -209,16 +214,17 @@ var configMapTestCases = []configMapTestCase{
 			assert.Empty(t, cm["ishared"].Validate())
 			assert.Empty(t, cm.Validate())
 
-			assert.Equal(t, "22 iterations shared among 12 VUs (maxDuration: 1m40s, gracefulStop: 30s)", cm["ishared"].GetDescription(nil))
+			et := lib.NewExecutionTuple(nil, nil)
+			assert.Equal(t, "22 iterations shared among 12 VUs (maxDuration: 1m40s, gracefulStop: 30s)", cm["ishared"].GetDescription(et))
 
-			schedReqs := cm["ishared"].GetExecutionRequirements(nil)
+			schedReqs := cm["ishared"].GetExecutionRequirements(et)
 			endOffset, isFinal := lib.GetEndOffset(schedReqs)
 			assert.Equal(t, 130*time.Second, endOffset)
 			assert.Equal(t, true, isFinal)
 			assert.Equal(t, uint64(12), lib.GetMaxPlannedVUs(schedReqs))
 			assert.Equal(t, uint64(12), lib.GetMaxPossibleVUs(schedReqs))
 
-			totalReqs := cm.GetFullExecutionRequirements(nil)
+			totalReqs := cm.GetFullExecutionRequirements(et)
 			assert.Equal(t, schedReqs, totalReqs)
 		}},
 	},
@@ -242,16 +248,17 @@ var configMapTestCases = []configMapTestCase{
 			assert.Empty(t, cm["ipervu"].Validate())
 			assert.Empty(t, cm.Validate())
 
-			assert.Equal(t, "23 iterations for each of 13 VUs (maxDuration: 10m0s)", cm["ipervu"].GetDescription(nil))
+			et := lib.NewExecutionTuple(nil, nil)
+			assert.Equal(t, "23 iterations for each of 13 VUs (maxDuration: 10m0s)", cm["ipervu"].GetDescription(et))
 
-			schedReqs := cm["ipervu"].GetExecutionRequirements(nil)
+			schedReqs := cm["ipervu"].GetExecutionRequirements(et)
 			endOffset, isFinal := lib.GetEndOffset(schedReqs)
 			assert.Equal(t, 600*time.Second, endOffset)
 			assert.Equal(t, true, isFinal)
 			assert.Equal(t, uint64(13), lib.GetMaxPlannedVUs(schedReqs))
 			assert.Equal(t, uint64(13), lib.GetMaxPossibleVUs(schedReqs))
 
-			totalReqs := cm.GetFullExecutionRequirements(nil)
+			totalReqs := cm.GetFullExecutionRequirements(et)
 			assert.Equal(t, schedReqs, totalReqs)
 		}},
 	},
@@ -267,6 +274,7 @@ var configMapTestCases = []configMapTestCase{
 	// constant-arrival-rate
 	{`{"carrival": {"type": "constant-arrival-rate", "rate": 30, "timeUnit": "1m", "duration": "10m", "preAllocatedVUs": 20, "maxVUs": 30}}`,
 		exp{custom: func(t *testing.T, cm lib.ExecutorConfigMap) {
+			et := lib.NewExecutionTuple(nil, nil)
 			sched := NewConstantArrivalRateConfig("carrival")
 			sched.Rate = null.IntFrom(30)
 			sched.Duration = types.NullDurationFrom(10 * time.Minute)
@@ -277,16 +285,16 @@ var configMapTestCases = []configMapTestCase{
 			assert.Empty(t, cm["carrival"].Validate())
 			assert.Empty(t, cm.Validate())
 
-			assert.Equal(t, "0.50 iterations/s for 10m0s (maxVUs: 20-30, gracefulStop: 30s)", cm["carrival"].GetDescription(nil))
+			assert.Equal(t, "0.50 iterations/s for 10m0s (maxVUs: 20-30, gracefulStop: 30s)", cm["carrival"].GetDescription(et))
 
-			schedReqs := cm["carrival"].GetExecutionRequirements(nil)
+			schedReqs := cm["carrival"].GetExecutionRequirements(et)
 			endOffset, isFinal := lib.GetEndOffset(schedReqs)
 			assert.Equal(t, 630*time.Second, endOffset)
 			assert.Equal(t, true, isFinal)
 			assert.Equal(t, uint64(20), lib.GetMaxPlannedVUs(schedReqs))
 			assert.Equal(t, uint64(30), lib.GetMaxPossibleVUs(schedReqs))
 
-			totalReqs := cm.GetFullExecutionRequirements(nil)
+			totalReqs := cm.GetFullExecutionRequirements(et)
 			assert.Equal(t, schedReqs, totalReqs)
 		}},
 	},
@@ -319,16 +327,17 @@ var configMapTestCases = []configMapTestCase{
 			assert.Empty(t, cm["varrival"].Validate())
 			assert.Empty(t, cm.Validate())
 
-			assert.Equal(t, "Up to 1.00 iterations/s for 8m0s over 2 stages (maxVUs: 20-50, gracefulStop: 30s)", cm["varrival"].GetDescription(nil))
+			et := lib.NewExecutionTuple(nil, nil)
+			assert.Equal(t, "Up to 1.00 iterations/s for 8m0s over 2 stages (maxVUs: 20-50, gracefulStop: 30s)", cm["varrival"].GetDescription(et))
 
-			schedReqs := cm["varrival"].GetExecutionRequirements(nil)
+			schedReqs := cm["varrival"].GetExecutionRequirements(et)
 			endOffset, isFinal := lib.GetEndOffset(schedReqs)
 			assert.Equal(t, 510*time.Second, endOffset)
 			assert.Equal(t, true, isFinal)
 			assert.Equal(t, uint64(20), lib.GetMaxPlannedVUs(schedReqs))
 			assert.Equal(t, uint64(50), lib.GetMaxPossibleVUs(schedReqs))
 
-			totalReqs := cm.GetFullExecutionRequirements(nil)
+			totalReqs := cm.GetFullExecutionRequirements(et)
 			assert.Equal(t, schedReqs, totalReqs)
 		}},
 	},
@@ -373,6 +382,7 @@ func TestConfigMapParsingAndValidation(t *testing.T) {
 
 func TestVariableLoopingVUsConfigExecutionPlanExample(t *testing.T) {
 	t.Parallel()
+	et := lib.NewExecutionTuple(nil, nil)
 	conf := NewVariableLoopingVUsConfig("test")
 	conf.StartVUs = null.IntFrom(4)
 	conf.Stages = []Stage{
@@ -432,7 +442,7 @@ func TestVariableLoopingVUsConfigExecutionPlanExample(t *testing.T) {
 		{TimeOffset: 42 * time.Second, PlannedVUs: 4},
 		{TimeOffset: 50 * time.Second, PlannedVUs: 1},
 		{TimeOffset: 53 * time.Second, PlannedVUs: 0},
-	}, conf.GetExecutionRequirements(nil))
+	}, conf.GetExecutionRequirements(et))
 
 	// Try a longer GracefulStop than the GracefulRampDown
 	conf.GracefulStop = types.NullDurationFrom(80 * time.Second)
@@ -444,7 +454,7 @@ func TestVariableLoopingVUsConfigExecutionPlanExample(t *testing.T) {
 		{TimeOffset: 42 * time.Second, PlannedVUs: 4},
 		{TimeOffset: 50 * time.Second, PlannedVUs: 1},
 		{TimeOffset: 103 * time.Second, PlannedVUs: 0},
-	}, conf.GetExecutionRequirements(nil))
+	}, conf.GetExecutionRequirements(et))
 
 	// Try a much shorter GracefulStop than the GracefulRampDown
 	conf.GracefulStop = types.NullDurationFrom(3 * time.Second)
@@ -453,7 +463,7 @@ func TestVariableLoopingVUsConfigExecutionPlanExample(t *testing.T) {
 		{TimeOffset: 1 * time.Second, PlannedVUs: 5},
 		{TimeOffset: 2 * time.Second, PlannedVUs: 6},
 		{TimeOffset: 26 * time.Second, PlannedVUs: 0},
-	}, conf.GetExecutionRequirements(nil))
+	}, conf.GetExecutionRequirements(et))
 
 	// Try a zero GracefulStop
 	conf.GracefulStop = types.NullDurationFrom(0 * time.Second)
@@ -462,9 +472,9 @@ func TestVariableLoopingVUsConfigExecutionPlanExample(t *testing.T) {
 		{TimeOffset: 1 * time.Second, PlannedVUs: 5},
 		{TimeOffset: 2 * time.Second, PlannedVUs: 6},
 		{TimeOffset: 23 * time.Second, PlannedVUs: 0},
-	}, conf.GetExecutionRequirements(nil))
+	}, conf.GetExecutionRequirements(et))
 
 	// Try a zero GracefulStop and GracefulRampDown, i.e. raw steps with 0 end cap
 	conf.GracefulRampDown = types.NullDurationFrom(0 * time.Second)
-	assert.Equal(t, rawStepsZeroEnd, conf.GetExecutionRequirements(nil))
+	assert.Equal(t, rawStepsZeroEnd, conf.GetExecutionRequirements(et))
 }

--- a/lib/executor/executors_test.go
+++ b/lib/executor/executors_test.go
@@ -87,7 +87,8 @@ var configMapTestCases = []configMapTestCase{
 			assert.Empty(t, cm["someKey"].Validate())
 			assert.Empty(t, cm.Validate())
 
-			et := lib.NewExecutionTuple(nil, nil)
+			et, err := lib.NewExecutionTuple(nil, nil)
+			require.NoError(t, err)
 			assert.Equal(t, "10 looping VUs for 1m0s (exec: someFunc, startTime: 1m10s, gracefulStop: 10s)", cm["someKey"].GetDescription(et))
 
 			schedReqs := cm["someKey"].GetExecutionRequirements(et)
@@ -135,7 +136,8 @@ var configMapTestCases = []configMapTestCase{
 			assert.Empty(t, cm["varloops"].Validate())
 			assert.Empty(t, cm.Validate())
 
-			et := lib.NewExecutionTuple(nil, nil)
+			et, err := lib.NewExecutionTuple(nil, nil)
+			require.NoError(t, err)
 			assert.Equal(t, "Up to 30 looping VUs for 3m10s over 2 stages (gracefulRampDown: 10s, startTime: 23s, gracefulStop: 15s)", cm["varloops"].GetDescription(et))
 
 			schedReqs := cm["varloops"].GetExecutionRequirements(et)
@@ -159,7 +161,8 @@ var configMapTestCases = []configMapTestCase{
 			assert.Empty(t, cm["varloops"].Validate())
 			assert.Empty(t, cm.Validate())
 
-			et := lib.NewExecutionTuple(nil, nil)
+			et, err := lib.NewExecutionTuple(nil, nil)
+			require.NoError(t, err)
 			assert.Equal(t, "Up to 10 looping VUs for 10s over 1 stages (gracefulRampDown: 10s)", cm["varloops"].GetDescription(et))
 
 			schedReqs := cm["varloops"].GetExecutionRequirements(et)
@@ -173,7 +176,8 @@ var configMapTestCases = []configMapTestCase{
 			assert.Empty(t, cm["varloops"].Validate())
 			assert.Empty(t, cm.Validate())
 
-			et := lib.NewExecutionTuple(nil, nil)
+			et, err := lib.NewExecutionTuple(nil, nil)
+			require.NoError(t, err)
 			assert.Equal(t, "Up to 10 looping VUs for 20s over 3 stages (gracefulRampDown: 0s)", cm["varloops"].GetDescription(et))
 
 			schedReqs := cm.GetFullExecutionRequirements(et)
@@ -187,7 +191,8 @@ var configMapTestCases = []configMapTestCase{
 			assert.Empty(t, cm["varloops"].Validate())
 			assert.Empty(t, cm.Validate())
 
-			et := lib.NewExecutionTuple(nil, nil)
+			et, err := lib.NewExecutionTuple(nil, nil)
+			require.NoError(t, err)
 			assert.Equal(t, "Up to 11 looping VUs for 20s over 4 stages (gracefulRampDown: 0s)", cm["varloops"].GetDescription(et))
 
 			schedReqs := cm.GetFullExecutionRequirements(et)
@@ -214,7 +219,8 @@ var configMapTestCases = []configMapTestCase{
 			assert.Empty(t, cm["ishared"].Validate())
 			assert.Empty(t, cm.Validate())
 
-			et := lib.NewExecutionTuple(nil, nil)
+			et, err := lib.NewExecutionTuple(nil, nil)
+			require.NoError(t, err)
 			assert.Equal(t, "22 iterations shared among 12 VUs (maxDuration: 1m40s, gracefulStop: 30s)", cm["ishared"].GetDescription(et))
 
 			schedReqs := cm["ishared"].GetExecutionRequirements(et)
@@ -248,7 +254,8 @@ var configMapTestCases = []configMapTestCase{
 			assert.Empty(t, cm["ipervu"].Validate())
 			assert.Empty(t, cm.Validate())
 
-			et := lib.NewExecutionTuple(nil, nil)
+			et, err := lib.NewExecutionTuple(nil, nil)
+			require.NoError(t, err)
 			assert.Equal(t, "23 iterations for each of 13 VUs (maxDuration: 10m0s)", cm["ipervu"].GetDescription(et))
 
 			schedReqs := cm["ipervu"].GetExecutionRequirements(et)
@@ -274,7 +281,8 @@ var configMapTestCases = []configMapTestCase{
 	// constant-arrival-rate
 	{`{"carrival": {"type": "constant-arrival-rate", "rate": 30, "timeUnit": "1m", "duration": "10m", "preAllocatedVUs": 20, "maxVUs": 30}}`,
 		exp{custom: func(t *testing.T, cm lib.ExecutorConfigMap) {
-			et := lib.NewExecutionTuple(nil, nil)
+			et, err := lib.NewExecutionTuple(nil, nil)
+			require.NoError(t, err)
 			sched := NewConstantArrivalRateConfig("carrival")
 			sched.Rate = null.IntFrom(30)
 			sched.Duration = types.NullDurationFrom(10 * time.Minute)
@@ -327,7 +335,8 @@ var configMapTestCases = []configMapTestCase{
 			assert.Empty(t, cm["varrival"].Validate())
 			assert.Empty(t, cm.Validate())
 
-			et := lib.NewExecutionTuple(nil, nil)
+			et, err := lib.NewExecutionTuple(nil, nil)
+			require.NoError(t, err)
 			assert.Equal(t, "Up to 1.00 iterations/s for 8m0s over 2 stages (maxVUs: 20-50, gracefulStop: 30s)", cm["varrival"].GetDescription(et))
 
 			schedReqs := cm["varrival"].GetExecutionRequirements(et)
@@ -382,7 +391,8 @@ func TestConfigMapParsingAndValidation(t *testing.T) {
 
 func TestVariableLoopingVUsConfigExecutionPlanExample(t *testing.T) {
 	t.Parallel()
-	et := lib.NewExecutionTuple(nil, nil)
+	et, err := lib.NewExecutionTuple(nil, nil)
+	require.NoError(t, err)
 	conf := NewVariableLoopingVUsConfig("test")
 	conf.StartVUs = null.IntFrom(4)
 	conf.Stages = []Stage{

--- a/lib/executor/externally_controlled.go
+++ b/lib/executor/externally_controlled.go
@@ -101,7 +101,7 @@ type ExternallyControlledConfig struct {
 var _ lib.ExecutorConfig = &ExternallyControlledConfig{}
 
 // GetDescription returns a human-readable description of the executor options
-func (mec ExternallyControlledConfig) GetDescription(_ *lib.ExecutionSegment) string {
+func (mec ExternallyControlledConfig) GetDescription(_ *lib.ExecutionTuple) string {
 	duration := "infinite"
 	if mec.Duration.Duration != 0 {
 		duration = mec.Duration.String()
@@ -140,11 +140,11 @@ func (mec ExternallyControlledConfig) Validate() []error {
 // point during a test run. That's used for sizing purposes and for user qouta
 // checking in the cloud execution, where the externally controlled executor
 // isn't supported.
-func (mec ExternallyControlledConfig) GetExecutionRequirements(es *lib.ExecutionSegment) []lib.ExecutionStep {
+func (mec ExternallyControlledConfig) GetExecutionRequirements(et *lib.ExecutionTuple) []lib.ExecutionStep {
 	startVUs := lib.ExecutionStep{
 		TimeOffset:      0,
-		PlannedVUs:      uint64(es.Scale(mec.MaxVUs.Int64)), // user-configured, VUs to be pre-initialized
-		MaxUnplannedVUs: 0,                                  // intentional, see function comment
+		PlannedVUs:      uint64(et.ES.Scale(mec.MaxVUs.Int64)), // user-configured, VUs to be pre-initialized
+		MaxUnplannedVUs: 0,                                     // intentional, see function comment
 	}
 
 	maxDuration := time.Duration(mec.Duration.Duration)
@@ -179,7 +179,7 @@ func (mec ExternallyControlledConfig) NewExecutor(es *lib.ExecutionState, logger
 }
 
 // HasWork reports whether there is any work to be done for the given execution segment.
-func (mec ExternallyControlledConfig) HasWork(es *lib.ExecutionSegment) bool {
+func (mec ExternallyControlledConfig) HasWork(_ *lib.ExecutionTuple) bool {
 	// We can always initialize new VUs via the REST API, so return true.
 	return true
 }

--- a/lib/executor/externally_controlled_test.go
+++ b/lib/executor/externally_controlled_test.go
@@ -49,7 +49,9 @@ func getTestExternallyControlledConfig() ExternallyControlledConfig {
 func TestExternallyControlledRun(t *testing.T) {
 	t.Parallel()
 	var doneIters uint64
-	es := lib.NewExecutionState(lib.Options{}, 10, 50)
+	et, err := lib.NewExecutionTuple(nil, nil)
+	require.NoError(t, err)
+	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	var ctx, cancel, executor, _ = setupExecutor(
 		t, getTestExternallyControlledConfig(), es,
 		simpleRunner(func(ctx context.Context) error {

--- a/lib/executor/per_vu_iterations_test.go
+++ b/lib/executor/per_vu_iterations_test.go
@@ -47,7 +47,9 @@ func getTestPerVUIterationsConfig() PerVUIterationsConfig {
 func TestPerVUIterationsRun(t *testing.T) {
 	t.Parallel()
 	var result sync.Map
-	es := lib.NewExecutionState(lib.Options{}, 10, 50)
+	et, err := lib.NewExecutionTuple(nil, nil)
+	require.NoError(t, err)
+	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	var ctx, cancel, executor, _ = setupExecutor(
 		t, getTestPerVUIterationsConfig(), es,
 		simpleRunner(func(ctx context.Context) error {
@@ -58,7 +60,7 @@ func TestPerVUIterationsRun(t *testing.T) {
 		}),
 	)
 	defer cancel()
-	err := executor.Run(ctx, nil)
+	err = executor.Run(ctx, nil)
 	require.NoError(t, err)
 
 	var totalIters uint64
@@ -79,7 +81,9 @@ func TestPerVUIterationsRunVariableVU(t *testing.T) {
 		result   sync.Map
 		slowVUID int64
 	)
-	es := lib.NewExecutionState(lib.Options{}, 10, 50)
+	et, err := lib.NewExecutionTuple(nil, nil)
+	require.NoError(t, err)
+	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	var ctx, cancel, executor, _ = setupExecutor(
 		t, getTestPerVUIterationsConfig(), es,
 		simpleRunner(func(ctx context.Context) error {
@@ -98,7 +102,7 @@ func TestPerVUIterationsRunVariableVU(t *testing.T) {
 		}),
 	)
 	defer cancel()
-	err := executor.Run(ctx, nil)
+	err = executor.Run(ctx, nil)
 	require.NoError(t, err)
 
 	val, ok := result.Load(slowVUID)

--- a/lib/executor/shared_iterations_test.go
+++ b/lib/executor/shared_iterations_test.go
@@ -47,7 +47,9 @@ func getTestSharedIterationsConfig() SharedIterationsConfig {
 func TestSharedIterationsRun(t *testing.T) {
 	t.Parallel()
 	var doneIters uint64
-	es := lib.NewExecutionState(lib.Options{}, 10, 50)
+	et, err := lib.NewExecutionTuple(nil, nil)
+	require.NoError(t, err)
+	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	var ctx, cancel, executor, _ = setupExecutor(
 		t, getTestSharedIterationsConfig(), es,
 		simpleRunner(func(ctx context.Context) error {
@@ -56,7 +58,7 @@ func TestSharedIterationsRun(t *testing.T) {
 		}),
 	)
 	defer cancel()
-	err := executor.Run(ctx, nil)
+	err = executor.Run(ctx, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(100), doneIters)
 }
@@ -69,7 +71,9 @@ func TestSharedIterationsRunVariableVU(t *testing.T) {
 		result   sync.Map
 		slowVUID int64
 	)
-	es := lib.NewExecutionState(lib.Options{}, 10, 50)
+	et, err := lib.NewExecutionTuple(nil, nil)
+	require.NoError(t, err)
+	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	var ctx, cancel, executor, _ = setupExecutor(
 		t, getTestSharedIterationsConfig(), es,
 		simpleRunner(func(ctx context.Context) error {
@@ -89,7 +93,7 @@ func TestSharedIterationsRunVariableVU(t *testing.T) {
 		}),
 	)
 	defer cancel()
-	err := executor.Run(ctx, nil)
+	err = executor.Run(ctx, nil)
 	require.NoError(t, err)
 
 	var totalIters uint64

--- a/lib/executor/variable_arrival_rate_test.go
+++ b/lib/executor/variable_arrival_rate_test.go
@@ -61,8 +61,7 @@ func TestGetPlannedRateChanges0DurationStage(t *testing.T) {
 			},
 		},
 	}
-	var es *lib.ExecutionSegment
-	changes := config.getPlannedRateChanges(es)
+	changes := config.getPlannedRateChanges(lib.NewExecutionTuple(nil, nil))
 	require.Equal(t, 2, len(changes))
 	require.Equal(t, time.Duration(0), changes[0].timeOffset)
 	require.Equal(t, types.NullDurationFrom(time.Millisecond*20), changes[0].tickerPeriod)
@@ -114,8 +113,7 @@ func TestGetPlannedRateChangesZeroDurationStart(t *testing.T) {
 		},
 	}
 
-	var es *lib.ExecutionSegment
-	changes := config.getPlannedRateChanges(es)
+	changes := config.getPlannedRateChanges(lib.NewExecutionTuple(nil, nil))
 	var expectedTickerPeriod types.Duration
 	for i, change := range changes {
 		switch {
@@ -167,8 +165,7 @@ func TestGetPlannedRateChanges(t *testing.T) {
 		},
 	}
 
-	var es *lib.ExecutionSegment
-	changes := config.getPlannedRateChanges(es)
+	changes := config.getPlannedRateChanges(lib.NewExecutionTuple(nil, nil))
 	var expectedTickerPeriod types.Duration
 	for i, change := range changes {
 		switch {
@@ -207,10 +204,9 @@ func BenchmarkGetPlannedRateChanges(b *testing.B) {
 		},
 	}
 
-	var es *lib.ExecutionSegment
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			changes := config.getPlannedRateChanges(es)
+			changes := config.getPlannedRateChanges(lib.NewExecutionTuple(nil, nil))
 
 			require.Equal(b, time.Duration(0),
 				changes[0].timeOffset%minIntervalBetweenRateAdjustments, "%+v", changes[0])

--- a/lib/executor/variable_looping_vus_test.go
+++ b/lib/executor/variable_looping_vus_test.go
@@ -58,7 +58,9 @@ func TestVariableLoopingVUsRun(t *testing.T) {
 	}
 
 	var iterCount int64
-	es := lib.NewExecutionState(lib.Options{}, 10, 50)
+	et, err := lib.NewExecutionTuple(nil, nil)
+	require.NoError(t, err)
+	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	var ctx, cancel, executor, _ = setupExecutor(
 		t, config, es,
 		simpleRunner(func(ctx context.Context) error {
@@ -114,7 +116,9 @@ func TestVariableLoopingVUsRampDownNoWobble(t *testing.T) {
 		},
 	}
 
-	es := lib.NewExecutionState(lib.Options{}, 10, 50)
+	et, err := lib.NewExecutionTuple(nil, nil)
+	require.NoError(t, err)
+	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	var ctx, cancel, executor, _ = setupExecutor(
 		t, config, es,
 		simpleRunner(func(ctx context.Context) error {

--- a/lib/executors.go
+++ b/lib/executors.go
@@ -97,15 +97,15 @@ type ExecutorConfig interface {
 	// Calculates the VU requirements in different stages of the executor's
 	// execution, including any extensions caused by waiting for iterations to
 	// finish with graceful stops or ramp-downs.
-	GetExecutionRequirements(*ExecutionSegment) []ExecutionStep
+	GetExecutionRequirements(*ExecutionTuple) []ExecutionStep
 
 	// Return a human-readable description of the executor
-	GetDescription(es *ExecutionSegment) string
+	GetDescription(*ExecutionTuple) string
 
 	NewExecutor(*ExecutionState, *logrus.Entry) (Executor, error)
 
 	// HasWork reports whether there is any work for the executor to do with a given segment.
-	HasWork(*ExecutionSegment) bool
+	HasWork(*ExecutionTuple) bool
 }
 
 // InitVUFunc is just a shorthand so we don't have to type the function
@@ -243,7 +243,7 @@ func (scs ExecutorConfigMap) GetSortedConfigs() []ExecutorConfig {
 // the configured executors. It takes into account their start times and their
 // individual VU requirements and calculates the total VU requirements for each
 // moment in the test execution.
-func (scs ExecutorConfigMap) GetFullExecutionRequirements(executionSegment *ExecutionSegment) []ExecutionStep {
+func (scs ExecutorConfigMap) GetFullExecutionRequirements(et *ExecutionTuple) []ExecutionStep {
 	sortedConfigs := scs.GetSortedConfigs()
 
 	// Combine the steps and requirements from all different executors, and
@@ -256,7 +256,7 @@ func (scs ExecutorConfigMap) GetFullExecutionRequirements(executionSegment *Exec
 	trackedSteps := []trackedStep{}
 	for configID, config := range sortedConfigs { // orderly iteration over a slice
 		configStartTime := config.GetStartTime()
-		configSteps := config.GetExecutionRequirements(executionSegment)
+		configSteps := config.GetExecutionRequirements(et)
 		for _, cs := range configSteps {
 			cs.TimeOffset += configStartTime // add the executor start time to the step time offset
 			trackedSteps = append(trackedSteps, trackedStep{cs, configID})

--- a/lib/options.go
+++ b/lib/options.go
@@ -192,7 +192,7 @@ type Options struct {
 
 	// Initial values for VUs, max VUs, duration cap, iteration cap, and stages.
 	// See the Runner or Executor interfaces for more information.
-	VUs null.Int `json:"vus" envconfig:"K6_VUS"`
+	VUs        null.Int           `json:"vus" envconfig:"K6_VUS"`
 	Duration   types.NullDuration `json:"duration" envconfig:"K6_DURATION"`
 	Iterations null.Int           `json:"iterations" envconfig:"K6_ITERATIONS"`
 	Stages     []Stage            `json:"stages" envconfig:"K6_STAGES"`
@@ -203,8 +203,9 @@ type Options struct {
 	// We should support specifying execution segments via environment
 	// variables, but we currently can't, because envconfig has this nasty bug
 	// (among others): https://github.com/kelseyhightower/envconfig/issues/113
-	Execution        ExecutorConfigMap `json:"execution,omitempty" ignored:"true"`
-	ExecutionSegment *ExecutionSegment `json:"executionSegment" ignored:"true"`
+	Execution        ExecutorConfigMap         `json:"execution,omitempty" ignored:"true"`
+	ExecutionSegment *ExecutionSegment         `json:"executionSegment" ignored:"true"`
+	ESS              *ExecutionSegmentSequence `json:"executionSegmentSequence" ignored:"true"`
 
 	// Timeouts for the setup() and teardown() functions
 	NoSetup         null.Bool          `json:"noSetup" envconfig:"NO_SETUP"`


### PR DESCRIPTION
The idea of this PR is to
1. Basic review of the algorithm - it is fairly short so it shouldn't take long and the basics of the implementations are hardly going to change.
2. Discuss whether it should be implemented as it is or should we basically calculate it for every segment so that it can be used in a future distributed mode? It really won't be much more code and will add some memory overhead but nothing big really. 
3. I think the returned values should be a list offsets(where the first one is the start) and the second the LCD, as you would otherwise need to calculate it again ... and there is really no point in having start and offsets as separate values. 
