### PR TITLE
Don't leak goroutines everywhere in the ws code

### DIFF
--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -581,7 +581,8 @@ func TestReadPump(t *testing.T) {
 			msgChan := make(chan []byte)
 			errChan := make(chan error)
 			closeChan := make(chan int)
-			go readPump(conn, msgChan, errChan, closeChan)
+			s := &Socket{conn: conn}
+			go s.readPump(msgChan, errChan, closeChan)
 
 		readChans:
 			for {


### PR DESCRIPTION
Previous to this, running k6 compiled with the race detector and ws
code will most definitely leak enough goroutines in 10 seconds that it
will stop because of the 8k limit ...


After this it seems to not leak anymore :confetti: I tested with 2k VUs 
which use around 7.5k goroutines and it seemed to move withing 200/300 
goroutines over a period of 5minutes without ever actually looking like
some goroutines leaked