### PR TITLE
Use the striping algorithm for shared iterations

### DIFF
--- a/core/local/local_test.go
+++ b/core/local/local_test.go
@@ -736,7 +736,8 @@ func TestNewExecutionSchedulerHasWork(t *testing.T) {
 		import http from 'k6/http';
 
 		export let options = {
-			executionSegment: "2/4:3/4",
+			executionSegment: "3/4:1",
+			executionSegmentSequence: "0,1/4,2/4,3/4,1",
 			execution: {
 				shared_iters1: {
 					type: "shared-iterations",

--- a/lib/executor/executors_test.go
+++ b/lib/executor/executors_test.go
@@ -232,6 +232,46 @@ var configMapTestCases = []configMapTestCase{
 
 			totalReqs := cm.GetFullExecutionRequirements(et)
 			assert.Equal(t, schedReqs, totalReqs)
+
+			et = mustNewExecutionTuple(newExecutionSegmentFromString("0:1/3"), newExecutionSegmentSequenceFromString("0,1/3,2/3,1"))
+			assert.Equal(t, "8 iterations shared among 4 VUs (maxDuration: 1m40s, gracefulStop: 30s)", cm["ishared"].GetDescription(et))
+
+			schedReqs = cm["ishared"].GetExecutionRequirements(et)
+			endOffset, isFinal = lib.GetEndOffset(schedReqs)
+			assert.Equal(t, 130*time.Second, endOffset)
+			assert.Equal(t, true, isFinal)
+			assert.Equal(t, uint64(4), lib.GetMaxPlannedVUs(schedReqs))
+			assert.Equal(t, uint64(4), lib.GetMaxPossibleVUs(schedReqs))
+
+			totalReqs = cm.GetFullExecutionRequirements(et)
+			assert.Equal(t, schedReqs, totalReqs)
+
+			et = mustNewExecutionTuple(newExecutionSegmentFromString("1/3:2/3"), newExecutionSegmentSequenceFromString("0,1/3,2/3,1"))
+			assert.Equal(t, "7 iterations shared among 4 VUs (maxDuration: 1m40s, gracefulStop: 30s)", cm["ishared"].GetDescription(et))
+
+			schedReqs = cm["ishared"].GetExecutionRequirements(et)
+			endOffset, isFinal = lib.GetEndOffset(schedReqs)
+			assert.Equal(t, 130*time.Second, endOffset)
+			assert.Equal(t, true, isFinal)
+			assert.Equal(t, uint64(4), lib.GetMaxPlannedVUs(schedReqs))
+			assert.Equal(t, uint64(4), lib.GetMaxPossibleVUs(schedReqs))
+
+			totalReqs = cm.GetFullExecutionRequirements(et)
+			assert.Equal(t, schedReqs, totalReqs)
+
+			et = mustNewExecutionTuple(newExecutionSegmentFromString("12/13:1"),
+				newExecutionSegmentSequenceFromString("0,1/13,2/13,3/13,4/13,5/13,6/13,7/13,8/13,9/13,10/13,11/13,12/13,1"))
+			assert.Equal(t, "0 iterations shared among 0 VUs (maxDuration: 1m40s, gracefulStop: 30s)", cm["ishared"].GetDescription(et))
+
+			schedReqs = cm["ishared"].GetExecutionRequirements(et)
+			endOffset, isFinal = lib.GetEndOffset(schedReqs)
+			assert.Equal(t, time.Duration(0), endOffset)
+			assert.Equal(t, true, isFinal)
+			assert.Equal(t, uint64(0), lib.GetMaxPlannedVUs(schedReqs))
+			assert.Equal(t, uint64(0), lib.GetMaxPossibleVUs(schedReqs))
+
+			totalReqs = cm.GetFullExecutionRequirements(et)
+			assert.Equal(t, schedReqs, totalReqs)
 		}},
 	},
 	{`{"ishared": {"type": "shared-iterations"}}`, exp{}}, // Has 1 VU & 1 iter default values

--- a/lib/executor/shared_iterations.go
+++ b/lib/executor/shared_iterations.go
@@ -72,12 +72,13 @@ var _ lib.ExecutorConfig = &SharedIterationsConfig{}
 
 // GetVUs returns the scaled VUs for the executor.
 func (sic SharedIterationsConfig) GetVUs(et *lib.ExecutionTuple) int64 {
-	return et.ES.Scale(sic.VUs.Int64)
+	return et.ScaleInt64(sic.VUs.Int64)
 }
 
 // GetIterations returns the scaled iteration count for the executor.
 func (sic SharedIterationsConfig) GetIterations(et *lib.ExecutionTuple) int64 {
-	return et.ES.Scale(sic.Iterations.Int64)
+	// Optimize this by probably changing the whole Config API
+	return et.GetNewExecutionTupleBasedOnValue(sic.VUs.Int64).ScaleInt64(sic.Iterations.Int64)
 }
 
 // GetDescription returns a human-readable description of the executor options
@@ -116,10 +117,20 @@ func (sic SharedIterationsConfig) Validate() []error {
 // the execution scheduler in its VU reservation calculations, so it knows how
 // many VUs to pre-initialize.
 func (sic SharedIterationsConfig) GetExecutionRequirements(et *lib.ExecutionTuple) []lib.ExecutionStep {
+	vus := sic.GetVUs(et)
+	if vus == 0 {
+		return []lib.ExecutionStep{
+			{
+				TimeOffset: 0,
+				PlannedVUs: 0,
+			},
+		}
+	}
+
 	return []lib.ExecutionStep{
 		{
 			TimeOffset: 0,
-			PlannedVUs: uint64(sic.GetVUs(et)),
+			PlannedVUs: uint64(vus),
 		},
 		{
 			TimeOffset: time.Duration(sic.MaxDuration.Duration + sic.GracefulStop.Duration),
@@ -132,7 +143,7 @@ func (sic SharedIterationsConfig) GetExecutionRequirements(et *lib.ExecutionTupl
 func (sic SharedIterationsConfig) NewExecutor(
 	es *lib.ExecutionState, logger *logrus.Entry,
 ) (lib.Executor, error) {
-	return SharedIterations{
+	return &SharedIterations{
 		BaseExecutor: NewBaseExecutor(sic, es, logger),
 		config:       sic,
 	}, nil
@@ -143,6 +154,7 @@ func (sic SharedIterationsConfig) NewExecutor(
 type SharedIterations struct {
 	*BaseExecutor
 	config SharedIterationsConfig
+	et     *lib.ExecutionTuple
 }
 
 // Make sure we implement the lib.Executor interface.
@@ -153,11 +165,17 @@ func (sic SharedIterationsConfig) HasWork(et *lib.ExecutionTuple) bool {
 	return sic.GetVUs(et) > 0 && sic.GetIterations(et) > 0
 }
 
+// Init values needed for the execution
+func (si *SharedIterations) Init(ctx context.Context) error {
+	si.et = si.BaseExecutor.executionState.ExecutionTuple.GetNewExecutionTupleBasedOnValue(si.config.VUs.Int64)
+	return nil
+}
+
 // Run executes a specific total number of iterations, which are all shared by
 // the configured VUs.
 func (si SharedIterations) Run(ctx context.Context, out chan<- stats.SampleContainer) (err error) {
 	numVUs := si.config.GetVUs(si.executionState.ExecutionTuple)
-	iterations := si.config.GetIterations(si.executionState.ExecutionTuple)
+	iterations := si.et.ScaleInt64(si.config.Iterations.Int64)
 	duration := time.Duration(si.config.MaxDuration.Duration)
 	gracefulStop := si.config.GetGracefulStop()
 
@@ -186,7 +204,7 @@ func (si SharedIterations) Run(ctx context.Context, out chan<- stats.SampleConta
 		return float64(currentDoneIters) / float64(totalIters), right
 	}
 	si.progress.Modify(pb.WithProgress(progresFn))
-	go trackProgress(ctx, maxDurationCtx, regDurationCtx, si, progresFn)
+	go trackProgress(ctx, maxDurationCtx, regDurationCtx, &si, progresFn)
 
 	// Actually schedule the VUs and iterations...
 	activeVUs := &sync.WaitGroup{}


### PR DESCRIPTION
Unfortunately because of the way the ExecutorConfig interface is
designed I can't just cache some of the results which will result in
some probably unneeded amount of calculation.

This will need either a change to the interface or for ExecutionTuple to
cache the results of GetNewExecutionTupleBasedOnValue, but I find it
unlikely this to be noticeable outside of extreme examples