### PR TITLE
Fix variable-looping-vus VU wobble during graceful ramp-down

### DIFF
--- a/lib/executor/variable_looping_vus.go
+++ b/lib/executor/variable_looping_vus.go
@@ -422,7 +422,7 @@ func (vlvc VariableLoopingVUsConfig) reserveVUsForGracefulRampDowns( //nolint:fu
 //
 // If gracefulRampDown is specified, it will also be taken into account, and the
 // number of needed VUs to handle that will also be reserved. See the
-// documentation of reserveGracefulVUScalingDown() for more details.
+// documentation of reserveVUsForGracefulRampDowns() for more details.
 //
 // On the other hand, gracefulStop is handled here. To facilitate it, we'll
 // ensure that the last execution step will have 0 VUs and will be at time

--- a/lib/executor/variable_looping_vus.go
+++ b/lib/executor/variable_looping_vus.go
@@ -590,7 +590,7 @@ func (vlv VariableLoopingVUs) Run(ctx context.Context, out chan<- stats.SampleCo
 				}
 				handleNewScheduledVUs(step.PlannedVUs)
 			case step := <-gracefulLimitEvents:
-				if step.PlannedVUs > currentScheduledVUs {
+				if step.PlannedVUs > currentMaxAllowedVUs {
 					// Handle the case where a value is read from the
 					// gracefulLimitEvents channel before rawStepEvents
 					handleNewScheduledVUs(step.PlannedVUs)

--- a/lib/executor/variable_looping_vus_test.go
+++ b/lib/executor/variable_looping_vus_test.go
@@ -22,6 +22,7 @@ package executor
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -35,10 +36,13 @@ import (
 	"github.com/loadimpact/k6/lib/types"
 )
 
-func getTestVariableLoopingVUsConfig() VariableLoopingVUsConfig {
-	return VariableLoopingVUsConfig{
-		BaseConfig: BaseConfig{GracefulStop: types.NullDurationFrom(0)},
-		StartVUs:   null.IntFrom(5),
+func TestVariableLoopingVUsRun(t *testing.T) {
+	t.Parallel()
+
+	config := VariableLoopingVUsConfig{
+		BaseConfig:       BaseConfig{GracefulStop: types.NullDurationFrom(0)},
+		GracefulRampDown: types.NullDurationFrom(0),
+		StartVUs:         null.IntFrom(5),
 		Stages: []Stage{
 			{
 				Duration: types.NullDurationFrom(1 * time.Second),
@@ -53,16 +57,12 @@ func getTestVariableLoopingVUsConfig() VariableLoopingVUsConfig {
 				Target:   null.IntFrom(3),
 			},
 		},
-		GracefulRampDown: types.NullDurationFrom(0),
 	}
-}
 
-func TestVariableLoopingVUsRun(t *testing.T) {
-	t.Parallel()
 	var iterCount int64
 	es := lib.NewExecutionState(lib.Options{}, 10, 50)
 	var ctx, cancel, executor, _ = setupExecutor(
-		t, getTestVariableLoopingVUsConfig(), es,
+		t, config, es,
 		simpleRunner(func(ctx context.Context) error {
 			time.Sleep(200 * time.Millisecond)
 			atomic.AddInt64(&iterCount, 1)
@@ -93,4 +93,86 @@ func TestVariableLoopingVUsRun(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []int64{5, 3, 0}, result)
 	assert.Equal(t, int64(40), iterCount)
+}
+
+// Ensure there's no wobble of VUs during graceful ramp-down, without segments.
+// See https://github.com/loadimpact/k6/issues/1296
+func TestVariableLoopingVUsRampDownNoWobble(t *testing.T) {
+	t.Parallel()
+
+	config := VariableLoopingVUsConfig{
+		BaseConfig:       BaseConfig{GracefulStop: types.NullDurationFrom(0)},
+		GracefulRampDown: types.NullDurationFrom(1 * time.Second),
+		StartVUs:         null.IntFrom(0),
+		Stages: []Stage{
+			{
+				Duration: types.NullDurationFrom(3 * time.Second),
+				Target:   null.IntFrom(10),
+			},
+			{
+				Duration: types.NullDurationFrom(2 * time.Second),
+				Target:   null.IntFrom(0),
+			},
+		},
+	}
+
+	es := lib.NewExecutionState(lib.Options{}, 10, 50)
+	var ctx, cancel, executor, _ = setupExecutor(
+		t, config, es,
+		simpleRunner(func(ctx context.Context) error {
+			time.Sleep(1 * time.Second)
+			return nil
+		}),
+	)
+	defer cancel()
+
+	var (
+		wg     sync.WaitGroup
+		result []int64
+		m      sync.Mutex
+	)
+
+	sampleActiveVUs := func(delay time.Duration) {
+		time.Sleep(delay)
+		m.Lock()
+		result = append(result, es.GetCurrentlyActiveVUsCount())
+		m.Unlock()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		sampleActiveVUs(100 * time.Millisecond)
+		sampleActiveVUs(3 * time.Second)
+		time.AfterFunc(2*time.Second, func() {
+			sampleActiveVUs(0)
+		})
+		time.Sleep(1 * time.Second)
+		// Sample ramp-down at a higher frequency
+		for i := 0; i < 15; i++ {
+			sampleActiveVUs(100 * time.Millisecond)
+		}
+	}()
+
+	err := executor.Run(ctx, nil)
+
+	wg.Wait()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), result[0])
+	assert.Equal(t, int64(10), result[1])
+	assert.Equal(t, int64(0), result[len(result)-1])
+
+	var curr int64
+	last := result[2]
+	// Check all ramp-down samples
+	for i := 3; i < len(result[2:]); i++ {
+		curr = result[i]
+		// Detect ramp-ups, missteps (e.g. 7 -> 4), but ignore pauses
+		if curr > last || (curr != last && curr != last-1) {
+			assert.FailNow(t,
+				fmt.Sprintf("ramping down wobble bug - "+
+					"current: %d, previous: %d\nVU samples: %v", curr, last, result))
+		}
+		last = curr
+	}
 }


### PR DESCRIPTION
This fixes the first bug mentioned in #1296, and adds a test that tries to ensure a smooth ramp-down.

I'm not proud of the test, and while it fairly consistently detected the bug and it might be useful for the second segment / execution plan issue, I'm concerned it might be flaky and would prefer a more deterministic approach of inspecting execution that doesn't rely on `time.Sleep`. Maybe inspecting metrics would be more reliable? Any ideas?