### PR TITLE
Refactor the Engine to process metrics independently from the test Run

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -148,7 +148,7 @@ a commandline interface for interacting with it.`,
 		logger := logrus.StandardLogger()
 
 		// We prepare a bunch of contexts:
-		//  - The runCtx is cancelled as soon as the Engine.Run() method finishes,
+		//  - The runCtx is cancelled as soon as the Engine's run() lambda finishes,
 		//    and can trigger things like the usage report and end of test summary.
 		//    Crucially, metrics processing by the Engine will still work after this
 		//    context is cancelled!
@@ -176,7 +176,7 @@ a commandline interface for interacting with it.`,
 		// This is manually triggered after the Engine's Run() has completed,
 		// and things like a single Ctrl+C don't affect it. We use it to make
 		// sure that the progressbars finish updating with the latest execution
-		// state one last ime, after the test run has finished.
+		// state one last time, after the test run has finished.
 		progressCtx, progressCancel := context.WithCancel(globalCtx)
 		defer progressCancel()
 		initBar = execScheduler.GetInitProgressBar()
@@ -309,7 +309,7 @@ a commandline interface for interacting with it.`,
 			}()
 		}
 
-		// Initialize the engine
+		// Start the test run
 		initBar.Modify(pb.WithConstProgress(0, "Start test"))
 		if err := engineRun(); err != nil {
 			return getExitCodeFromEngine(err)

--- a/core/engine.go
+++ b/core/engine.go
@@ -45,11 +45,16 @@ const (
 	BackoffMax    = 10 * time.Second
 )
 
-// The Engine is the beating heart of K6.
+// The Engine is the beating heart of k6.
 type Engine struct {
-	runLock sync.Mutex // y tho? TODO: remove?
+	// TODO: Make most of the stuff here private! And think how to refactor the
+	// engine to be less stateful... it's currently one big mess of moving
+	// pieces, and you implicitly first have to call Init() and then Run() -
+	// maybe we should refactor it so we have a `Session` dauther-object that
+	// Init() returns? The only problem with doing this is the REST API - it
+	// expects to be able to get information from the Engine and is initialized
+	// before the Init() call...
 
-	//TODO: make most of the stuff here private!
 	ExecutionScheduler lib.ExecutionScheduler
 	executionState     *lib.ExecutionState
 
@@ -59,7 +64,7 @@ type Engine struct {
 	NoSummary     bool
 	SummaryExport bool
 
-	logger   *logrus.Logger
+	logger   *logrus.Entry
 	stopChan chan struct{}
 
 	Metrics     map[string]*stats.Metric
@@ -89,7 +94,7 @@ func NewEngine(ex lib.ExecutionScheduler, o lib.Options, logger *logrus.Logger) 
 		Metrics:  make(map[string]*stats.Metric),
 		Samples:  make(chan stats.SampleContainer, o.MetricSamplesBufferSize.Int64),
 		stopChan: make(chan struct{}),
-		logger:   logger,
+		logger:   logger.WithField("component", "engine"),
 	}
 
 	e.thresholds = o.Thresholds
@@ -106,125 +111,179 @@ func NewEngine(ex lib.ExecutionScheduler, o lib.Options, logger *logrus.Logger) 
 	return e, nil
 }
 
-// Init is used to initialize the execution scheduler. That's a costly operation, since it
-// initializes all of the planned VUs and could potentially take a long time.
-func (e *Engine) Init(ctx context.Context) error {
-	return e.ExecutionScheduler.Init(ctx, e.Samples)
-}
-
-func (e *Engine) setRunStatus(status lib.RunStatus) {
-	for _, c := range e.Collectors {
-		c.SetRunStatus(status)
+// Init is used to initialize the execution scheduler and all metrics processing
+// in the engine. The first is a costly operation, since it initializes all of
+// the planned VUs and could potentially take a long time. It either returns an
+// error immediately, or it returns test Run() and WindDown() functions.
+//
+// Things to note:
+//  - The first lambda, Run(), synchronously executes the actual load test.
+//  - It can be prematurely aborted by cancelling the runCtx - this won't stop
+//    the metrics collection by the Engine.
+//  - Stopping the metrics collection can be done at any time after Run() has
+//    returned by cancelling the globalCtx
+//  - The second returned lambda can be used to wait for that process to finish.
+func (e *Engine) Init(globalCtx, runCtx context.Context) (run func() error, wait func(), err error) {
+	e.logger.Debug("Initialization starting...")
+	// TODO: if we ever need metrics processing in the init context, we can move
+	// this below the other components... or even start them concurrently?
+	if err := e.ExecutionScheduler.Init(runCtx, e.Samples); err != nil {
+		return nil, nil, err
 	}
+
+	// TODO: move all of this in a separate struct? see main TODO above
+
+	runSubCtx, runSubCancel := context.WithCancel(runCtx)
+
+	resultCh := make(chan error)
+	runFn := func() error {
+		e.logger.Debug("Execution scheduler starting...")
+		err := e.ExecutionScheduler.Run(globalCtx, runSubCtx, e.Samples)
+		e.logger.WithError(err).Debug("Execution scheduler terminated")
+
+		select {
+		case <-runSubCtx.Done():
+			// do nothing, the test run was aborted somehow
+		default:
+			resultCh <- err // we finished normally, so send the result
+		}
+
+		return err
+	}
+	waitFn := e.startBackgroundProcesses(globalCtx, runCtx, resultCh, runSubCancel)
+	return runFn, waitFn, nil
 }
 
-func (e *Engine) Run(ctx context.Context) error {
-	e.runLock.Lock()
-	defer e.runLock.Unlock()
+// This starts a bunch of goroutines to process metrics, thresholds, and set the
+// test run status when it ends. It returns a function that can be used after
+// the provided context is called, to wait for the complete winding down of all
+// started goroutines.
+func (e *Engine) startBackgroundProcesses( //nolint:funlen
+	globalCtx, runCtx context.Context, runResult <-chan error, runSubCancel func(),
+) (wait func()) {
+	processes := new(sync.WaitGroup)
 
-	e.logger.Debug("Engine: Starting with parameters...")
-
-	collectorwg := sync.WaitGroup{}
-	collectorctx, collectorcancel := context.WithCancel(context.Background())
-
+	// Spin up all configured collectors
 	for _, collector := range e.Collectors {
-		collectorwg.Add(1)
+		processes.Add(1)
 		go func(collector lib.Collector) {
-			collector.Run(collectorctx)
-			collectorwg.Done()
+			collector.Run(globalCtx)
+			processes.Done()
 		}(collector)
 	}
 
-	subctx, subcancel := context.WithCancel(context.Background())
-	subwg := sync.WaitGroup{}
-
-	// Run metrics emission.
-	subwg.Add(1)
+	// Siphon and handle all produced metric samples
+	processes.Add(1)
 	go func() {
-		e.runMetricsEmission(subctx)
-		e.logger.Debug("Engine: Emission terminated")
-		subwg.Done()
+		defer processes.Done()
+		e.processMetrics(globalCtx)
 	}()
 
-	// Run thresholds.
+	// Run VU metrics emission, only while the test is running.
+	// TODO: move? this seems like something the ExecutionScheduler should emit...
+	processes.Add(1)
+	go func() {
+		defer processes.Done()
+		e.logger.Debug("Starting emission of VU metrics...")
+		e.runMetricsEmission(runCtx)
+		e.logger.Debug("Metrics emission terminated")
+	}()
+
+	// Update the test run status when the test finishes
+	processes.Add(1)
+	thresholdAbortChan := make(chan struct{})
+	go func() {
+		defer processes.Done()
+		select {
+		case err := <-runResult:
+			if err != nil {
+				e.logger.WithError(err).Debug("run: execution scheduler returned an error")
+				e.setRunStatus(lib.RunStatusAbortedSystem)
+			} else {
+				e.logger.Debug("run: execution scheduler terminated")
+				e.setRunStatus(lib.RunStatusFinished)
+			}
+		case <-runCtx.Done():
+			e.logger.Debug("run: context expired; exiting...")
+			e.setRunStatus(lib.RunStatusAbortedUser)
+		case <-e.stopChan:
+			runSubCancel()
+			e.logger.Debug("run: stopped by user; exiting...")
+			e.setRunStatus(lib.RunStatusAbortedUser)
+		case <-thresholdAbortChan:
+			e.logger.Debug("run: stopped by thresholds; exiting...")
+			runSubCancel()
+			e.setRunStatus(lib.RunStatusAbortedThreshold)
+		}
+	}()
+
+	// Run thresholds, if not disabled.
 	if !e.NoThresholds {
-		subwg.Add(1)
+		processes.Add(1)
 		go func() {
-			e.runThresholds(subctx, subcancel)
-			e.logger.Debug("Engine: Thresholds terminated")
-			subwg.Done()
+			defer processes.Done()
+			defer e.logger.Debug("Engine: Thresholds terminated")
+			ticker := time.NewTicker(ThresholdsRate)
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-ticker.C:
+					if e.processThresholds() {
+						close(thresholdAbortChan)
+						return
+					}
+				case <-runCtx.Done():
+					return
+				}
+			}
 		}()
 	}
 
-	// Run the execution scheduler.
-	errC := make(chan error)
-	subwg.Add(1)
-	go func() {
-		errC <- e.ExecutionScheduler.Run(subctx, e.Samples)
-		e.logger.Debug("Engine: Execution scheduler terminated")
-		subwg.Done()
-	}()
+	return processes.Wait
+}
 
+func (e *Engine) processMetrics(globalCtx context.Context) {
 	sampleContainers := []stats.SampleContainer{}
+
 	defer func() {
-		// Shut down subsystems.
-		subcancel()
+		// Process any remaining metrics in the pipeline, by this point Run()
+		// has already finished and nothing else should be producing metrics.
+		e.logger.Debug("Metrics processing winding down...")
 
-		// Process samples until the subsystems have shut down.
-		// Filter out samples produced past the end of a test.
-		go func() {
-			if errC != nil {
-				<-errC
-				errC = nil
-			}
-			subwg.Wait()
-			close(e.Samples)
-		}()
-
+		close(e.Samples)
 		for sc := range e.Samples {
 			sampleContainers = append(sampleContainers, sc)
 		}
-
 		e.processSamples(sampleContainers)
 
-		// Process final thresholds.
 		if !e.NoThresholds {
-			e.processThresholds(nil)
+			e.processThresholds() // Process the thresholds one final time
 		}
-
-		// Finally, shut down collector.
-		collectorcancel()
-		collectorwg.Wait()
 	}()
 
 	ticker := time.NewTicker(CollectRate)
+	defer ticker.Stop()
+
+	e.logger.Debug("Metrics processing started...")
 	for {
 		select {
 		case <-ticker.C:
 			if len(sampleContainers) > 0 {
 				e.processSamples(sampleContainers)
-				sampleContainers = []stats.SampleContainer{}
+				sampleContainers = []stats.SampleContainer{} // TODO: optimize?
 			}
 		case sc := <-e.Samples:
 			sampleContainers = append(sampleContainers, sc)
-		case err := <-errC:
-			errC = nil
-			if err != nil {
-				e.logger.WithError(err).Debug("run: execution scheduler returned an error")
-				e.setRunStatus(lib.RunStatusAbortedSystem)
-				return err
-			}
-			e.logger.Debug("run: execution scheduler terminated")
-			return nil
-		case <-ctx.Done():
-			e.logger.Debug("run: context expired; exiting...")
-			e.setRunStatus(lib.RunStatusAbortedUser)
-			return nil
-		case <-e.stopChan:
-			e.logger.Debug("run: stopped by user; exiting...")
-			e.setRunStatus(lib.RunStatusAbortedUser)
-			return nil
+		case <-globalCtx.Done():
+			return
 		}
+	}
+}
+
+func (e *Engine) setRunStatus(status lib.RunStatus) {
+	for _, c := range e.Collectors {
+		c.SetRunStatus(status)
 	}
 }
 
@@ -282,24 +341,11 @@ func (e *Engine) emitMetrics() {
 	}})
 }
 
-func (e *Engine) runThresholds(ctx context.Context, abort func()) {
-	ticker := time.NewTicker(ThresholdsRate)
-	for {
-		select {
-		case <-ticker.C:
-			e.processThresholds(abort)
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
-func (e *Engine) processThresholds(abort func()) {
+func (e *Engine) processThresholds() (shouldAbort bool) {
 	e.MetricsLock.Lock()
 	defer e.MetricsLock.Unlock()
 
 	t := e.executionState.GetCurrentTestRunDuration()
-	abortOnFail := false
 
 	e.thresholdsTainted = false
 	for _, m := range e.Metrics {
@@ -318,17 +364,13 @@ func (e *Engine) processThresholds(abort func()) {
 			e.logger.WithField("m", m.Name).Debug("Thresholds failed")
 			m.Tainted = null.BoolFrom(true)
 			e.thresholdsTainted = true
-			if !abortOnFail && m.Thresholds.Abort {
-				abortOnFail = true
+			if m.Thresholds.Abort {
+				shouldAbort = true
 			}
 		}
 	}
 
-	if abortOnFail && abort != nil {
-		//TODO: When sending this status we get a 422 Unprocessable Entity
-		e.setRunStatus(lib.RunStatusAbortedThreshold)
-		abort()
-	}
+	return shouldAbort
 }
 
 func (e *Engine) processSamplesForMetrics(sampleCointainers []stats.SampleContainer) {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -929,7 +929,6 @@ func TestMinIterationDurationInSetupTeardownStage(t *testing.T) {
 			require.NoError(t, err)
 
 			engine, run, wait := newTestEngine(t, nil, runner, runner.GetOptions())
-			defer wait()
 
 			errC := make(chan error)
 			go func() { errC <- run() }()
@@ -938,6 +937,7 @@ func TestMinIterationDurationInSetupTeardownStage(t *testing.T) {
 				t.Fatal("Test timed out")
 			case err := <-errC:
 				require.NoError(t, err)
+				wait()
 				require.False(t, engine.IsTainted())
 			}
 		})

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -587,7 +587,6 @@ func TestRunTags(t *testing.T) {
 		SystemTags:            &stats.DefaultSystemTagSet,
 		InsecureSkipTLSVerify: null.BoolFrom(true),
 	})
-	defer wait()
 
 	collector := &dummy.Collector{}
 	engine.Collectors = []lib.Collector{collector}
@@ -601,6 +600,7 @@ func TestRunTags(t *testing.T) {
 	case err := <-errC:
 		require.NoError(t, err)
 	}
+	wait()
 
 	systemMetrics := []*stats.Metric{
 		metrics.VUs, metrics.VUsMax, metrics.Iterations, metrics.IterationDuration,
@@ -736,7 +736,6 @@ func TestEmittedMetricsWhenScalingDown(t *testing.T) {
 	require.NoError(t, err)
 
 	engine, run, wait := newTestEngine(t, nil, runner, lib.Options{})
-	defer wait()
 
 	collector := &dummy.Collector{}
 	engine.Collectors = []lib.Collector{collector}
@@ -749,6 +748,7 @@ func TestEmittedMetricsWhenScalingDown(t *testing.T) {
 		t.Fatal("Test timed out")
 	case err := <-errC:
 		require.NoError(t, err)
+		wait()
 		require.False(t, engine.IsTainted())
 	}
 
@@ -842,7 +842,6 @@ func TestMetricsEmission(t *testing.T) {
 			require.NoError(t, err)
 
 			engine, run, wait := newTestEngine(t, nil, runner, runner.GetOptions())
-			defer wait()
 
 			collector := &dummy.Collector{}
 			engine.Collectors = []lib.Collector{collector}
@@ -855,6 +854,7 @@ func TestMetricsEmission(t *testing.T) {
 				t.Fatal("Test timed out")
 			case err := <-errC:
 				require.NoError(t, err)
+				wait()
 				require.False(t, engine.IsTainted())
 			}
 

--- a/core/local/local_test.go
+++ b/core/local/local_test.go
@@ -92,7 +92,7 @@ func TestExecutionSchedulerRun(t *testing.T) {
 	defer cancel()
 
 	err := make(chan error, 1)
-	go func() { err <- execScheduler.Run(ctx, samples) }()
+	go func() { err <- execScheduler.Run(ctx, ctx, samples) }()
 	assert.NoError(t, <-err)
 }
 
@@ -114,7 +114,7 @@ func TestExecutionSchedulerSetupTeardownRun(t *testing.T) {
 		ctx, cancel, execScheduler, samples := newTestExecutionScheduler(t, runner, nil, lib.Options{})
 
 		err := make(chan error, 1)
-		go func() { err <- execScheduler.Run(ctx, samples) }()
+		go func() { err <- execScheduler.Run(ctx, ctx, samples) }()
 		defer cancel()
 		<-setupC
 		<-teardownC
@@ -128,7 +128,7 @@ func TestExecutionSchedulerSetupTeardownRun(t *testing.T) {
 		}
 		ctx, cancel, execScheduler, samples := newTestExecutionScheduler(t, runner, nil, lib.Options{})
 		defer cancel()
-		assert.EqualError(t, execScheduler.Run(ctx, samples), "setup error")
+		assert.EqualError(t, execScheduler.Run(ctx, ctx, samples), "setup error")
 	})
 	t.Run("Don't Run Setup", func(t *testing.T) {
 		runner := &minirunner.MiniRunner{
@@ -145,7 +145,7 @@ func TestExecutionSchedulerSetupTeardownRun(t *testing.T) {
 			Iterations: null.IntFrom(1),
 		})
 		defer cancel()
-		assert.EqualError(t, execScheduler.Run(ctx, samples), "teardown error")
+		assert.EqualError(t, execScheduler.Run(ctx, ctx, samples), "teardown error")
 	})
 
 	t.Run("Teardown Error", func(t *testing.T) {
@@ -163,7 +163,7 @@ func TestExecutionSchedulerSetupTeardownRun(t *testing.T) {
 		})
 		defer cancel()
 
-		assert.EqualError(t, execScheduler.Run(ctx, samples), "teardown error")
+		assert.EqualError(t, execScheduler.Run(ctx, ctx, samples), "teardown error")
 	})
 	t.Run("Don't Run Teardown", func(t *testing.T) {
 		runner := &minirunner.MiniRunner{
@@ -180,7 +180,7 @@ func TestExecutionSchedulerSetupTeardownRun(t *testing.T) {
 			Iterations: null.IntFrom(1),
 		})
 		defer cancel()
-		assert.NoError(t, execScheduler.Run(ctx, samples))
+		assert.NoError(t, execScheduler.Run(ctx, ctx, samples))
 	})
 }
 
@@ -224,7 +224,7 @@ func TestExecutionSchedulerStages(t *testing.T) {
 				Stages: data.Stages,
 			})
 			defer cancel()
-			assert.NoError(t, execScheduler.Run(ctx, samples))
+			assert.NoError(t, execScheduler.Run(ctx, ctx, samples))
 			assert.True(t, execScheduler.GetState().GetCurrentTestRunDuration() >= data.Duration)
 		})
 	}
@@ -249,7 +249,7 @@ func TestExecutionSchedulerEndTime(t *testing.T) {
 	assert.True(t, isFinal)
 
 	startTime := time.Now()
-	assert.NoError(t, execScheduler.Run(ctx, samples))
+	assert.NoError(t, execScheduler.Run(ctx, ctx, samples))
 	runTime := time.Since(startTime)
 	assert.True(t, runTime > 1*time.Second, "test did not take 1s")
 	assert.True(t, runTime < 10*time.Second, "took more than 10 seconds")
@@ -276,7 +276,7 @@ func TestExecutionSchedulerRuntimeErrors(t *testing.T) {
 	assert.True(t, isFinal)
 
 	startTime := time.Now()
-	assert.NoError(t, execScheduler.Run(ctx, samples))
+	assert.NoError(t, execScheduler.Run(ctx, ctx, samples))
 	runTime := time.Since(startTime)
 	assert.True(t, runTime > 1*time.Second, "test did not take 1s")
 	assert.True(t, runTime < 10*time.Second, "took more than 10 seconds")
@@ -313,7 +313,7 @@ func TestExecutionSchedulerEndErrors(t *testing.T) {
 	assert.True(t, isFinal)
 
 	startTime := time.Now()
-	assert.NoError(t, execScheduler.Run(ctx, samples))
+	assert.NoError(t, execScheduler.Run(ctx, ctx, samples))
 	runTime := time.Since(startTime)
 	assert.True(t, runTime > 1*time.Second, "test did not take 1s")
 	assert.True(t, runTime < 10*time.Second, "took more than 10 seconds")
@@ -357,7 +357,7 @@ func TestExecutionSchedulerEndIterations(t *testing.T) {
 
 	samples := make(chan stats.SampleContainer, 300)
 	require.NoError(t, execScheduler.Init(ctx, samples))
-	require.NoError(t, execScheduler.Run(ctx, samples))
+	require.NoError(t, execScheduler.Run(ctx, ctx, samples))
 
 	assert.Equal(t, uint64(100), execScheduler.GetState().GetFullIterationCount())
 	assert.Equal(t, uint64(0), execScheduler.GetState().GetPartialIterationCount())
@@ -382,7 +382,7 @@ func TestExecutionSchedulerIsRunning(t *testing.T) {
 	state := execScheduler.GetState()
 
 	err := make(chan error)
-	go func() { err <- execScheduler.Run(ctx, nil) }()
+	go func() { err <- execScheduler.Run(ctx, ctx, nil) }()
 	for !state.HasStarted() {
 		time.Sleep(10 * time.Microsecond)
 	}
@@ -558,7 +558,7 @@ func TestRealTimeAndSetupTeardownMetrics(t *testing.T) {
 	sampleContainers := make(chan stats.SampleContainer)
 	go func() {
 		require.NoError(t, execScheduler.Init(ctx, sampleContainers))
-		assert.NoError(t, execScheduler.Run(ctx, sampleContainers))
+		assert.NoError(t, execScheduler.Run(ctx, ctx, sampleContainers))
 		close(done)
 	}()
 

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -47,7 +47,7 @@ import (
 	k6metrics "github.com/loadimpact/k6/js/modules/k6/metrics"
 	"github.com/loadimpact/k6/js/modules/k6/ws"
 	"github.com/loadimpact/k6/lib"
-	_ "github.com/loadimpact/k6/lib/executor" //TODO: figure out something better
+	_ "github.com/loadimpact/k6/lib/executor" // TODO: figure out something better
 	"github.com/loadimpact/k6/lib/metrics"
 	"github.com/loadimpact/k6/lib/testutils/httpmultibin"
 	"github.com/loadimpact/k6/lib/types"
@@ -284,13 +284,14 @@ func TestSetupDataIsolation(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	require.NoError(t, engine.Init(ctx))
+	run, wait, err := engine.Init(ctx, ctx)
+	require.NoError(t, err)
 
 	collector := &dummy.Collector{}
 	engine.Collectors = []lib.Collector{collector}
 
 	errC := make(chan error)
-	go func() { errC <- engine.Run(ctx) }()
+	go func() { errC <- run() }()
 
 	select {
 	case <-time.After(10 * time.Second):
@@ -300,6 +301,7 @@ func TestSetupDataIsolation(t *testing.T) {
 		cancel()
 		require.NoError(t, err)
 		require.False(t, engine.IsTainted())
+		wait()
 	}
 	var count int
 	for _, s := range collector.Samples {

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -300,8 +300,8 @@ func TestSetupDataIsolation(t *testing.T) {
 	case err := <-errC:
 		cancel()
 		require.NoError(t, err)
-		require.False(t, engine.IsTainted())
 		wait()
+		require.False(t, engine.IsTainted())
 	}
 	var count int
 	for _, s := range collector.Samples {

--- a/lib/execution.go
+++ b/lib/execution.go
@@ -62,7 +62,7 @@ type ExecutionScheduler interface {
 
 	// Run the ExecutionScheduler, funneling the generated metric samples
 	// through the supplied out channel.
-	Run(lobalCtx, runCtx context.Context, engineOut chan<- stats.SampleContainer) error
+	Run(globalCtx, runCtx context.Context, engineOut chan<- stats.SampleContainer) error
 
 	// Pause a test, or start/resume it. To check if a test is paused, use
 	// GetState().IsPaused().

--- a/lib/execution.go
+++ b/lib/execution.go
@@ -62,7 +62,7 @@ type ExecutionScheduler interface {
 
 	// Run the ExecutionScheduler, funneling the generated metric samples
 	// through the supplied out channel.
-	Run(ctx context.Context, engineOut chan<- stats.SampleContainer) error
+	Run(lobalCtx, runCtx context.Context, engineOut chan<- stats.SampleContainer) error
 
 	// Pause a test, or start/resume it. To check if a test is paused, use
 	// GetState().IsPaused().


### PR DESCRIPTION
This allows metric processing to still occur, even after the script run has completed. In practice, this allows you to run k6 with the `--linger --no-teardown` flags, and execute the `teardown()` function manually through the REST API, after the main test run has completed.

This also fixes https://github.com/loadimpact/k6/issues/1369 - now a second Ctrl+C will _always_ abort k6, albeit in a very abrupt way. On the other hand, the first Ctrl+C would be more graceful than it currently is, since it will now allow `teardown()` to be executed.