### PR TITLE
Re-enable the usage report

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -24,8 +24,11 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"encoding/json"
+	"net/http"
 	"os"
 	"os/signal"
+	"runtime"
 	"sync"
 	"syscall"
 	"time"
@@ -260,39 +263,6 @@ a commandline interface for interacting with it.`,
 		signal.Notify(sigC, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 		defer signal.Stop(sigC)
 
-		// If the user hasn't opted out: report usage.
-		//TODO: fix
-		//TODO: move to a separate function
-		/*
-			if !conf.NoUsageReport.Bool {
-				go func() {
-					u := "http://k6reports.loadimpact.com/"
-					mime := "application/json"
-					var endTSeconds float64
-					if endT := engine.Executor.GetEndTime(); endT.Valid {
-						endTSeconds = time.Duration(endT.Duration).Seconds()
-					}
-					var stagesEndTSeconds float64
-					if stagesEndT := lib.SumStages(engine.Executor.GetStages()); stagesEndT.Valid {
-						stagesEndTSeconds = time.Duration(stagesEndT.Duration).Seconds()
-					}
-					body, err := json.Marshal(map[string]interface{}{
-						"k6_version":  Version,
-						"vus_max":     engine.Executor.GetVUsMax(),
-						"iterations":  engine.Executor.GetEndIterations(),
-						"duration":    endTSeconds,
-						"st_duration": stagesEndTSeconds,
-						"goos":        runtime.GOOS,
-						"goarch":      runtime.GOARCH,
-					})
-					if err != nil {
-						panic(err) // This should never happen!!
-					}
-					_, _ = http.Post(u, mime, bytes.NewBuffer(body))
-				}()
-			}
-		*/
-
 		// Ticker for progress bar updates. Less frequent updates for non-TTYs, none if quiet.
 		updateFreq := 50 * time.Millisecond
 		if !stdoutTTY {
@@ -369,6 +339,10 @@ a commandline interface for interacting with it.`,
 			logger.Warn("No data generated, because no script iterations finished, consider making the test duration longer")
 		}
 
+		if !conf.NoUsageReport.Bool {
+			_ = reportUsage(execScheduler)
+		}
+
 		data := ui.SummaryData{
 			Metrics:   engine.Metrics,
 			RootGroup: engine.ExecutionScheduler.GetRunner().GetDefaultGroup(),
@@ -412,6 +386,36 @@ a commandline interface for interacting with it.`,
 		}
 		return nil
 	},
+}
+
+func reportUsage(execScheduler *local.ExecutionScheduler) error {
+	execPlan := execScheduler.GetExecutionPlan()
+	executorConfigs := execScheduler.GetExecutorConfigs()
+	execState := execScheduler.GetState()
+
+	executors := make(map[string]int)
+	for _, ec := range executorConfigs {
+		executors[ec.GetType()]++
+	}
+
+	body, err := json.Marshal(map[string]interface{}{
+		"k6_version": consts.Version,
+		"executors":  executors,
+		"vus_max":    lib.GetMaxPossibleVUs(execPlan),
+		"iterations": execState.GetFullIterationCount(),
+		"duration":   execState.GetCurrentTestRunDuration().String(),
+		"goos":       runtime.GOOS,
+		"goarch":     runtime.GOARCH,
+	})
+	if err != nil {
+		return err
+	}
+
+	res, err := http.Post("https://reports.k6.io/", "application/json", bytes.NewBuffer(body))
+	defer func() {
+		_ = res.Body.Close()
+	}()
+	return err
 }
 
 func runCmdFlagSet() *pflag.FlagSet {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -405,7 +405,7 @@ func reportUsage(execScheduler *local.ExecutionScheduler, wg *sync.WaitGroup) er
 	}
 
 	body, err := json.Marshal(map[string]interface{}{
-		"k6_version": consts.Version,
+		"k6_version": consts.FullVersion(),
 		"executors":  executors,
 		"vus_init":   execState.GetInitializedVUsCount(),
 		"vus_max":    lib.GetMaxPossibleVUs(execPlan),

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -407,6 +407,7 @@ func reportUsage(execScheduler *local.ExecutionScheduler, wg *sync.WaitGroup) er
 	body, err := json.Marshal(map[string]interface{}{
 		"k6_version": consts.Version,
 		"executors":  executors,
+		"vus_init":   execState.GetInitializedVUsCount(),
 		"vus_max":    lib.GetMaxPossibleVUs(execPlan),
 		"iterations": execState.GetFullIterationCount(),
 		"duration":   execState.GetCurrentTestRunDuration().String(),

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -321,8 +321,9 @@ a commandline interface for interacting with it.`,
 			}
 		}
 
-		reportCh := make(chan struct{})
+		var reportCh chan struct{}
 		if !conf.NoUsageReport.Bool {
+			reportCh = make(chan struct{})
 			go func() {
 				_ = reportUsage(execScheduler)
 				close(reportCh)
@@ -386,9 +387,11 @@ a commandline interface for interacting with it.`,
 			<-sigC
 		}
 
-		select {
-		case <-reportCh:
-		case <-time.After(3 * time.Second):
+		if reportCh != nil {
+			select {
+			case <-reportCh:
+			case <-time.After(3 * time.Second):
+			}
 		}
 
 		if engine.IsTainted() {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -419,7 +419,9 @@ func reportUsage(execScheduler *local.ExecutionScheduler, wg *sync.WaitGroup) er
 	client := http.Client{Timeout: 3 * time.Second}
 	res, err := client.Post("https://reports.k6.io/", "application/json", bytes.NewBuffer(body))
 	defer func() {
-		_ = res.Body.Close()
+		if err == nil {
+			_ = res.Body.Close()
+		}
 		wg.Done()
 	}()
 


### PR DESCRIPTION
Closes #1301

This re-enables the usage report, and updates its payload to include executor types and number of them used.

Example of payload:

```json
{
  "duration": "1m0.029405562s",
  "executors": {
    "constant-arrival-rate": 1,
    "constant-looping-vus": 2,
    "externally-controlled": 1,
    "per-vu-iterations": 1,
    "shared-iterations": 1,
    "variable-arrival-rate": 1,
    "variable-looping-vus": 2
  },
  "goarch": "amd64",
  "goos": "linux",
  "iterations": 2175,
  "k6_version": "0.26.0",
  "vus_max": 130
}
```

Note that currently this POST to https://reports.k6.io/ fails with a `502 Bad Gateway`, which I'm assuming is because of the change in schema and the backend will have to be updated to match. The differences are minor: this drops `duration_st` and adds `executors`.