### PR TITLE
Support use TLS when connect to Kafka for producer

### DIFF
--- a/stats/kafka/collector.go
+++ b/stats/kafka/collector.go
@@ -59,12 +59,14 @@ func New(conf Config) (*Collector, error) {
 		}
 
 		tlsConfig.InsecureSkipVerify = conf.InsecureSkipVerify
-		// Only set TLS if use
-		if !conf.TestUseTLS {
-			cfg = sarama.NewConfig()
-			cfg.Net.TLS.Enable = true
-			cfg.Net.TLS.Config = tlsConfig
-		}
+
+		cfg = sarama.NewConfig()
+		cfg.Net.TLS.Enable = true
+		cfg.Net.TLS.Config = tlsConfig
+		cfg.Producer.RequiredAcks = sarama.WaitForAll
+		cfg.Producer.Return.Successes = true
+		cfg.Producer.Return.Errors = true
+		cfg.Producer.Partitioner = sarama.NewRandomPartitioner
 	}
 
 	producer, err := sarama.NewSyncProducer(conf.Brokers, cfg)

--- a/stats/kafka/collector_test.go
+++ b/stats/kafka/collector_test.go
@@ -22,6 +22,7 @@ package kafka
 
 import (
 	"context"
+	"os"
 	"sync"
 	"testing"
 
@@ -29,6 +30,96 @@ import (
 	"github.com/loadimpact/k6/stats"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/guregu/null.v3"
+)
+
+const (
+	FakeCertificateName = "cert.csr"
+	FakePrivateKeyName  = "private.key"
+)
+
+const (
+	FakeCertificate = `-----BEGIN CERTIFICATE-----
+MIIE7jCCAtYCCQC7Yg+y9BeOUjANBgkqhkiG9w0BAQsFADA5MQswCQYDVQQGEwJW
+TjEOMAwGA1UECAwFSGFub2kxGjAYBgNVBAMMEXd3dy5rYWZrYS10bHMuY29tMB4X
+DTIwMDQxNjA4MTAzNFoXDTIxMDQxNjA4MTAzNFowOTELMAkGA1UEBhMCVk4xDjAM
+BgNVBAgMBUhhbm9pMRowGAYDVQQDDBF3d3cua2Fma2EtdGxzLmNvbTCCAiIwDQYJ
+KoZIhvcNAQEBBQADggIPADCCAgoCggIBAMRfHv7aWSzpJskvgfEPLAsNt2mlMrsy
++yjQBucIX8v4FBv4SflVxoNk1epazdxMWB4SjWLSK3vSLdGcNfyoiUlwbAu7m106
+m3BD80yxnyl+x1dwKfYDqLnt+KMibiU3zR2HZGFhP4HQdZ9b4DjOvME5t96b/d/m
+8jNlSpvD5jH9HfCVghJLWN9dA3KHV6KGAXZFv50+KE6PNwMrDsx4eR8J4MN74NsY
+narBKhnm7j6OvYkP+8e/lIHQ/vJNopcrmYtqzJNmPg9JZIjYhIl9xq53L1GsYVaD
+Ef9gqV7UwsHDatE2XsvrRogGj1nPnImmoG4/ldLv/6sKS86B35OPaRshoxjoJ0P5
++3wM3Mc65FXVSHCMFts849Mj+sJ1PzmPN/w9DAxm26HepM9t2shSbvp5Rl7WdI58
+G28bp29ah5WXcXok7bpmZu5hG9iS8KkpQoFji5vi5GqWX78de89sBhKriIPsKWZo
+cGlU6LZvSh60keXct08mHZkoSvnWIUc+3IdMLfvMgz4JLKZChz0y+2JgPJWYBax0
+6d7ip4P6mgRzmzv2pu+QxvRPZOEEYjh9thwjRZ1XIqgeHFCEM9C8iTb7ga65y5kP
+fMgBFsTcPNAFaOt+bKZvTQDeErc5x2R3V4yrnFXAusXy1Y4leibIljkfjU2tJ9Zx
+GGVLpkpG48j1AgMBAAEwDQYJKoZIhvcNAQELBQADggIBACwm36OvzSIUYUJ9s2x9
+rfkgix7go1n8FWccaeuOm1yj+mICBnGKFbJNMaK82wvpHTwUAk7DB4nEMmxw6dmW
+DqPBj1YpEd1PiWWEiLQ/RyI4dAhEsuZrQjbDeXnoSziqXF1oMUVSFhATQEYZWJQq
+sqIsi5M0FfPxmQwN5ODw6OWZVV+pyl2XF4FWAGGuQLuFez8nc4x2lYoZ4F4udOdo
+NpW6yojjlnC5jrG+j//3ypWTraBxkYm474ci3O9S6eJfWCrjbS8/jOFNBEfFURtf
+OOcArbpc9QXcKP1izm3YsEr+pGIjUuhoi+LBbJMW0HqwXjvN0ZwOGfRAjsBql2ce
+XvLNryhN8lbWFG9d3fo0rjX/sWiyPWTOXAEOEmI+fmJHvUWg7+Y5qI9UWojj+BVr
+Wklvd/ejZrAufI3uOBMOIWHAXQRLAYlaElLtuKHlDonyra60Iz+fC+9qC/KwUgcU
+tfiMRHKCYlX+58yzJ83Q/u/eFbTy44gGBmLx+SR8/lOcIjl525e0MTMjdCiB8zV9
+gB6PhGFP0eOE27F7u3CKLUcQkLaESlK7TU0SbkvXJydXhUGgt/oreapWvb5jtC2H
+LhcYyoMx3OZHorG9aeqeVUtTq0i6uTgI0VaUxYI2w+Evz/aGy/K7g0X7GYXOdF3Q
+uVS8R520GTnZ1PW4RlY2Jpfp
+-----END CERTIFICATE-----`
+
+	FakePrivateKey = `-----BEGIN PRIVATE KEY-----
+MIIJRAIBADANBgkqhkiG9w0BAQEFAASCCS4wggkqAgEAAoICAQDEXx7+2lks6SbJ
+L4HxDywLDbdppTK7Mvso0AbnCF/L+BQb+En5VcaDZNXqWs3cTFgeEo1i0it70i3R
+nDX8qIlJcGwLu5tdOptwQ/NMsZ8pfsdXcCn2A6i57fijIm4lN80dh2RhYT+B0HWf
+W+A4zrzBObfem/3f5vIzZUqbw+Yx/R3wlYISS1jfXQNyh1eihgF2Rb+dPihOjzcD
+Kw7MeHkfCeDDe+DbGJ2qwSoZ5u4+jr2JD/vHv5SB0P7yTaKXK5mLasyTZj4PSWSI
+2ISJfcaudy9RrGFWgxH/YKle1MLBw2rRNl7L60aIBo9Zz5yJpqBuP5XS7/+rCkvO
+gd+Tj2kbIaMY6CdD+ft8DNzHOuRV1UhwjBbbPOPTI/rCdT85jzf8PQwMZtuh3qTP
+bdrIUm76eUZe1nSOfBtvG6dvWoeVl3F6JO26ZmbuYRvYkvCpKUKBY4ub4uRqll+/
+HXvPbAYSq4iD7ClmaHBpVOi2b0oetJHl3LdPJh2ZKEr51iFHPtyHTC37zIM+CSym
+Qoc9MvtiYDyVmAWsdOne4qeD+poEc5s79qbvkMb0T2ThBGI4fbYcI0WdVyKoHhxQ
+hDPQvIk2+4GuucuZD3zIARbE3DzQBWjrfmymb00A3hK3Ocdkd1eMq5xVwLrF8tWO
+JXomyJY5H41NrSfWcRhlS6ZKRuPI9QIDAQABAoICAQCoyw6sh+kxNnP1aRWrrJvy
+IGcwsyRJTwgey7mzKzqU6/f1FtYXMUjCtpE9sbHUE/eGWfIYKIniFAb4burk88WW
+T8E/0JI6b98ef/oJSYCDPYuBuFMJOZn1v/0B1N2StkVkhXWeUuYw4ovIYEP68JHF
+EaTf/3wY0r4LuZyJCbm77FOo8gptSUDqNlx5PKbyd3eYP1n2gnBJHsdtvLwqu795
+E5eU0M215pHYLdPPkfXl5fI7d3a3+xBfCdOrWVpR0NNZyIJyjOb5Yt+81UgPmwKG
+AsK01JSStXVp65+KeR2zShNuI+sWI3VsBR+BVni6xXSPb66MM2mzjtUce/w/LX1s
+ptdJHDeP+Qo/pSxUpJi1Q/s4MkjfGVo2AdvJ2qTOXmlAgLUJsxKwQn9qi3v8ZcpD
+G6I7LdySlsDv3zGUWNpQ9YLUfidnKbEQE+NWO5BKwP4uX8hzZOVyXaWDUvt0C/6J
+SsgjpNk3jF75FvYL+nI4ne8CEp/O6a5h2lhOdHgY1uGjV1WHUGiSh0w7yB7h8Ga9
+DWjAId0defANueG0KsHlHx4Ak2Ci9pBiRsUjT2Jol4usyvppOxPNk0ylq+D33EAh
+zwyc4KhVIcVxCO+BRH9KYZKmGxd5JnenY7hlFAj3m3q+d/ubbmcgO1mHj8dcfAJ6
+qOJ5Keroc/jVG3nOrbhC/QKCAQEA9Vny37BnZTkmPc7YDjFEPqeW+lV0ls5vaF+L
+PUUexHJxsxLuCoa8/nVdtLhjeatGYfyQfjID71St7z9l3lGzsJy+kdhHc7H22D8P
+xj+QMmfAvl5ifUhuliCXb7IoFKDXguXJL7wsi8U6Y9DG6jgtLGbQh8lfx+cLO9LS
+4YMbrmy/CT7wMbanO6MvYNM1+9CCfAQdqM4GDSb5sB+A2XtC8Ad+WsWm2jVmvPJY
+cpPNOPOOuhpcTIOIGIpa3tafxRdDWTaafKC1v6mpj7rMePRTf6OvLdXtusffzTQY
+2/+jhJPwu7YfnvQbskgaDsS4mbxWiXpOS/A5swcAqQp3fVWuiwKCAQEAzOT3pWJV
+bX++LsvLu62zz7sqbPkF0xutal8XCIDL1iqLpwu3jVUJt2REqUtwhbeNXTBV4sLK
+l71ZcA6RojUxSeePZyrIl21MVDMyGTQcfUvm6fBYtyL9Bw8vM7+rY296OFIsYfGS
+KWKNdg7BllaCWjG6Kwj8RZu82bkTD6eRDMrJm1KzgdLZ/z6ol182DIGNcRD0/A8K
+J5+rKTxsxo8W8bb6uGipC2gQNZpyVgDTXz5Ze8SubFEq2cGr4Pct/S9LSR78Kn5d
+dd4q0MVpxniqsJVJ/qC1gZQA72x7dEncldj7UPsmcvtmZcEPZZvpkQT/12m+2hpG
+xZ1qO4TsZa7WfwKCAQEA6pHJu4ULBWLDJfqY49DEX2aY2NNUuU26g749ACISTVzh
+SYTCoru4+0q4gSx8pnlSvCHc/1nQG0QJWyBww0G3mxXwuL1fasRtrMd1zGM++IHr
+a9YPMZpLaCrWvcpFuZshEBui4ol0yViR/5Y+ZvW4cqgFnJyxfwxs2BAy37oagAOm
+DS/oMo9fiYv1owurpAnwhqLkvFvkuzRVKcakyMio8ZUof55SbHL7u4+zci/O2DE7
+dr/3GIv0VQoJ4NyvOZ6JHEUxJA/+U7Tg0PKVxNpK7lBPDnJma9nmJWk2jzb0Xa+X
+S8/OoYje5e87Qn1fxFOlJKETNFUCxR/fyL2iCekeCwKCAQAadJ39PrslDk9yH2JI
+8166PcJ2m5jC71nu2CRTNr4bAxdRFFQ47Xf5s/qhmVoICfE4zRrp0pjyCsLXkyn+
+tbuNfVaozX9k/fnTDWE0m+Pp0bkZD62EyAG/vZgsqFzq0+QGDaYpZ1Wl/lGhorog
+PT9Lggw1rk1Ud41k1168sLgr3Ks3YPBInP8E1ARUtzh1WOz4YmYffZmkEBu7kU/C
+O4uM3kF1Oh5JmMAvC6gjrqucKqLHNlgHKFvODhGxVHkdrdOct2F74yESLQN+PV8w
+/zea4UvSktGcz41nXKx8EWVn+8JHbIZEZm2MSedBCWaZEPovyDmaU7Y7od2rnbgg
+UPjlAoIBAQCd7svMuZ09BG/Ed2pRySH5Gl7qxieffQs/p5ofhHCcFOD1CBftasw6
+5fL5kWWQ/aaIXb8MNEA3vE6FLgSXs1qfNjlkUPEW/fjb2KD7o56GhORCyv8tVUH7
+PfxnhLOTJQ5VpH1pv/7Cgqi1HX1p0bP1SkJEimdrDwMfLjbHw+7JH5GEknxEf2kf
+HA6pN1TdGjMoJ6uFD3xH2bouVXtV4MF4g3GI2QlUtutVuPN1n2NazVjbaAM65Q/9
+L/hGN2BUVtVgp3FZ9hSNQwwZs1Ohf3TIOSSL1NypugQ48zL002XfKk9uJuu9zUdn
+EWRsC1qR8zzRIzw2b5OrE+TrZvp56tTr
+-----END PRIVATE KEY-----`
 )
 
 func TestRun(t *testing.T) {
@@ -42,6 +133,46 @@ func TestRun(t *testing.T) {
 	cfg := Config{
 		Brokers: []string{broker.Addr()},
 		Topic:   null.NewString("my_topic", false),
+	}
+	config := NewConfig().Apply(cfg)
+	c, err := New(config)
+
+	assert.Nil(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		c.Run(ctx)
+	}()
+	cancel()
+	wg.Wait()
+}
+
+func TestRunWithTLS(t *testing.T) {
+	broker := sarama.NewMockBroker(t, 1)
+	coordinator := sarama.NewMockBroker(t, 2)
+	seedMeta := new(sarama.MetadataResponse)
+	seedMeta.AddBroker(coordinator.Addr(), coordinator.BrokerID())
+	seedMeta.AddTopicPartition("my_topic", 0, 1, []int32{}, []int32{}, sarama.ErrNoError)
+	broker.Returns(seedMeta)
+
+	err := CreateFakeTLS()
+	assert.Nil(t, err)
+	defer func() {
+		err = RemoveFakeTLS()
+		assert.Nil(t, err)
+	}()
+
+	cfg := Config{
+		Brokers:            []string{broker.Addr()},
+		Topic:              null.NewString("my_topic", false),
+		ClientCertFilePath: FakeCertificateName,
+		ClientKeyFilePath:  FakePrivateKeyName,
+		InsecureSkipVerify: true,
+		ClientUseTLS:       true,
+		TestUseTLS:         true,
 	}
 	config := NewConfig().Apply(cfg)
 	c, err := New(config)
@@ -82,4 +213,28 @@ func TestFormatSamples(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, []string{expJSON1, expJSON2}, fmtdSamples)
+}
+
+func CreateFakeTLS() error {
+	err := WriteStringToFile(FakeCertificate, FakeCertificateName)
+	if err != nil {
+		return err
+	}
+	err = WriteStringToFile(FakePrivateKey, FakePrivateKeyName)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func RemoveFakeTLS() error {
+	err := os.Remove(FakeCertificateName)
+	if err != nil {
+		return err
+	}
+	err = os.Remove(FakePrivateKeyName)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/stats/kafka/config.go
+++ b/stats/kafka/config.go
@@ -47,7 +47,6 @@ type Config struct {
 	ClientCAFilePath   string `json:"ca" envconfig:"K6_KAFKA_CA"`
 	InsecureSkipVerify bool   `json:"insecure" envconfig:"K6_KAFKA_INSECURE"`
 	ClientUseTLS       bool
-	TestUseTLS         bool
 
 	InfluxDBConfig influxdb.Config `json:"influxdb"`
 }
@@ -96,7 +95,6 @@ func (c Config) Apply(cfg Config) Config {
 
 	c.InsecureSkipVerify = cfg.InsecureSkipVerify
 	c.ClientUseTLS = cfg.ClientUseTLS
-	c.TestUseTLS = cfg.TestUseTLS
 
 	return c
 }

--- a/stats/kafka/io.go
+++ b/stats/kafka/io.go
@@ -1,0 +1,49 @@
+package kafka
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Check current file path is exist
+func GetAbsolutelyFilePath(path string) (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	// If input file path is not absolutely filepath, let's join it with current working directory
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(wd, strings.Trim(path, "."))
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+
+	//
+	if info.IsDir() {
+		return "", fmt.Errorf("%v is is not a file", path)
+	}
+
+	return path, nil
+}
+
+func WriteStringToFile(body, path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	_, err = f.WriteString(body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/stats/kafka/tls.go
+++ b/stats/kafka/tls.go
@@ -1,0 +1,40 @@
+package kafka
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+)
+
+func NewTLSConfig(clientCertFilePath, clientKeyFilePath, caCertFilePath string) (*tls.Config, error) {
+	//Load client certificate
+	if clientCertFilePath == "" || clientKeyFilePath == "" {
+		return nil, fmt.Errorf("client cert or client key must not be empty")
+	}
+
+	cert, err := tls.LoadX509KeyPair(clientCertFilePath, clientKeyFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}
+
+	//Load CA certificate
+	if caCertFilePath != "" {
+		caCert, err := ioutil.ReadFile(caCertFilePath)
+		if err != nil {
+			return nil, err
+		}
+
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+		tlsConfig.RootCAs = caCertPool
+	}
+
+	tlsConfig.BuildNameToCertificate()
+
+	return tlsConfig, nil
+}


### PR DESCRIPTION
This pull request adds more TLS config for Kafka Producer when brokers need to verify the connection by SSL Certificate.

Some parameters have added:
- cert: The certificate file path (must be input)
- key: The private key file path (must be input)
- ca: The CA certificate file path (optional)
- insecure: Disable verify common name (default: false)

*Caution: You must add both the cert and key to enable TLS config.*

Example to use:
```bash
$ k6 run --logformat=raw --out kafka=brokers=localhost:9092,topic=k6-output,format=json,cert=mycert.csr,key=mykey.key,ca=myca.pem,insecure=true scripts.js
```
