### PR TITLE
Reuse the context and state in js.VU as much as possible

### DIFF
--- a/js/empty_iteartions_bench_test.go
+++ b/js/empty_iteartions_bench_test.go
@@ -1,0 +1,40 @@
+package js
+
+import (
+	"context"
+	"testing"
+
+	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/stats"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkEmptyIteration(b *testing.B) {
+	b.StopTimer()
+
+	r, err := getSimpleRunner("/script.js", `exports.default = function() { }`)
+	if !assert.NoError(b, err) {
+		return
+	}
+	require.NoError(b, err)
+
+	var ch = make(chan stats.SampleContainer, 100)
+	defer close(ch)
+	go func() { // read the channel so it doesn't block
+		for range ch {
+		}
+	}()
+	initVU, err := r.NewVU(1, ch)
+	if !assert.NoError(b, err) {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		err = vu.RunOnce()
+		assert.NoError(b, err)
+	}
+}

--- a/js/http_bench_test.go
+++ b/js/http_bench_test.go
@@ -58,6 +58,7 @@ func BenchmarkHTTPRequests(b *testing.B) {
 	require.NoError(b, err)
 
 	var ch = make(chan stats.SampleContainer, 100)
+	defer close(ch)
 	go func() { // read the channel so it doesn't block
 		for range ch {
 		}
@@ -101,6 +102,7 @@ func BenchmarkHTTPRequestsBase(b *testing.B) {
 	require.NoError(b, err)
 
 	var ch = make(chan stats.SampleContainer, 100)
+	defer close(ch)
 	go func() { // read the channel so it doesn't block
 		for range ch {
 		}

--- a/js/http_bench_test.go
+++ b/js/http_bench_test.go
@@ -59,8 +59,7 @@ func BenchmarkHTTPRequests(b *testing.B) {
 
 	var ch = make(chan stats.SampleContainer, 100)
 	go func() { // read the channel so it doesn't block
-		for {
-			<-ch
+		for range ch {
 		}
 	}()
 	initVU, err := r.NewVU(1, ch)
@@ -103,8 +102,7 @@ func BenchmarkHTTPRequestsBase(b *testing.B) {
 
 	var ch = make(chan stats.SampleContainer, 100)
 	go func() { // read the channel so it doesn't block
-		for {
-			<-ch
+		for range ch {
 		}
 	}()
 	initVU, err := r.NewVU(1, ch)

--- a/js/runner.go
+++ b/js/runner.go
@@ -196,19 +196,6 @@ func (r *Runner) newVU(id int64, samplesOut chan<- stats.SampleContainer) (*VU, 
 		Samples:        samplesOut,
 	}
 
-	opts := vu.Runner.Bundle.Options
-	tags := opts.RunTags.CloneTags()
-
-	if opts.SystemTags.Has(stats.TagVU) {
-		tags["vu"] = strconv.FormatInt(vu.ID, 10)
-	}
-	if opts.SystemTags.Has(stats.TagIter) {
-		tags["iter"] = strconv.FormatInt(vu.Iteration, 10)
-	}
-	if opts.SystemTags.Has(stats.TagGroup) {
-		tags["group"] = r.defaultGroup.Path
-	}
-
 	vu.state = &lib.State{
 		Logger:    vu.Runner.Logger,
 		Options:   vu.Runner.Bundle.Options,
@@ -221,7 +208,7 @@ func (r *Runner) newVU(id int64, samplesOut chan<- stats.SampleContainer) (*VU, 
 		Vu:        vu.ID,
 		Samples:   vu.Samples,
 		Iteration: vu.Iteration,
-		Tags:      tags,
+		Tags:      vu.Runner.Bundle.Options.RunTags.CloneTags(),
 		Group:     r.defaultGroup,
 	}
 	vu.Runtime.Set("__VU", vu.ID)
@@ -575,7 +562,6 @@ func (u *VU) runFn(
 		u.Transport.CloseIdleConnections()
 	}
 
-	// TODO: stats.NewSampleTags can be cached and not do it for each iteration
 	u.state.Samples <- u.Dialer.GetTrail(startTime, endTime, isFullIteration, isDefault, stats.NewSampleTags(u.state.Tags))
 
 	return v, isFullIteration, endTime.Sub(startTime), err

--- a/js/runner.go
+++ b/js/runner.go
@@ -195,6 +195,35 @@ func (r *Runner) newVU(id int64, samplesOut chan<- stats.SampleContainer) (*VU, 
 		BPool:          bpool.NewBufferPool(100),
 		Samples:        samplesOut,
 	}
+
+	opts := vu.Runner.Bundle.Options
+	tags := opts.RunTags.CloneTags()
+
+	if opts.SystemTags.Has(stats.TagVU) {
+		tags["vu"] = strconv.FormatInt(vu.ID, 10)
+	}
+	if opts.SystemTags.Has(stats.TagIter) {
+		tags["iter"] = strconv.FormatInt(vu.Iteration, 10)
+	}
+	if opts.SystemTags.Has(stats.TagGroup) {
+		tags["group"] = r.defaultGroup.Path
+	}
+
+	vu.state = &lib.State{
+		Logger:    vu.Runner.Logger,
+		Options:   vu.Runner.Bundle.Options,
+		Transport: vu.Transport,
+		Dialer:    vu.Dialer,
+		TLSConfig: vu.TLSConfig,
+		CookieJar: cookieJar,
+		RPSLimit:  vu.Runner.RPSLimit,
+		BPool:     vu.BPool,
+		Vu:        vu.ID,
+		Samples:   vu.Samples,
+		Iteration: vu.Iteration,
+		Tags:      tags,
+		Group:     r.defaultGroup,
+	}
 	vu.Runtime.Set("__VU", vu.ID)
 	vu.Runtime.Set("console", common.Bind(vu.Runtime, vu.Console, vu.Context))
 
@@ -316,19 +345,27 @@ func (r *Runner) runPart(ctx context.Context, out chan<- stats.SampleContainer, 
 		return goja.Undefined(), nil
 	}
 
+	ctx = common.WithRuntime(ctx, vu.Runtime)
+	ctx = lib.WithState(ctx, vu.state)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	go func() {
 		<-ctx.Done()
 		vu.Runtime.Interrupt(errInterrupt)
 	}()
+	*vu.Context = ctx
 
 	group, err := lib.NewGroup(name, r.GetDefaultGroup())
 	if err != nil {
 		return goja.Undefined(), err
 	}
 
-	v, _, _, err := vu.runFn(ctx, "", group, false, nil, fn, vu.Runtime.ToValue(arg))
+	if r.Bundle.Options.SystemTags.Has(stats.TagGroup) {
+		vu.state.Tags["group"] = group.Path
+	}
+	vu.state.Group = group
+
+	v, _, _, err := vu.runFn(ctx, false, fn, vu.Runtime.ToValue(arg))
 
 	// deadline is reached so we have timeouted but this might've not been registered correctly
 	if deadline, ok := ctx.Deadline(); ok && time.Now().After(deadline) {
@@ -372,6 +409,8 @@ type VU struct {
 	Samples chan<- stats.SampleContainer
 
 	setupData goja.Value
+
+	state *lib.State
 }
 
 // Verify that interfaces are implemented
@@ -404,6 +443,29 @@ func (u *VU) Activate(params *lib.VUActivationParams) lib.ActiveVU {
 		env[key] = value
 	}
 	u.Runtime.Set("__ENV", env)
+
+	opts := u.Runner.Bundle.Options
+	// TODO: maybe we can cache the original tags only clone them and add (if any) new tags on top ?
+	u.state.Tags = opts.RunTags.CloneTags()
+	for k, v := range params.Tags {
+		u.state.Tags[k] = v
+	}
+	if opts.SystemTags.Has(stats.TagVU) {
+		u.state.Tags["vu"] = strconv.FormatInt(u.ID, 10)
+	}
+	if opts.SystemTags.Has(stats.TagIter) {
+		u.state.Tags["iter"] = strconv.FormatInt(u.Iteration, 10)
+	}
+	if opts.SystemTags.Has(stats.TagGroup) {
+		u.state.Tags["group"] = u.state.Group.Path
+	}
+	if opts.SystemTags.Has(stats.TagScenario) {
+		u.state.Tags["scenario"] = params.Scenario
+	}
+
+	params.RunContext = common.WithRuntime(params.RunContext, u.Runtime)
+	params.RunContext = lib.WithState(params.RunContext, u.state)
+	*u.Context = params.RunContext
 
 	avu := &ActiveVU{
 		VU:                 u,
@@ -461,9 +523,7 @@ func (u *ActiveVU) RunOnce() error {
 	}
 
 	// Call the exported function.
-	_, isFullIteration, totalTime, err := u.runFn(
-		u.RunContext, u.Scenario, u.Runner.defaultGroup, true, u.Tags, fn, u.setupData,
-	)
+	_, isFullIteration, totalTime, err := u.runFn(u.RunContext, true, fn, u.setupData)
 
 	// If MinIterationDuration is specified and the iteration wasn't cancelled
 	// and was less than it, sleep for the remainder
@@ -478,56 +538,24 @@ func (u *ActiveVU) RunOnce() error {
 }
 
 func (u *VU) runFn(
-	ctx context.Context, scenario string, group *lib.Group, isDefault bool,
-	customTags map[string]string, fn goja.Callable, args ...goja.Value,
+	ctx context.Context, isDefault bool, fn goja.Callable, args ...goja.Value,
 ) (goja.Value, bool, time.Duration, error) {
-	cookieJar := u.CookieJar
 	if !u.Runner.Bundle.Options.NoCookiesReset.ValueOrZero() {
 		var err error
-		cookieJar, err = cookiejar.New(nil)
+		u.state.CookieJar, err = cookiejar.New(nil)
 		if err != nil {
 			return goja.Undefined(), false, time.Duration(0), err
 		}
 	}
 
 	opts := &u.Runner.Bundle.Options
-	tags := opts.RunTags.CloneTags()
-	for k, v := range customTags {
-		tags[k] = v
-	}
-	if opts.SystemTags.Has(stats.TagVU) {
-		tags["vu"] = strconv.FormatInt(u.ID, 10)
-	}
 	if opts.SystemTags.Has(stats.TagIter) {
-		tags["iter"] = strconv.FormatInt(u.Iteration, 10)
-	}
-	if opts.SystemTags.Has(stats.TagGroup) {
-		tags["group"] = group.Path
-	}
-	if scenario != "" && opts.SystemTags.Has(stats.TagScenario) {
-		tags["scenario"] = scenario
+		u.state.Tags["iter"] = strconv.FormatInt(u.Iteration, 10)
 	}
 
-	state := &lib.State{
-		Logger:    u.Runner.Logger,
-		Options:   u.Runner.Bundle.Options,
-		Group:     group,
-		Transport: u.Transport,
-		Dialer:    u.Dialer,
-		TLSConfig: u.TLSConfig,
-		CookieJar: cookieJar,
-		RPSLimit:  u.Runner.RPSLimit,
-		BPool:     u.BPool,
-		Vu:        u.ID,
-		Samples:   u.Samples,
-		Iteration: u.Iteration,
-		Tags:      tags,
-	}
-
-	newctx := common.WithRuntime(ctx, u.Runtime)
-	newctx = lib.WithState(newctx, state)
-	*u.Context = newctx
-
+	// TODO: this seems like the wrong place for the iteration incrementation
+	// also this means that teardown and setup have __ITER defined
+	// maybe move it to RunOnce ?
 	u.Runtime.Set("__ITER", u.Iteration)
 	u.Iteration++
 
@@ -547,7 +575,8 @@ func (u *VU) runFn(
 		u.Transport.CloseIdleConnections()
 	}
 
-	state.Samples <- u.Dialer.GetTrail(startTime, endTime, isFullIteration, isDefault, stats.IntoSampleTags(&tags))
+	// TODO: stats.NewSampleTags can be cached and not do it for each iteration
+	u.state.Samples <- u.Dialer.GetTrail(startTime, endTime, isFullIteration, isDefault, stats.NewSampleTags(u.state.Tags))
 
 	return v, isFullIteration, endTime.Sub(startTime), err
 }


### PR DESCRIPTION
This took way longer then I anticipated mostly because of ... how
strange some things work.

The basic idea came from that for each iteration we constantly remake the
iterations which looked (and probably is) the lowest hanging fruit in k6
about creating too many objects.

Unfortunately because of how .. tags work and that iteration is a tag I
need to still copy the tags for GetTrail .. (it gets copied either way
for other metrics).

When running with an empty body this changed the amount of cpu taken
by scanobject and decreased it from 7.98s to 5.81s (while most other not
GC related had difference within 0.3s).

This is very small step ... having tags being immutable so we don't have
to constantly copy them will likely be much more significant or if we
can reduce the calls to runtime.nanotime which are literally now the top
CPU usage with empty iterations and are the top CPU usage for simple
scripts even before that :D.