### PR TITLE
Add "scenario" as default system tag

### DIFF
--- a/js/runner.go
+++ b/js/runner.go
@@ -456,7 +456,7 @@ func (u *ActiveVU) RunOnce() error {
 
 	fn, ok := u.exports[u.Exec]
 	if !ok {
-		// Shouldn't happen; this is validated in ExecutionScheduler.Init()
+		// Shouldn't happen; this is validated in cmd.validateScenarioConfig()
 		panic(fmt.Sprintf("function '%s' not found in exports", u.Exec))
 	}
 

--- a/js/runner.go
+++ b/js/runner.go
@@ -328,7 +328,7 @@ func (r *Runner) runPart(ctx context.Context, out chan<- stats.SampleContainer, 
 		return goja.Undefined(), err
 	}
 
-	v, _, _, err := vu.runFn(ctx, group, false, nil, fn, vu.Runtime.ToValue(arg))
+	v, _, _, err := vu.runFn(ctx, "", group, false, nil, fn, vu.Runtime.ToValue(arg))
 
 	// deadline is reached so we have timeouted but this might've not been registered correctly
 	if deadline, ok := ctx.Deadline(); ok && time.Now().After(deadline) {
@@ -462,7 +462,7 @@ func (u *ActiveVU) RunOnce() error {
 
 	// Call the exported function.
 	_, isFullIteration, totalTime, err := u.runFn(
-		u.RunContext, u.Runner.defaultGroup, true, u.Tags, fn, u.setupData,
+		u.RunContext, u.Scenario, u.Runner.defaultGroup, true, u.Tags, fn, u.setupData,
 	)
 
 	// If MinIterationDuration is specified and the iteration wasn't cancelled
@@ -478,8 +478,8 @@ func (u *ActiveVU) RunOnce() error {
 }
 
 func (u *VU) runFn(
-	ctx context.Context, group *lib.Group, isDefault bool, customTags map[string]string,
-	fn goja.Callable, args ...goja.Value,
+	ctx context.Context, scenario string, group *lib.Group, isDefault bool,
+	customTags map[string]string, fn goja.Callable, args ...goja.Value,
 ) (goja.Value, bool, time.Duration, error) {
 	cookieJar := u.CookieJar
 	if !u.Runner.Bundle.Options.NoCookiesReset.ValueOrZero() {
@@ -503,6 +503,9 @@ func (u *VU) runFn(
 	}
 	if opts.SystemTags.Has(stats.TagGroup) {
 		tags["group"] = group.Path
+	}
+	if scenario != "" && opts.SystemTags.Has(stats.TagScenario) {
+		tags["scenario"] = scenario
 	}
 
 	state := &lib.State{

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -1626,6 +1626,7 @@ func TestSystemTags(t *testing.T) {
 		{"ocsp_status", "https_get", "unknown"},
 		{"error", "bad_url_get", `dial: connection refused`},
 		{"error_code", "bad_url_get", "1212"},
+		{"scenario", "http_get", "default"},
 		//TODO: add more tests
 	}
 
@@ -1645,6 +1646,7 @@ func TestSystemTags(t *testing.T) {
 			activeVU := vu.Activate(&lib.VUActivationParams{
 				RunContext: context.Background(),
 				Exec:       tc.exec,
+				Scenario:   "default",
 			})
 			require.NoError(t, activeVU.RunOnce())
 

--- a/lib/executor/helpers.go
+++ b/lib/executor/helpers.go
@@ -223,6 +223,7 @@ func getVUActivationParams(
 ) *lib.VUActivationParams {
 	return &lib.VUActivationParams{
 		RunContext:         ctx,
+		Scenario:           conf.Name,
 		Exec:               conf.GetExec(),
 		Env:                conf.GetEnv(),
 		Tags:               conf.GetTags(),

--- a/lib/runner.go
+++ b/lib/runner.go
@@ -49,7 +49,7 @@ type VUActivationParams struct {
 	RunContext         context.Context
 	DeactivateCallback func(InitializedVU)
 	Env, Tags          map[string]string
-	Exec               string
+	Exec, Scenario     string
 }
 
 // A Runner is a factory for VUs. It should precompute as much as possible upon

--- a/stats/system_tag.go
+++ b/stats/system_tag.go
@@ -49,6 +49,7 @@ const (
 	TagError
 	TagErrorCode
 	TagTLSVersion
+	TagScenario
 
 	// System tags not enabled by default.
 	TagIter
@@ -61,7 +62,7 @@ const (
 // Other tags that are not enabled by default include: iter, vu, ocsp_status, ip
 //nolint:gochecknoglobals
 var DefaultSystemTagSet = TagProto | TagSubproto | TagStatus | TagMethod | TagURL | TagName | TagGroup |
-	TagCheck | TagCheck | TagError | TagErrorCode | TagTLSVersion
+	TagCheck | TagCheck | TagError | TagErrorCode | TagTLSVersion | TagScenario
 
 // Add adds a tag to tag set.
 func (i *SystemTagSet) Add(tag SystemTagSet) {

--- a/stats/system_tag_set_gen.go
+++ b/stats/system_tag_set_gen.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 )
 
-const _SystemTagSetName = "protosubprotostatusmethodurlnamegroupcheckerrorerror_codetls_versionitervuocsp_statusip"
+const _SystemTagSetName = "protosubprotostatusmethodurlnamegroupcheckerrorerror_codetls_versionscenarioitervuocsp_statusip"
 
 var _SystemTagSetMap = map[SystemTagSet]string{
 	1:     _SystemTagSetName[0:5],
@@ -21,10 +21,11 @@ var _SystemTagSetMap = map[SystemTagSet]string{
 	256:   _SystemTagSetName[42:47],
 	512:   _SystemTagSetName[47:57],
 	1024:  _SystemTagSetName[57:68],
-	2048:  _SystemTagSetName[68:72],
-	4096:  _SystemTagSetName[72:74],
-	8192:  _SystemTagSetName[74:85],
-	16384: _SystemTagSetName[85:87],
+	2048:  _SystemTagSetName[68:76],
+	4096:  _SystemTagSetName[76:80],
+	8192:  _SystemTagSetName[80:82],
+	16384: _SystemTagSetName[82:93],
+	32768: _SystemTagSetName[93:95],
 }
 
 func (i SystemTagSet) String() string {
@@ -34,7 +35,7 @@ func (i SystemTagSet) String() string {
 	return fmt.Sprintf("SystemTagSet(%d)", i)
 }
 
-var _SystemTagSetValues = []SystemTagSet{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384}
+var _SystemTagSetValues = []SystemTagSet{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768}
 
 var _SystemTagSetNameToValueMap = map[string]SystemTagSet{
 	_SystemTagSetName[0:5]:   1,
@@ -48,10 +49,11 @@ var _SystemTagSetNameToValueMap = map[string]SystemTagSet{
 	_SystemTagSetName[42:47]: 256,
 	_SystemTagSetName[47:57]: 512,
 	_SystemTagSetName[57:68]: 1024,
-	_SystemTagSetName[68:72]: 2048,
-	_SystemTagSetName[72:74]: 4096,
-	_SystemTagSetName[74:85]: 8192,
-	_SystemTagSetName[85:87]: 16384,
+	_SystemTagSetName[68:76]: 2048,
+	_SystemTagSetName[76:80]: 4096,
+	_SystemTagSetName[80:82]: 8192,
+	_SystemTagSetName[82:93]: 16384,
+	_SystemTagSetName[93:95]: 32768,
 }
 
 // SystemTagSetString retrieves an enum value from the enum constants string name.


### PR DESCRIPTION
This tags all metrics emitted in the main "exec" function with a "scenario" tag set to the scenario name or "default" if no custom scenarios were defined. It can be disabled with the `--system-tags` option.

There's no issue for this specific feature, but see #796 and #1300.