### PR TITLE
feature: Add optional port to host mappings.

### DIFF
--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -908,8 +908,8 @@ func TestVUIntegrationHosts(t *testing.T) {
 
 	r1.SetOptions(lib.Options{
 		Throw: null.BoolFrom(true),
-		Hosts: map[string]lib.IPPort{
-			"test.loadimpact.com": lib.NewIPPort(net.ParseIP("127.0.0.1")),
+		Hosts: map[string]*lib.HostAddress{
+			"test.loadimpact.com": {IP: net.ParseIP("127.0.0.1"), Port: 80},
 		},
 	})
 

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -908,8 +908,8 @@ func TestVUIntegrationHosts(t *testing.T) {
 
 	r1.SetOptions(lib.Options{
 		Throw: null.BoolFrom(true),
-		Hosts: map[string]net.IP{
-			"test.loadimpact.com": net.ParseIP("127.0.0.1"),
+		Hosts: map[string]lib.IPPort{
+			"test.loadimpact.com": lib.NewIPPort(net.ParseIP("127.0.0.1")),
 		},
 	})
 

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -909,7 +909,7 @@ func TestVUIntegrationHosts(t *testing.T) {
 	r1.SetOptions(lib.Options{
 		Throw: null.BoolFrom(true),
 		Hosts: map[string]*lib.HostAddress{
-			"test.loadimpact.com": {IP: net.ParseIP("127.0.0.1"), Port: 80},
+			"test.loadimpact.com": {IP: net.ParseIP("127.0.0.1")},
 		},
 	})
 

--- a/lib/netext/dialer.go
+++ b/lib/netext/dialer.go
@@ -191,14 +191,18 @@ func (d *Dialer) getCachedHost(addr, host, port string) (*lib.HostAddress, error
 
 	// lookup for host defined in Hosts option before trying to resolve DNS.
 	if remote, ok := d.Hosts[host]; ok {
-		if remote.Port == 0 && port != "" {
-			newPort, err := strconv.Atoi(port)
-			if err != nil {
-				return nil, err
-			}
-			remote.Port = newPort
+		if remote.Port != 0 || port == "" {
+			return remote, nil
 		}
-		return remote, nil
+
+		newPort, err := strconv.Atoi(port)
+		if err != nil {
+			return nil, err
+		}
+
+		newRemote := *remote
+		newRemote.Port = newPort
+		return &newRemote, nil
 	}
 
 	return nil, nil

--- a/lib/netext/dialer.go
+++ b/lib/netext/dialer.go
@@ -149,17 +149,9 @@ func (d *Dialer) dialAddr(addr string) (string, error) {
 	// lookup for domain defined in Hosts option before trying to resolve DNS.
 	remote, ok := d.Hosts[addr]
 	if !ok {
-		remote, ok = d.Hosts[host]
-		if !ok {
-			var err error
-			ip, err := d.Resolver.FetchOne(host)
-			if err != nil {
-				return "", err
-			}
-			remote, err = lib.NewHostAddress(ip, port)
-			if err != nil {
-				return "", err
-			}
+		remote, err = d.fetchHostAddress(host, port)
+		if err != nil {
+			return "", err
 		}
 	}
 
@@ -178,6 +170,18 @@ func (d *Dialer) dialAddr(addr string) (string, error) {
 	}
 
 	return remote.String(), nil
+}
+
+func (d *Dialer) fetchHostAddress(host, port string) (*lib.HostAddress, error) {
+	remote := d.Hosts[host]
+	if remote != nil {
+		return remote, nil
+	}
+	ip, err := d.Resolver.FetchOne(host)
+	if err != nil {
+		return nil, err
+	}
+	return lib.NewHostAddress(ip, port)
 }
 
 // NetTrail contains information about the exchanged data size and length of a

--- a/lib/netext/dialer.go
+++ b/lib/netext/dialer.go
@@ -208,6 +208,7 @@ func (d *Dialer) getCachedHost(addr, host, port string) (*lib.HostAddress, error
 
 		newRemote := *remote
 		newRemote.Port = newPort
+
 		return &newRemote, nil
 	}
 

--- a/lib/netext/dialer.go
+++ b/lib/netext/dialer.go
@@ -173,10 +173,10 @@ func (d *Dialer) findRemote(addr string) (*lib.HostAddress, error) {
 		return lib.NewHostAddress(ip, port)
 	}
 
-	return d.fetchRemoteFromResover(host, port)
+	return d.fetchRemoteFromResolver(host, port)
 }
 
-func (d *Dialer) fetchRemoteFromResover(host, port string) (*lib.HostAddress, error) {
+func (d *Dialer) fetchRemoteFromResolver(host, port string) (*lib.HostAddress, error) {
 	ip, err := d.Resolver.FetchOne(host)
 	if err != nil {
 		return nil, err

--- a/lib/netext/dialer.go
+++ b/lib/netext/dialer.go
@@ -27,6 +27,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/viki-org/dnscache"
 
 	"github.com/loadimpact/k6/lib"
@@ -181,6 +182,13 @@ func (d *Dialer) fetchHostAddress(host, port string) (*lib.HostAddress, error) {
 	if err != nil {
 		return nil, err
 	}
+	if ip == nil {
+		ip = net.ParseIP(host)
+	}
+	if ip == nil {
+		return nil, errors.Errorf("lookup %s: no such host", host)
+	}
+
 	return lib.NewHostAddress(ip, port)
 }
 

--- a/lib/netext/dialer.go
+++ b/lib/netext/dialer.go
@@ -147,7 +147,7 @@ func (d *Dialer) dialAddr(addr string) (string, error) {
 		return "", err
 	}
 
-	// lookup for domain defined in Hosts option before trying to resolve DNS.
+	// lookup for full address defined in Hosts option before trying to resolve DNS.
 	remote, ok := d.Hosts[addr]
 	if !ok {
 		remote, err = d.fetchHostAddress(host, port)
@@ -174,16 +174,19 @@ func (d *Dialer) dialAddr(addr string) (string, error) {
 }
 
 func (d *Dialer) fetchHostAddress(host, port string) (*lib.HostAddress, error) {
+	// lookup for host defined in Hosts option.
 	remote := d.Hosts[host]
 	if remote != nil {
 		return remote, nil
 	}
-	ip, err := d.Resolver.FetchOne(host)
-	if err != nil {
-		return nil, err
-	}
+
+	ip := net.ParseIP(host)
 	if ip == nil {
-		ip = net.ParseIP(host)
+		var err error
+		ip, err = d.Resolver.FetchOne(host)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if ip == nil {
 		return nil, errors.Errorf("lookup %s: no such host", host)

--- a/lib/netext/dialer.go
+++ b/lib/netext/dialer.go
@@ -169,13 +169,19 @@ func (d *Dialer) findRemote(addr string) (*lib.HostAddress, error) {
 	}
 
 	ip := net.ParseIP(host)
-
-	if ip == nil {
-		ip, err = d.Resolver.FetchOne(host)
-		if err != nil {
-			return nil, err
-		}
+	if ip != nil {
+		return lib.NewHostAddress(ip, port)
 	}
+
+	return d.fetchRemoteFromResover(host, port)
+}
+
+func (d *Dialer) fetchRemoteFromResover(host, port string) (*lib.HostAddress, error) {
+	ip, err := d.Resolver.FetchOne(host)
+	if err != nil {
+		return nil, err
+	}
+
 	if ip == nil {
 		return nil, errors.Errorf("lookup %s: no such host", host)
 	}

--- a/lib/netext/dialer.go
+++ b/lib/netext/dialer.go
@@ -163,7 +163,7 @@ func (d *Dialer) findRemote(addr string) (*lib.HostAddress, error) {
 		return nil, err
 	}
 
-	remote, err := d.getCachedHost(addr, host, port)
+	remote, err := d.getConfiguredHost(addr, host, port)
 	if err != nil || remote != nil {
 		return remote, err
 	}
@@ -189,13 +189,11 @@ func (d *Dialer) fetchRemoteFromResover(host, port string) (*lib.HostAddress, er
 	return lib.NewHostAddress(ip, port)
 }
 
-func (d *Dialer) getCachedHost(addr, host, port string) (*lib.HostAddress, error) {
-	// lookup for full address defined in Hosts option before trying to resolve DNS.
+func (d *Dialer) getConfiguredHost(addr, host, port string) (*lib.HostAddress, error) {
 	if remote, ok := d.Hosts[addr]; ok {
 		return remote, nil
 	}
 
-	// lookup for host defined in Hosts option before trying to resolve DNS.
 	if remote, ok := d.Hosts[host]; ok {
 		if remote.Port != 0 || port == "" {
 			return remote, nil

--- a/lib/netext/dialer_test.go
+++ b/lib/netext/dialer_test.go
@@ -78,14 +78,16 @@ func TestDialerAddr(t *testing.T) {
 
 	for _, tc := range testCases {
 		tc := tc
+
 		t.Run(tc.address, func(t *testing.T) {
 			addr, err := dialer.getDialAddr(tc.address)
+
 			if tc.expErr != "" {
 				require.EqualError(t, err, tc.expErr)
-				return
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expAddress, addr)
 			}
-			require.NoError(t, err)
-			require.Equal(t, tc.expAddress, addr)
 		})
 	}
 }

--- a/lib/netext/dialer_test.go
+++ b/lib/netext/dialer_test.go
@@ -1,0 +1,52 @@
+package netext
+
+import (
+	"net"
+	"testing"
+
+	"github.com/loadimpact/k6/lib"
+	"github.com/stretchr/testify/assert"
+)
+
+type testResolver struct {
+	hosts map[string]net.IP
+}
+
+func (r testResolver) FetchOne(host string) (net.IP, error) { return r.hosts[host], nil }
+
+func TestDialerAddrWithDNSResolver(t *testing.T) {
+	dialer := newDialerWithResolver(net.Dialer{}, newResolver())
+
+	addr, err := dialer.dialAddr("example.com:80")
+	assert.NoError(t, err)
+	assert.Equal(t, "1.2.3.4:80", addr)
+}
+
+func TestDialerAddrWithCachedHost(t *testing.T) {
+	dialer := newDialerWithResolver(net.Dialer{}, newResolver())
+	dialer.Hosts = map[string]lib.IPPort{
+		"example.com":      {IP: net.ParseIP("3.4.5.6"), Port: ""},
+		"example.com:443":  {IP: net.ParseIP("3.4.5.6"), Port: "8443"},
+		"example.com:8080": {IP: net.ParseIP("3.4.5.6"), Port: "9090"},
+	}
+
+	addr, err := dialer.dialAddr("example.com:80")
+	assert.NoError(t, err)
+	assert.Equal(t, "3.4.5.6:80", addr)
+
+	addr, err = dialer.dialAddr("example.com:443")
+	assert.NoError(t, err)
+	assert.Equal(t, "3.4.5.6:8443", addr)
+
+	addr, err = dialer.dialAddr("example.com:8080")
+	assert.NoError(t, err)
+	assert.Equal(t, "3.4.5.6:9090", addr)
+}
+
+func newResolver() testResolver {
+	return testResolver{
+		hosts: map[string]net.IP{
+			"example.com": net.ParseIP("1.2.3.4"),
+		},
+	}
+}

--- a/lib/netext/dialer_test.go
+++ b/lib/netext/dialer_test.go
@@ -1,7 +1,7 @@
 /*
  *
  * k6 - a next-generation load testing tool
- * Copyright (C) 2016 Load Impact
+ * Copyright (C) 2020 Load Impact
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/lib/netext/dialer_test.go
+++ b/lib/netext/dialer_test.go
@@ -1,3 +1,23 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2016 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 package netext
 
 import (
@@ -14,23 +34,25 @@ type testResolver struct {
 
 func (r testResolver) FetchOne(host string) (net.IP, error) { return r.hosts[host], nil }
 
-func TestDialerAddrWithDNSResolver(t *testing.T) {
+func TestDialerAddr(t *testing.T) {
 	dialer := newDialerWithResolver(net.Dialer{}, newResolver())
-
-	addr, err := dialer.dialAddr("example.com:80")
-	assert.NoError(t, err)
-	assert.Equal(t, "1.2.3.4:80", addr)
-}
-
-func TestDialerAddrWithCachedHost(t *testing.T) {
-	dialer := newDialerWithResolver(net.Dialer{}, newResolver())
-	dialer.Hosts = map[string]lib.IPPort{
-		"example.com":      {IP: net.ParseIP("3.4.5.6"), Port: ""},
-		"example.com:443":  {IP: net.ParseIP("3.4.5.6"), Port: "8443"},
-		"example.com:8080": {IP: net.ParseIP("3.4.5.6"), Port: "9090"},
+	dialer.Hosts = map[string]*lib.HostAddress{
+		"example.com":           {IP: net.ParseIP("3.4.5.6")},
+		"example.com:443":       {IP: net.ParseIP("3.4.5.6"), Port: 8443},
+		"example.com:8080":      {IP: net.ParseIP("3.4.5.6"), Port: 9090},
+		"example-deny-host.com": {IP: net.ParseIP("8.9.10.11")},
 	}
 
-	addr, err := dialer.dialAddr("example.com:80")
+	ipNet, err := lib.ParseCIDR("8.9.10.0/24")
+	assert.NoError(t, err)
+
+	dialer.Blacklist = []*lib.IPNet{ipNet}
+
+	addr, err := dialer.dialAddr("example-resolver.com:80")
+	assert.NoError(t, err)
+	assert.Equal(t, "1.2.3.4:80", addr)
+
+	addr, err = dialer.dialAddr("example.com:80")
 	assert.NoError(t, err)
 	assert.Equal(t, "3.4.5.6:80", addr)
 
@@ -41,12 +63,19 @@ func TestDialerAddrWithCachedHost(t *testing.T) {
 	addr, err = dialer.dialAddr("example.com:8080")
 	assert.NoError(t, err)
 	assert.Equal(t, "3.4.5.6:9090", addr)
+
+	addr, err = dialer.dialAddr("example-deny-resolver.com:80")
+	assert.EqualError(t, err, "IP (8.9.10.11) is in a blacklisted range (8.9.10.0/24)")
+
+	addr, err = dialer.dialAddr("example-deny-host.com:80")
+	assert.EqualError(t, err, "IP (8.9.10.11) is in a blacklisted range (8.9.10.0/24)")
 }
 
 func newResolver() testResolver {
 	return testResolver{
 		hosts: map[string]net.IP{
-			"example.com": net.ParseIP("1.2.3.4"),
+			"example-resolver.com":      net.ParseIP("1.2.3.4"),
+			"example-deny-resolver.com": net.ParseIP("8.9.10.11"),
 		},
 	}
 }

--- a/lib/netext/dialer_test.go
+++ b/lib/netext/dialer_test.go
@@ -64,10 +64,10 @@ func TestDialerAddr(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "3.4.5.6:9090", addr)
 
-	addr, err = dialer.dialAddr("example-deny-resolver.com:80")
+	_, err = dialer.dialAddr("example-deny-resolver.com:80")
 	assert.EqualError(t, err, "IP (8.9.10.11) is in a blacklisted range (8.9.10.0/24)")
 
-	addr, err = dialer.dialAddr("example-deny-host.com:80")
+	_, err = dialer.dialAddr("example-deny-host.com:80")
 	assert.EqualError(t, err, "IP (8.9.10.11) is in a blacklisted range (8.9.10.0/24)")
 }
 

--- a/lib/netext/dialer_test.go
+++ b/lib/netext/dialer_test.go
@@ -79,7 +79,7 @@ func TestDialerAddr(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.address, func(t *testing.T) {
-			addr, err := dialer.dialAddr(tc.address)
+			addr, err := dialer.getDialAddr(tc.address)
 			if tc.expErr != "" {
 				require.EqualError(t, err, tc.expErr)
 				return

--- a/lib/options.go
+++ b/lib/options.go
@@ -21,7 +21,6 @@
 package lib
 
 import (
-	"bytes"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -239,15 +238,11 @@ func (h *HostAddress) UnmarshalText(text []byte) error {
 }
 
 func splitHostPort(text []byte) (net.IP, string, error) {
-	host := string(text)
-	var port string
-
-	if isHostPort(text) {
-		var err error
-		host, port, err = net.SplitHostPort(host)
-		if err != nil {
-			return nil, "", err
-		}
+	host, port, err := net.SplitHostPort(string(text))
+	if err != nil {
+		// This error means that there is no port.
+		// Make host the full text.
+		host = string(text)
 	}
 
 	ip := net.ParseIP(host)
@@ -256,12 +251,6 @@ func splitHostPort(text []byte) (net.IP, string, error) {
 	}
 
 	return ip, port, nil
-}
-
-func isHostPort(text []byte) bool {
-	return bytes.ContainsRune(text, ':') &&
-		(bytes.ContainsRune(text, '.') || // ipV4
-			(bytes.ContainsRune(text, '[') && bytes.ContainsRune(text, ']'))) // ipV6
 }
 
 // ParseCIDR creates an IPNet out of a CIDR string

--- a/lib/options.go
+++ b/lib/options.go
@@ -206,7 +206,7 @@ func (h *HostAddress) String() string {
 // The encoding is the same as returned by String, with one exception:
 // When len(ip) is zero, it returns an empty slice.
 func (h *HostAddress) MarshalText() ([]byte, error) {
-	if len(h.IP) == 0 {
+	if h == nil || len(h.IP) == 0 {
 		return []byte(""), nil
 	}
 
@@ -225,24 +225,22 @@ func (h *HostAddress) UnmarshalText(text []byte) error {
 	}
 
 	s := string(text)
-	ip, port, err := net.SplitHostPort(s)
+	host, port, err := net.SplitHostPort(s)
 	if err != nil {
 		return err
 	}
 
-	x := net.ParseIP(ip)
-	if x == nil {
+	ip := net.ParseIP(host)
+	if ip == nil {
 		return &net.ParseError{Type: "IP address", Text: s}
 	}
 
-	p, err := strconv.Atoi(port)
+	nh, err := NewHostAddress(ip, port)
 	if err != nil {
-		return &net.ParseError{Type: "IP address", Text: s}
+		return err
 	}
 
-	h.IP = x
-	h.Port = p
-
+	*h = *nh
 	return nil
 }
 

--- a/lib/options.go
+++ b/lib/options.go
@@ -158,10 +158,8 @@ func (c *TLSAuth) Certificate() (*tls.Certificate, error) {
 }
 
 // IPNet is a wrapper around net.IPNet for JSON unmarshalling
-type IPNet net.IPNet
-
-func (ipnet *IPNet) String() string {
-	return (*net.IPNet)(ipnet).String()
+type IPNet struct {
+	net.IPNet
 }
 
 // UnmarshalText populates the IPNet from the given CIDR
@@ -260,7 +258,7 @@ func ParseCIDR(s string) (*IPNet, error) {
 		return nil, err
 	}
 
-	parsedIPNet := IPNet(*ipnet)
+	parsedIPNet := IPNet{IPNet: *ipnet}
 
 	return &parsedIPNet, nil
 }

--- a/lib/options.go
+++ b/lib/options.go
@@ -188,7 +188,6 @@ func NewHostAddress(ip net.IP, portString string) (*HostAddress, error) {
 		if port, err = strconv.Atoi(portString); err != nil {
 			return nil, err
 		}
-
 	}
 
 	return &HostAddress{

--- a/lib/options.go
+++ b/lib/options.go
@@ -232,6 +232,7 @@ func (h *HostAddress) UnmarshalText(text []byte) error {
 	}
 
 	*h = *nh
+
 	return nil
 }
 

--- a/lib/options.go
+++ b/lib/options.go
@@ -41,8 +41,6 @@ import (
 // iterations+vus, or stages)
 const DefaultScenarioName = "default"
 
-const defaultHostPort = 80
-
 // DefaultSummaryTrendStats are the default trend columns shown in the test summary output
 // nolint: gochecknoglobals
 var DefaultSummaryTrendStats = []string{"avg", "min", "med", "max", "p(90)", "p(95)"}

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -294,8 +294,10 @@ func TestOptions(t *testing.T) {
 	t.Run("BlacklistIPs", func(t *testing.T) {
 		opts := Options{}.Apply(Options{
 			BlacklistIPs: []*IPNet{{
-				IP:   net.IPv4zero,
-				Mask: net.CIDRMask(1, 1),
+				IPNet: net.IPNet{
+					IP:   net.IPv4zero,
+					Mask: net.CIDRMask(1, 1),
+				},
 			}},
 		})
 		assert.NotNil(t, opts.BlacklistIPs)
@@ -489,18 +491,18 @@ func TestCIDRUnmarshal(t *testing.T) {
 	}{
 		{
 			"10.0.0.0/8",
-			&IPNet{
+			&IPNet{IPNet: net.IPNet{
 				IP:   net.IP{10, 0, 0, 0},
 				Mask: net.IPv4Mask(255, 0, 0, 0),
-			},
+			}},
 			false,
 		},
 		{
 			"fc00:1234:5678::/48",
-			&IPNet{
+			&IPNet{IPNet: net.IPNet{
 				IP:   net.ParseIP("fc00:1234:5678::"),
 				Mask: net.CIDRMask(48, 128),
-			},
+			}},
 			false,
 		},
 		{"10.0.0.0", nil, true},

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -305,14 +305,15 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("Hosts", func(t *testing.T) {
-		host, err := NewHostAddress(net.ParseIP("192.0.2.1"), "")
+		host, err := NewHostAddress(net.ParseIP("192.0.2.1"), "80")
 		assert.NoError(t, err)
+
 		opts := Options{}.Apply(Options{Hosts: map[string]*HostAddress{
 			"test.loadimpact.com": host,
 		}})
 		assert.NotNil(t, opts.Hosts)
 		assert.NotEmpty(t, opts.Hosts)
-		assert.Equal(t, "192.0.2.1", opts.Hosts["test.loadimpact.com"].String())
+		assert.Equal(t, "192.0.2.1:80", opts.Hosts["test.loadimpact.com"].String())
 	})
 
 	t.Run("Throws", func(t *testing.T) {

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -305,8 +305,10 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("Hosts", func(t *testing.T) {
-		opts := Options{}.Apply(Options{Hosts: map[string]IPPort{
-			"test.loadimpact.com": NewIPPort(net.ParseIP("192.0.2.1")),
+		host, err := NewHostAddress(net.ParseIP("192.0.2.1"), "")
+		assert.NoError(t, err)
+		opts := Options{}.Apply(Options{Hosts: map[string]*HostAddress{
+			"test.loadimpact.com": host,
 		}})
 		assert.NotNil(t, opts.Hosts)
 		assert.NotEmpty(t, opts.Hosts)

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -527,7 +527,7 @@ func TestCIDRUnmarshal(t *testing.T) {
 }
 
 func TestHostAddressUnmarshal(t *testing.T) {
-	var testData = []struct {
+	testData := []struct {
 		input          string
 		expectedOutput *HostAddress
 		expectFailure  string

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -305,8 +305,8 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("Hosts", func(t *testing.T) {
-		opts := Options{}.Apply(Options{Hosts: map[string]net.IP{
-			"test.loadimpact.com": net.ParseIP("192.0.2.1"),
+		opts := Options{}.Apply(Options{Hosts: map[string]IPPort{
+			"test.loadimpact.com": NewIPPort(net.ParseIP("192.0.2.1")),
 		}})
 		assert.NotNil(t, opts.Hosts)
 		assert.NotEmpty(t, opts.Hosts)

--- a/lib/testutils/httpmultibin/httpmultibin.go
+++ b/lib/testutils/httpmultibin/httpmultibin.go
@@ -242,9 +242,9 @@ func NewHTTPMultiBin(t testing.TB) *HTTPMultiBin {
 	http2IP := net.ParseIP(http2URL.Hostname())
 	require.NotNil(t, http2IP)
 
-	httpDomainValue, err := lib.NewHostAddress(httpIP, "80")
+	httpDomainValue, err := lib.NewHostAddress(httpIP, "")
 	require.NoError(t, err)
-	httpsDomainValue, err := lib.NewHostAddress(httpsIP, "443")
+	httpsDomainValue, err := lib.NewHostAddress(httpsIP, "")
 	require.NoError(t, err)
 
 	// Set up the dialer with shorter timeouts and the custom domains

--- a/lib/testutils/httpmultibin/httpmultibin.go
+++ b/lib/testutils/httpmultibin/httpmultibin.go
@@ -248,9 +248,9 @@ func NewHTTPMultiBin(t testing.TB) *HTTPMultiBin {
 		KeepAlive: 10 * time.Second,
 		DualStack: true,
 	})
-	dialer.Hosts = map[string]net.IP{
-		httpDomain:  httpIP,
-		httpsDomain: httpsIP,
+	dialer.Hosts = map[string]lib.IPPort{
+		httpDomain:  lib.NewIPPort(httpIP),
+		httpsDomain: lib.NewIPPort(httpsIP),
 	}
 
 	// Pre-configure the HTTP client transport with the dialer and TLS config (incl. HTTP2 support)

--- a/lib/testutils/httpmultibin/httpmultibin.go
+++ b/lib/testutils/httpmultibin/httpmultibin.go
@@ -242,15 +242,20 @@ func NewHTTPMultiBin(t testing.TB) *HTTPMultiBin {
 	http2IP := net.ParseIP(http2URL.Hostname())
 	require.NotNil(t, http2IP)
 
+	httpDomainValue, err := lib.NewHostAddress(httpIP, "80")
+	require.NoError(t, err)
+	httpsDomainValue, err := lib.NewHostAddress(httpsIP, "443")
+	require.NoError(t, err)
+
 	// Set up the dialer with shorter timeouts and the custom domains
 	dialer := netext.NewDialer(net.Dialer{
 		Timeout:   2 * time.Second,
 		KeepAlive: 10 * time.Second,
 		DualStack: true,
 	})
-	dialer.Hosts = map[string]lib.IPPort{
-		httpDomain:  lib.NewIPPort(httpIP),
-		httpsDomain: lib.NewIPPort(httpsIP),
+	dialer.Hosts = map[string]*lib.HostAddress{
+		httpDomain:  httpDomainValue,
+		httpsDomain: httpsDomainValue,
 	}
 
 	// Pre-configure the HTTP client transport with the dialer and TLS config (incl. HTTP2 support)

--- a/lib/testutils/httpmultibin/httpmultibin.go
+++ b/lib/testutils/httpmultibin/httpmultibin.go
@@ -46,6 +46,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http2"
 
+	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/lib/netext"
 	"github.com/loadimpact/k6/lib/netext/httpext"
 )


### PR DESCRIPTION
This is an extension for the host mapping feature. It allows people to map to a different port than the one in the original url.

This is very convenient when you run k6 against a fleet of docker
containers to test the same service but want to keep the port mapping.

Signed-off-by: David Calavera <david.calavera@gmail.com>