### PR TITLE
Copy __ENV so that 2 VUs don't share the same one

### DIFF
--- a/js/bundle.go
+++ b/js/bundle.go
@@ -255,7 +255,11 @@ func (b *Bundle) instantiate(rt *goja.Runtime, init *InitContext) error {
 	_ = module.Set("exports", exports)
 	rt.Set("module", module)
 
-	rt.Set("__ENV", b.Env)
+	env := make(map[string]string, len(b.Env))
+	for key, value := range b.Env {
+		env[key] = value
+	}
+	rt.Set("__ENV", env)
 	rt.Set("console", common.Bind(rt, newConsole(), init.ctxPtr))
 
 	*init.ctxPtr = common.WithRuntime(context.Background(), rt)


### PR DESCRIPTION
as in #799(which was about the same issue with setup data), we
don't actually have problems with a VU seeing changes from
previous iterations. It will be too expensive to constantly copy, it
won't panic and there are no issues with distributed execution.

fixes #1328 