### PR TITLE
WIP: Refactor variable-looping-vus

### DIFF
--- a/lib/executor/variable_looping_vus.go
+++ b/lib/executor/variable_looping_vus.go
@@ -382,13 +382,13 @@ func (vlvc VariableLoopingVUsConfig) reserveVUsForGracefulRampDowns( //nolint:fu
 		skippedToNewRawStep := false
 		timeOffsetWithTimeout := rawStep.TimeOffset + gracefulRampDownPeriod
 
-		for advStepNum := rawStepNum + 1; advStepNum < rawStepsLen; advStepNum++ {
-			advStep := rawSteps[advStepNum]
-			if advStep.TimeOffset > timeOffsetWithTimeout {
+		for nextStepNum := rawStepNum + 1; nextStepNum < rawStepsLen; nextStepNum++ {
+			nextStep := rawSteps[nextStepNum]
+			if nextStep.TimeOffset > timeOffsetWithTimeout {
 				break
 			}
-			if advStep.PlannedVUs >= lastPlannedVUs {
-				rawStepNum = advStepNum - 1
+			if nextStep.PlannedVUs >= lastPlannedVUs {
+				rawStepNum = nextStepNum - 1
 				skippedToNewRawStep = true
 				break
 			}
@@ -422,7 +422,7 @@ func (vlvc VariableLoopingVUsConfig) reserveVUsForGracefulRampDowns( //nolint:fu
 //
 // If gracefulRampDown is specified, it will also be taken into account, and the
 // number of needed VUs to handle that will also be reserved. See the
-// documentation of reserveGracefulVUScalingDown() for more details.
+// documentation of reserveVUsForGracefulRampDowns() for more details.
 //
 // On the other hand, gracefulStop is handled here. To facilitate it, we'll
 // ensure that the last execution step will have 0 VUs and will be at time


### PR DESCRIPTION
This is a RFC for a WIP alternative variable-looping-vus implementation that fixes the first bug reported in #1296, and _seems_ to be functionally equivalent to the previous implementation, while being a bit simpler (dumber?) in that it avoids the streaming of a second channel with modified timings based on gracefulRampDown. I found the previous implementation difficult to understand (despite of the excellent documentation!), as simultaneously streaming two different execution plans is more difficult to reason about and troubleshoot.

I'm hoping that this experiment covers all functionality of this executor, but please test it yourself and let me know. From my tests it seems to work the same as before, even with executionSegments. That is, `2/4:3/4` _mostly_ executes 1/4 of the iterations that would be executed with `1`. I say mostly because it sometimes comes a bit short, but I think that can be fixed by stabilizing the execution plan, which would also fix the second bug reported in that issue (I'll provide more details in the issue).

The biggest drawback I see with this approach is that `time.AfterFunc` will potentially create lots of goroutines, though in practice I doubt it could become a problem (even with thousands of VUs, right?).

Tests are currently broken and will be fixed if we decide to continue with this approach.