### PR TITLE
Wait for metrics processing to finish before writing test summary

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -275,8 +275,8 @@ a commandline interface for interacting with it.`,
 		go func() {
 			sig := <-sigC
 			logger.WithField("sig", sig).Debug("Stopping k6 in response to signal...")
-			runCancel()
-			lingerCancel() // stop the test run, metric processing is cancelled below
+			runCancel() // stop the test run, metric processing is cancelled below
+			lingerCancel()
 
 			// If we get a second signal, we immediately exit, so something like
 			// https://github.com/loadimpact/k6/issues/971 never happens again


### PR DESCRIPTION
This is a naive attempt at fixing the following issues:

- Sometimes the end-of-test summary is not shown on quick tests. (#1434)
- Sometimes no metrics are processed by collectors on quick tests. Tested with JSON and InfluxDB collectors.
- Verbose logging output (`-v`) is interspersed with the EOT summary, causing log lines to appear after it.
- When `--linger` is used, collectors don't stop submitting metrics until `^C` is pressed, even though the test run is finished by that point. (Was this a bug or a feature? :D)

In my manual tests with the example from #1434, these changes consistently fix the above issues, but I wasn't able to write an engine Run test that reproduced them, the tests always pass for some reason.