### PR TITLE
Refactor ExecutionSegment sequences, wrappers and tuples

### DIFF
--- a/lib/execution_segment.go
+++ b/lib/execution_segment.go
@@ -704,6 +704,9 @@ func NewExecutionTuple(segment *ExecutionSegment, sequence *ExecutionSegmentSequ
 
 // ScaleInt64 scales the provided value for our execution segment.
 func (et *ExecutionTuple) ScaleInt64(value int64) int64 {
+	if len(et.Sequence.ExecutionSegmentSequence) == 1 {
+		return value // if we don't have any segmentation, just return the original value
+	}
 	return et.Sequence.ScaleInt64(et.SegmentIndex, value)
 }
 

--- a/lib/executor/constant_arrival_rate.go
+++ b/lib/executor/constant_arrival_rate.go
@@ -189,11 +189,12 @@ type ConstantArrivalRate struct {
 var _ lib.Executor = &ConstantArrivalRate{}
 
 // Init values needed for the execution
-func (car *ConstantArrivalRate) Init(ctx context.Context) (err error) {
+func (car *ConstantArrivalRate) Init(ctx context.Context) error {
 	// err should always be nil, because Init() won't be called for executors
 	// with no work, as determined by their config's HasWork() method.
-	car.et, err = car.BaseExecutor.executionState.ExecutionTuple.GetNewExecutionTupleFromValue(car.config.MaxVUs.Int64)
-	return
+	et, err := car.BaseExecutor.executionState.ExecutionTuple.GetNewExecutionTupleFromValue(car.config.MaxVUs.Int64)
+	car.et = et
+	return err
 }
 
 // Run executes a constant number of iterations per second.

--- a/lib/executor/constant_looping_vus.go
+++ b/lib/executor/constant_looping_vus.go
@@ -72,7 +72,7 @@ var _ lib.ExecutorConfig = &ConstantLoopingVUsConfig{}
 
 // GetVUs returns the scaled VUs for the executor.
 func (clvc ConstantLoopingVUsConfig) GetVUs(et *lib.ExecutionTuple) int64 {
-	return et.ES.Scale(clvc.VUs.Int64)
+	return et.Segment.Scale(clvc.VUs.Int64)
 }
 
 // GetDescription returns a human-readable description of the executor options

--- a/lib/executor/externally_controlled.go
+++ b/lib/executor/externally_controlled.go
@@ -143,8 +143,8 @@ func (mec ExternallyControlledConfig) Validate() []error {
 func (mec ExternallyControlledConfig) GetExecutionRequirements(et *lib.ExecutionTuple) []lib.ExecutionStep {
 	startVUs := lib.ExecutionStep{
 		TimeOffset:      0,
-		PlannedVUs:      uint64(et.ES.Scale(mec.MaxVUs.Int64)), // user-configured, VUs to be pre-initialized
-		MaxUnplannedVUs: 0,                                     // intentional, see function comment
+		PlannedVUs:      uint64(et.Segment.Scale(mec.MaxVUs.Int64)), // user-configured, VUs to be pre-initialized
+		MaxUnplannedVUs: 0,                                          // intentional, see function comment
 	}
 
 	maxDuration := time.Duration(mec.Duration.Duration)
@@ -208,9 +208,11 @@ type ExternallyControlled struct {
 }
 
 // Make sure we implement all the interfaces
-var _ lib.Executor = &ExternallyControlled{}
-var _ lib.PausableExecutor = &ExternallyControlled{}
-var _ lib.LiveUpdatableExecutor = &ExternallyControlled{}
+var (
+	_ lib.Executor              = &ExternallyControlled{}
+	_ lib.PausableExecutor      = &ExternallyControlled{}
+	_ lib.LiveUpdatableExecutor = &ExternallyControlled{}
+)
 
 // GetCurrentConfig just returns the executor's current configuration.
 func (mex *ExternallyControlled) GetCurrentConfig() ExternallyControlledConfig {
@@ -313,7 +315,7 @@ func (mex *ExternallyControlled) stopWhenDurationIsReached(ctx context.Context, 
 			checkInterval.Stop()
 			return
 
-		//TODO: something more optimized that sleeps for pauses?
+		// TODO: something more optimized that sleeps for pauses?
 		case <-checkInterval.C:
 			if mex.executionState.GetCurrentTestRunDuration() >= duration {
 				cancel()
@@ -400,7 +402,7 @@ func (rs *externallyControlledRunState) retrieveStartMaxVUs() error {
 }
 
 func (rs *externallyControlledRunState) progresFn() (float64, []string) {
-	//TODO: simulate spinner for the other case or cycle 0-100?
+	// TODO: simulate spinner for the other case or cycle 0-100?
 	currentActiveVUs := atomic.LoadInt64(rs.activeVUsCount)
 	currentMaxVUs := atomic.LoadInt64(rs.maxVUs)
 	vusFmt := pb.GetFixedLengthIntFormat(currentMaxVUs)

--- a/lib/executor/per_vu_iterations.go
+++ b/lib/executor/per_vu_iterations.go
@@ -60,7 +60,7 @@ func NewPerVUIterationsConfig(name string) PerVUIterationsConfig {
 		BaseConfig:  NewBaseConfig(name, perVUIterationsType),
 		VUs:         null.NewInt(1, false),
 		Iterations:  null.NewInt(1, false),
-		MaxDuration: types.NewNullDuration(10*time.Minute, false), //TODO: shorten?
+		MaxDuration: types.NewNullDuration(10*time.Minute, false), // TODO: shorten?
 	}
 }
 
@@ -69,7 +69,7 @@ var _ lib.ExecutorConfig = &PerVUIterationsConfig{}
 
 // GetVUs returns the scaled VUs for the executor.
 func (pvic PerVUIterationsConfig) GetVUs(et *lib.ExecutionTuple) int64 {
-	return et.ES.Scale(pvic.VUs.Int64)
+	return et.Segment.Scale(pvic.VUs.Int64)
 }
 
 // GetIterations returns the UNSCALED iteration count for the executor. It's

--- a/lib/executor/shared_iterations.go
+++ b/lib/executor/shared_iterations.go
@@ -170,11 +170,12 @@ func (sic SharedIterationsConfig) HasWork(et *lib.ExecutionTuple) bool {
 }
 
 // Init values needed for the execution
-func (si *SharedIterations) Init(ctx context.Context) (err error) {
+func (si *SharedIterations) Init(ctx context.Context) error {
 	// err should always be nil, because Init() won't be called for executors
 	// with no work, as determined by their config's HasWork() method.
-	si.et, err = si.BaseExecutor.executionState.ExecutionTuple.GetNewExecutionTupleFromValue(si.config.VUs.Int64)
-	return
+	et, err := si.BaseExecutor.executionState.ExecutionTuple.GetNewExecutionTupleFromValue(si.config.VUs.Int64)
+	si.et = et
+	return err
 }
 
 // Run executes a specific total number of iterations, which are all shared by

--- a/lib/executor/variable_arrival_rate.go
+++ b/lib/executor/variable_arrival_rate.go
@@ -77,24 +77,24 @@ var _ lib.ExecutorConfig = &VariableArrivalRateConfig{}
 
 // GetPreAllocatedVUs is just a helper method that returns the scaled pre-allocated VUs.
 func (varc VariableArrivalRateConfig) GetPreAllocatedVUs(et *lib.ExecutionTuple) int64 {
-	return et.ES.Scale(varc.PreAllocatedVUs.Int64)
+	return et.Segment.Scale(varc.PreAllocatedVUs.Int64)
 }
 
 // GetMaxVUs is just a helper method that returns the scaled max VUs.
 func (varc VariableArrivalRateConfig) GetMaxVUs(et *lib.ExecutionTuple) int64 {
-	return et.ES.Scale(varc.MaxVUs.Int64)
+	return et.Segment.Scale(varc.MaxVUs.Int64)
 }
 
 // GetDescription returns a human-readable description of the executor options
 func (varc VariableArrivalRateConfig) GetDescription(et *lib.ExecutionTuple) string {
-	//TODO: something better? always show iterations per second?
-	maxVUsRange := fmt.Sprintf("maxVUs: %d", et.ES.Scale(varc.PreAllocatedVUs.Int64))
+	// TODO: something better? always show iterations per second?
+	maxVUsRange := fmt.Sprintf("maxVUs: %d", et.Segment.Scale(varc.PreAllocatedVUs.Int64))
 	if varc.MaxVUs.Int64 > varc.PreAllocatedVUs.Int64 {
-		maxVUsRange += fmt.Sprintf("-%d", et.ES.Scale(varc.MaxVUs.Int64))
+		maxVUsRange += fmt.Sprintf("-%d", et.Segment.Scale(varc.MaxVUs.Int64))
 	}
 	maxUnscaledRate := getStagesUnscaledMaxTarget(varc.StartRate.Int64, varc.Stages)
 	maxArrRatePerSec, _ := getArrivalRatePerSec(
-		getScaledArrivalRate(et.ES, maxUnscaledRate, time.Duration(varc.TimeUnit.Duration)),
+		getScaledArrivalRate(et.Segment, maxUnscaledRate, time.Duration(varc.TimeUnit.Duration)),
 	).Float64()
 
 	return fmt.Sprintf("Up to %.2f iterations/s for %s over %d stages%s",
@@ -140,8 +140,8 @@ func (varc VariableArrivalRateConfig) GetExecutionRequirements(et *lib.Execution
 	return []lib.ExecutionStep{
 		{
 			TimeOffset:      0,
-			PlannedVUs:      uint64(et.ES.Scale(varc.PreAllocatedVUs.Int64)),
-			MaxUnplannedVUs: uint64(et.ES.Scale(varc.MaxVUs.Int64 - varc.PreAllocatedVUs.Int64)),
+			PlannedVUs:      uint64(et.Segment.Scale(varc.PreAllocatedVUs.Int64)),
+			MaxUnplannedVUs: uint64(et.Segment.Scale(varc.MaxVUs.Int64 - varc.PreAllocatedVUs.Int64)),
 		},
 		{
 			TimeOffset:      sumStagesDuration(varc.Stages) + time.Duration(varc.GracefulStop.Duration),
@@ -168,7 +168,7 @@ func (varc VariableArrivalRateConfig) HasWork(et *lib.ExecutionTuple) bool {
 
 // VariableArrivalRate tries to execute a specific number of iterations for a
 // specific period.
-//TODO: combine with the ConstantArrivalRate?
+// TODO: combine with the ConstantArrivalRate?
 type VariableArrivalRate struct {
 	*BaseExecutor
 	config VariableArrivalRateConfig
@@ -236,7 +236,7 @@ var _ lib.Executor = &VariableArrivalRate{}
 // the striping algorithm from the lib.ExecutionTuple for additional speed up but this could
 // possibly be refactored if need for this arises.
 func (varc VariableArrivalRateConfig) cal(et *lib.ExecutionTuple, ch chan<- time.Duration) {
-	start, offsets, _ := et.GetStripedOffsets(et.ES)
+	start, offsets, _ := et.GetStripedOffsets()
 	li := -1
 	// TODO: move this to a utility function, or directly what GetStripedOffsets uses once we see everywhere we will use it
 	next := func() int64 {
@@ -279,7 +279,7 @@ func (varc VariableArrivalRateConfig) cal(et *lib.ExecutionTuple, ch chan<- time
 
 // Run executes a variable number of iterations per second.
 func (varr VariableArrivalRate) Run(ctx context.Context, out chan<- stats.SampleContainer) (err error) { //nolint:funlen
-	segment := varr.executionState.ExecutionTuple.ES
+	segment := varr.executionState.ExecutionTuple.Segment
 	gracefulStop := varr.config.GetGracefulStop()
 	duration := sumStagesDuration(varr.config.Stages)
 	preAllocatedVUs := varr.config.GetPreAllocatedVUs(varr.executionState.ExecutionTuple)
@@ -382,9 +382,9 @@ func (varr VariableArrivalRate) Run(ctx context.Context, out chan<- stats.Sample
 
 	remainingUnplannedVUs := maxVUs - preAllocatedVUs
 
-	var timer = time.NewTimer(time.Hour)
-	var start = time.Now()
-	var ch = make(chan time.Duration, 10) // buffer 10 iteration times ahead
+	timer := time.NewTimer(time.Hour)
+	start := time.Now()
+	ch := make(chan time.Duration, 10) // buffer 10 iteration times ahead
 	var prevTime time.Duration
 	go varr.config.cal(varr.executionState.ExecutionTuple, ch)
 	for nextTime := range ch {
@@ -411,7 +411,7 @@ func (varr VariableArrivalRate) Run(ctx context.Context, out chan<- stats.Sample
 			// ideally, we get the VU from the buffer without any issues
 		default:
 			if remainingUnplannedVUs == 0 {
-				//TODO: emit an error metric?
+				// TODO: emit an error metric?
 				varr.logger.Warningf("Insufficient VUs, reached %d active VUs and cannot allocate more", maxVUs)
 				continue
 			}

--- a/lib/executor/variable_arrival_rate_test.go
+++ b/lib/executor/variable_arrival_rate_test.go
@@ -68,7 +68,7 @@ func TestVariableArrivalRateRunNotEnoughAllocatedVUsWarn(t *testing.T) {
 	et, err := lib.NewExecutionTuple(nil, nil)
 	require.NoError(t, err)
 	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
-	var ctx, cancel, executor, logHook = setupExecutor(
+	ctx, cancel, executor, logHook := setupExecutor(
 		t, getTestVariableArrivalRateConfig(), es,
 		simpleRunner(func(ctx context.Context) error {
 			time.Sleep(time.Second)
@@ -76,7 +76,7 @@ func TestVariableArrivalRateRunNotEnoughAllocatedVUsWarn(t *testing.T) {
 		}),
 	)
 	defer cancel()
-	var engineOut = make(chan stats.SampleContainer, 1000)
+	engineOut := make(chan stats.SampleContainer, 1000)
 	err = executor.Run(ctx, engineOut)
 	require.NoError(t, err)
 	entries := logHook.Drain()
@@ -95,7 +95,7 @@ func TestVariableArrivalRateRunCorrectRate(t *testing.T) {
 	et, err := lib.NewExecutionTuple(nil, nil)
 	require.NoError(t, err)
 	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
-	var ctx, cancel, executor, logHook = setupExecutor(
+	ctx, cancel, executor, logHook := setupExecutor(
 		t, getTestVariableArrivalRateConfig(), es,
 		simpleRunner(func(ctx context.Context) error {
 			atomic.AddInt64(&count, 1)
@@ -122,7 +122,7 @@ func TestVariableArrivalRateRunCorrectRate(t *testing.T) {
 		currentCount = atomic.SwapInt64(&count, 0)
 		assert.InDelta(t, 50, currentCount, 2)
 	}()
-	var engineOut = make(chan stats.SampleContainer, 1000)
+	engineOut := make(chan stats.SampleContainer, 1000)
 	err = executor.Run(ctx, engineOut)
 	wg.Wait()
 	require.NoError(t, err)
@@ -132,13 +132,14 @@ func TestVariableArrivalRateRunCorrectRate(t *testing.T) {
 func TestVariableArrivalRateRunCorrectRateWithSlowRate(t *testing.T) {
 	t.Parallel()
 	var count int64
-	var now = time.Now()
+	now := time.Now()
 	et, err := lib.NewExecutionTuple(nil, nil)
 	require.NoError(t, err)
 	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
-	var expectedTimes = []time.Duration{
-		time.Millisecond * 3464, time.Millisecond * 4898, time.Second * 6}
-	var ctx, cancel, executor, logHook = setupExecutor(
+	expectedTimes := []time.Duration{
+		time.Millisecond * 3464, time.Millisecond * 4898, time.Second * 6,
+	}
+	ctx, cancel, executor, logHook := setupExecutor(
 		t, VariableArrivalRateConfig{
 			TimeUnit: types.NullDurationFrom(time.Second),
 			Stages: []Stage{
@@ -175,7 +176,7 @@ func TestVariableArrivalRateRunCorrectRateWithSlowRate(t *testing.T) {
 		}),
 	)
 	defer cancel()
-	var engineOut = make(chan stats.SampleContainer, 1000)
+	engineOut := make(chan stats.SampleContainer, 1000)
 	err = executor.Run(ctx, engineOut)
 	require.NoError(t, err)
 	require.Equal(t, int64(len(expectedTimes)), count)
@@ -252,9 +253,11 @@ func TestVariableArrivalRateCal(t *testing.T) {
 			et:            mustNewExecutionTuple(newExecutionSegmentFromString("2/3:1"), newExecutionSegmentSequenceFromString("0,1/3,2/3,1")),
 		},
 		{
-			expectedTimes: []time.Duration{time.Millisecond * 1825, time.Millisecond * 2581, time.Millisecond * 3162, time.Millisecond * 3651, time.Millisecond * 4082, time.Millisecond * 4472,
+			expectedTimes: []time.Duration{
+				time.Millisecond * 1825, time.Millisecond * 2581, time.Millisecond * 3162, time.Millisecond * 3651, time.Millisecond * 4082, time.Millisecond * 4472,
 				time.Millisecond * 4830, time.Millisecond * 5166, time.Millisecond * 5499, time.Millisecond * 5833, time.Millisecond * 6169, time.Millisecond * 6527,
-				time.Millisecond * 6917, time.Millisecond * 7348, time.Millisecond * 7837, time.Millisecond * 8418, time.Millisecond * 9174, time.Millisecond * 10999},
+				time.Millisecond * 6917, time.Millisecond * 7348, time.Millisecond * 7837, time.Millisecond * 8418, time.Millisecond * 9174, time.Millisecond * 10999,
+			},
 			et:       mustNewExecutionTuple(nil, nil),
 			timeUnit: time.Second / 3, // three  times as fast
 		},
@@ -270,9 +273,9 @@ func TestVariableArrivalRateCal(t *testing.T) {
 		}
 
 		t.Run(fmt.Sprintf("%s timeunit %s", et, config.TimeUnit), func(t *testing.T) {
-			var ch = make(chan time.Duration)
+			ch := make(chan time.Duration)
 			go config.cal(et, ch)
-			var changes = make([]time.Duration, 0, len(expectedTimes))
+			changes := make([]time.Duration, 0, len(expectedTimes))
 			for c := range ch {
 				changes = append(changes, c)
 			}
@@ -292,7 +295,7 @@ func BenchmarkCal(b *testing.B) {
 	} {
 		t := t
 		b.Run(t.String(), func(b *testing.B) {
-			var config = VariableArrivalRateConfig{
+			config := VariableArrivalRateConfig{
 				TimeUnit:  types.NullDurationFrom(time.Second),
 				StartRate: null.IntFrom(50),
 				Stages: []Stage{
@@ -311,7 +314,7 @@ func BenchmarkCal(b *testing.B) {
 			b.ResetTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
-					var ch = make(chan time.Duration, 20)
+					ch := make(chan time.Duration, 20)
 					go config.cal(et, ch)
 					for c := range ch {
 						_ = c
@@ -328,7 +331,7 @@ func BenchmarkCalRat(b *testing.B) {
 	} {
 		t := t
 		b.Run(t.String(), func(b *testing.B) {
-			var config = VariableArrivalRateConfig{
+			config := VariableArrivalRateConfig{
 				TimeUnit:  types.NullDurationFrom(time.Second),
 				StartRate: null.IntFrom(50),
 				Stages: []Stage{
@@ -347,7 +350,7 @@ func BenchmarkCalRat(b *testing.B) {
 			b.ResetTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
-					var ch = make(chan time.Duration, 20)
+					ch := make(chan time.Duration, 20)
 					go config.calRat(et, ch)
 					for c := range ch {
 						_ = c
@@ -364,7 +367,7 @@ func TestCompareCalImplementation(t *testing.T) {
 	// in my experiment the difference is 1(nanosecond) in 7 case for the whole test
 	// the duration is 1 second for each stage as calRat takes way longer - a longer better test can
 	// be done when/if it's performance is improved
-	var config = VariableArrivalRateConfig{
+	config := VariableArrivalRateConfig{
 		TimeUnit:  types.NullDurationFrom(time.Second),
 		StartRate: null.IntFrom(0),
 		Stages: []Stage{
@@ -408,8 +411,8 @@ func TestCompareCalImplementation(t *testing.T) {
 	}
 
 	et := mustNewExecutionTuple(nil, nil)
-	var chRat = make(chan time.Duration, 20)
-	var ch = make(chan time.Duration, 20)
+	chRat := make(chan time.Duration, 20)
+	ch := make(chan time.Duration, 20)
 	go config.calRat(et, chRat)
 	go config.cal(et, ch)
 	count := 0
@@ -436,7 +439,7 @@ func sqrtRat(x *big.Rat) *big.Rat {
 	var ns, ds big.Int
 	ni, di := x.Num(), x.Denom()
 	z.SetFrac(ns.Rsh(ni, uint(ni.BitLen())/2), ds.Rsh(di, uint(di.BitLen())/2))
-	for i := 10; i > 0; i-- { //TODO: better termination
+	for i := 10; i > 0; i-- { // TODO: better termination
 		a.Sub(a.Mul(&z, &z), x)
 		f, _ := a.Float64()
 		if f == 0 {
@@ -452,7 +455,7 @@ func sqrtRat(x *big.Rat) *big.Rat {
 func (varc VariableArrivalRateConfig) calRat(et *lib.ExecutionTuple, ch chan<- time.Duration) {
 	defer close(ch)
 
-	start, offsets, _ := et.GetStripedOffsets(et.ES)
+	start, offsets, _ := et.GetStripedOffsets()
 	li := -1
 	next := func() int64 {
 		li++
@@ -460,9 +463,9 @@ func (varc VariableArrivalRateConfig) calRat(et *lib.ExecutionTuple, ch chan<- t
 	}
 	iRat := big.NewRat(start+1, 1)
 
-	var carry = big.NewRat(0, 1)
-	var doneSoFar = big.NewRat(0, 1)
-	var endCount = big.NewRat(0, 1)
+	carry := big.NewRat(0, 1)
+	doneSoFar := big.NewRat(0, 1)
+	endCount := big.NewRat(0, 1)
 	curr := varc.StartRate.ValueOrZero()
 	var base time.Duration
 	for _, stage := range varc.Stages {

--- a/lib/executors.go
+++ b/lib/executors.go
@@ -36,7 +36,7 @@ import (
 	"github.com/loadimpact/k6/ui/pb"
 )
 
-//TODO: remove globals and use some type of explicit dependency injection?
+// TODO: remove globals and use some type of explicit dependency injection?
 //nolint:gochecknoglobals
 var (
 	executorConfigTypesMutex   sync.RWMutex
@@ -72,7 +72,7 @@ type ExecutionStep struct {
 	MaxUnplannedVUs uint64
 }
 
-//TODO: make []ExecutionStep or []ExecutorConfig their own type?
+// TODO: make []ExecutionStep or []ExecutorConfig their own type?
 
 // ExecutorConfig is an interface that should be implemented by all executor config types
 type ExecutorConfig interface {
@@ -119,7 +119,7 @@ type Executor interface {
 	GetProgress() *pb.ProgressBar
 	GetLogger() *logrus.Entry
 
-	Init(ctx context.Context) error //TODO: remove, since it's currently unused?
+	Init(ctx context.Context) error
 	Run(ctx context.Context, engineOut chan<- stats.SampleContainer) error
 }
 
@@ -173,7 +173,7 @@ func (scs *ExecutorConfigMap) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	//TODO: use a more sophisticated combination of dec.Token() and dec.More(),
+	// TODO: use a more sophisticated combination of dec.Token() and dec.More(),
 	// which would allow us to support both arrays and maps for this config?
 	var protoConfigs map[string]protoExecutorConfig
 	if err := StrictJSONUnmarshal(data, &protoConfigs); err != nil {

--- a/lib/options.go
+++ b/lib/options.go
@@ -315,7 +315,7 @@ func (o Options) Apply(opts Options) Options {
 	// config tier, they will be preserved, so the validation after we've consolidated
 	// all of the options can return an error.
 	if opts.Duration.Valid || opts.Iterations.Valid || opts.Stages != nil || opts.Execution != nil {
-		//TODO: emit a warning or a notice log message if overwrite lower tier config options?
+		// TODO: emit a warning or a notice log message if overwrite lower tier config options?
 		o.Duration = types.NewNullDuration(0, false)
 		o.Iterations = null.NewInt(0, false)
 		o.Stages = nil
@@ -449,8 +449,8 @@ func (o Options) Apply(opts Options) Options {
 
 // Validate checks if all of the specified options make sense
 func (o Options) Validate() []error {
-	//TODO: validate all of the other options... that we should have already been validating...
-	//TODO: maybe integrate an external validation lib: https://github.com/avelino/awesome-go#validation
+	// TODO: validate all of the other options... that we should have already been validating...
+	// TODO: maybe integrate an external validation lib: https://github.com/avelino/awesome-go#validation
 	var errors []error
 	if o.ExecutionSegmentSequence != nil {
 		var segmentFound bool


### PR DESCRIPTION
This cleans up the interfaces and makes it possible to re-use the heavy calculations for a segment sequence. 

closes https://github.com/loadimpact/k6/issues/1379