### PR TITLE
Add v0.26.2 release notes

### DIFF
--- a/release notes/v0.26.2.md
+++ b/release notes/v0.26.2.md
@@ -1,0 +1,3 @@
+k6 v0.26.2 is a minor release that updates the used Go version for the Windows builds to Go 1.13.8. Due to an oversight, previous v0.26 k6 builds for Windows used an old Go version, while builds of other OSes used the correct one. This is meant to address an issue in the Go net/http package: https://github.com/golang/go/issues/34285 .
+
+There are no functional changes compared to v0.26.1.


### PR DESCRIPTION
This is a strange minor release that was done to fix the Windows build,
but otherwise doesn't have any functional changes, so this only updates
the release notes.

See https://github.com/loadimpact/k6/commit/459da79ef51b37e5eaba4575c9065d9e592e5c49