### PR TITLE
remove space from logrus Field

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -171,8 +171,8 @@ func Load(
 ) (*SourceData, error) {
 	logrus.WithFields(
 		logrus.Fields{
-			"moduleSpecifier":          moduleSpecifier,
-			"original moduleSpecifier": originalModuleSpecifier,
+			"moduleSpecifier":         moduleSpecifier,
+			"originalModuleSpecifier": originalModuleSpecifier,
 		}).Debug("Loading...")
 
 	var pathOnFs string


### PR DESCRIPTION
This just is the only places where there is space and looks quite strange in the log:
![image](https://user-images.githubusercontent.com/312246/85402551-8a4ed280-b564-11ea-8938-17535d8863c8.png)
