### PR TITLE
Make some executor tests more deterministic

### DIFF
--- a/lib/executor/variable_looping_vus_test.go
+++ b/lib/executor/variable_looping_vus_test.go
@@ -22,7 +22,6 @@ package executor
 
 import (
 	"context"
-	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -153,17 +152,12 @@ func TestVariableLoopingVUsRampDownNoWobble(t *testing.T) {
 	assert.Equal(t, int64(10), result[1])
 	assert.Equal(t, int64(0), result[len(result)-1])
 
-	var curr int64
-	last := result[2]
-	// Check all ramp-down samples for wobble
+	vuChanges := []int64{result[2]}
+	// Check ramp-down consistency
 	for i := 3; i < len(result[2:]); i++ {
-		curr = result[i]
-		// Detect ramp-ups, missteps (e.g. 7 -> 4), but ignore pauses (repeats)
-		if curr > last || (curr != last && curr != last-1) {
-			assert.FailNow(t,
-				fmt.Sprintf("ramping down wobble bug - "+
-					"current: %d, previous: %d\nVU samples: %v", curr, last, result))
+		if result[i] != result[i-1] {
+			vuChanges = append(vuChanges, result[i])
 		}
-		last = curr
 	}
+	assert.Equal(t, []int64{10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0}, vuChanges)
 }


### PR DESCRIPTION
This refactors a couple of tests mentioned in #1357 to reduce their chances of failure. :) It doesn't get rid of the flakiness entirely, but merely shifts things around and uses safer timings. In my tests the behavior is much more stable now, though there could still be some failures on Windows during quick CPU usage bursts, which I'm hopeful we won't run into on GH Actions.

After these changes stress testing both for about an hour didn't produce failures on Linux nor Windows:
![2020-03-25-145505_887x773_scrot](https://user-images.githubusercontent.com/1009277/77549274-ee072800-6eaf-11ea-958c-d9b61cc449bd.png)
![2020-03-25-145613_1208x1053_scrot](https://user-images.githubusercontent.com/1009277/77549304-f8292680-6eaf-11ea-8744-199007801bbf.png)

Whereas on `new-schedulers` both tests fail quickly:
![2020-03-25-150045_888x772_scrot](https://user-images.githubusercontent.com/1009277/77549392-1000aa80-6eb0-11ea-971d-5af6633304c4.png)

It's likely these might be more susceptible to failure when run as part of the entire package instead of individually, and while I didn't see them fail when stress testing `lib/executor`, I did see others mentioned [here](https://github.com/loadimpact/k6/issues/1357#issuecomment-603774494), some of which I'll take a look at next.

Moving forward, it might be a good idea to setup stress testing of certain packages as a periodic CI task so we can catch the flakiness sooner.