### PR TITLE
Make MaxVUs equal to preallocatedVUs when missing for arrival rate executors

### DIFF
--- a/lib/executor/constant_arrival_rate.go
+++ b/lib/executor/constant_arrival_rate.go
@@ -66,8 +66,8 @@ type ConstantArrivalRateConfig struct {
 }
 
 // NewConstantArrivalRateConfig returns a ConstantArrivalRateConfig with default values
-func NewConstantArrivalRateConfig(name string) ConstantArrivalRateConfig {
-	return ConstantArrivalRateConfig{
+func NewConstantArrivalRateConfig(name string) *ConstantArrivalRateConfig {
+	return &ConstantArrivalRateConfig{
 		BaseConfig: NewBaseConfig(name, constantArrivalRateType),
 		TimeUnit:   types.NewNullDuration(1*time.Second, false),
 	}
@@ -108,7 +108,7 @@ func (carc ConstantArrivalRateConfig) GetDescription(et *lib.ExecutionTuple) str
 }
 
 // Validate makes sure all options are configured and valid
-func (carc ConstantArrivalRateConfig) Validate() []error {
+func (carc *ConstantArrivalRateConfig) Validate() []error {
 	errors := carc.BaseConfig.Validate()
 	if !carc.Rate.Valid {
 		errors = append(errors, fmt.Errorf("the iteration rate isn't specified"))
@@ -135,7 +135,7 @@ func (carc ConstantArrivalRateConfig) Validate() []error {
 	}
 
 	if !carc.MaxVUs.Valid {
-		errors = append(errors, fmt.Errorf("the number of maxVUs isn't specified"))
+		carc.MaxVUs.Int64 = carc.PreAllocatedVUs.Int64
 	} else if carc.MaxVUs.Int64 < carc.PreAllocatedVUs.Int64 {
 		errors = append(errors, fmt.Errorf("maxVUs shouldn't be less than preAllocatedVUs"))
 	}
@@ -167,7 +167,7 @@ func (carc ConstantArrivalRateConfig) NewExecutor(
 	es *lib.ExecutionState, logger *logrus.Entry,
 ) (lib.Executor, error) {
 	return &ConstantArrivalRate{
-		BaseExecutor: NewBaseExecutor(carc, es, logger),
+		BaseExecutor: NewBaseExecutor(&carc, es, logger),
 		config:       carc,
 	}, nil
 }

--- a/lib/executor/constant_arrival_rate.go
+++ b/lib/executor/constant_arrival_rate.go
@@ -135,6 +135,7 @@ func (carc *ConstantArrivalRateConfig) Validate() []error {
 	}
 
 	if !carc.MaxVUs.Valid {
+		// TODO: don't change the config while validating
 		carc.MaxVUs.Int64 = carc.PreAllocatedVUs.Int64
 	} else if carc.MaxVUs.Int64 < carc.PreAllocatedVUs.Int64 {
 		errors = append(errors, fmt.Errorf("maxVUs shouldn't be less than preAllocatedVUs"))

--- a/lib/executor/constant_arrival_rate_test.go
+++ b/lib/executor/constant_arrival_rate_test.go
@@ -54,8 +54,8 @@ func newExecutionSegmentSequenceFromString(str string) *lib.ExecutionSegmentSequ
 	return &r
 }
 
-func getTestConstantArrivalRateConfig() ConstantArrivalRateConfig {
-	return ConstantArrivalRateConfig{
+func getTestConstantArrivalRateConfig() *ConstantArrivalRateConfig {
+	return &ConstantArrivalRateConfig{
 		BaseConfig:      BaseConfig{GracefulStop: types.NullDurationFrom(1 * time.Second)},
 		TimeUnit:        types.NullDurationFrom(time.Second),
 		Rate:            null.IntFrom(50),

--- a/lib/executor/executors_test.go
+++ b/lib/executor/executors_test.go
@@ -349,7 +349,12 @@ var configMapTestCases = []configMapTestCase{
 	},
 	{`{"carrival": {"executor": "constant-arrival-rate", "rate": 10, "duration": "10m", "preAllocatedVUs": 20, "maxVUs": 30}}`, exp{}},
 	{`{"carrival": {"executor": "constant-arrival-rate", "rate": 10, "duration": "10m", "preAllocatedVUs": 20, "maxVUs": 30, "timeUnit": "-1s"}}`, exp{validationError: true}},
-	{`{"carrival": {"executor": "constant-arrival-rate", "rate": 10, "duration": "10m", "preAllocatedVUs": 20}}`, exp{validationError: true}},
+	{`{"carrival": {"executor": "constant-arrival-rate", "rate": 10, "duration": "10m", "preAllocatedVUs": 20}}`,
+		exp{custom: func(t *testing.T, cm lib.ScenarioConfigs) {
+			assert.Empty(t, cm["carrival"].Validate())
+			require.EqualValues(t, 20, cm["carrival"].(*ConstantArrivalRateConfig).MaxVUs.Int64)
+		}},
+	},
 	{`{"carrival": {"executor": "constant-arrival-rate", "rate": 10, "duration": "10m", "maxVUs": 30}}`, exp{validationError: true}},
 	{`{"carrival": {"executor": "constant-arrival-rate", "rate": 10, "preAllocatedVUs": 20, "maxVUs": 30}}`, exp{validationError: true}},
 	{`{"carrival": {"executor": "constant-arrival-rate", "duration": "10m", "preAllocatedVUs": 20, "maxVUs": 30}}`, exp{validationError: true}},
@@ -394,7 +399,12 @@ var configMapTestCases = []configMapTestCase{
 	{`{"varrival": {"executor": "ramping-arrival-rate", "preAllocatedVUs": 20, "maxVUs": 50, "stages": [{"duration": "5m", "target": 10}]}}`, exp{}},
 	{`{"varrival": {"executor": "ramping-arrival-rate", "preAllocatedVUs": -20, "maxVUs": 50, "stages": [{"duration": "5m", "target": 10}]}}`, exp{validationError: true}},
 	{`{"varrival": {"executor": "ramping-arrival-rate", "startRate": -1, "preAllocatedVUs": 20, "maxVUs": 50, "stages": [{"duration": "5m", "target": 10}]}}`, exp{validationError: true}},
-	{`{"varrival": {"executor": "ramping-arrival-rate", "preAllocatedVUs": 20, "stages": [{"duration": "5m", "target": 10}]}}`, exp{validationError: true}},
+	{`{"varrival": {"executor": "ramping-arrival-rate", "preAllocatedVUs": 20, "stages": [{"duration": "5m", "target": 10}]}}`,
+		exp{custom: func(t *testing.T, cm lib.ScenarioConfigs) {
+			assert.Empty(t, cm["varrival"].Validate())
+			require.EqualValues(t, 20, cm["varrival"].(*RampingArrivalRateConfig).MaxVUs.Int64)
+		}},
+	},
 	{`{"varrival": {"executor": "ramping-arrival-rate", "maxVUs": 50, "stages": [{"duration": "5m", "target": 10}]}}`, exp{validationError: true}},
 	{`{"varrival": {"executor": "ramping-arrival-rate", "preAllocatedVUs": 20, "maxVUs": 50}}`, exp{validationError: true}},
 	{`{"varrival": {"executor": "ramping-arrival-rate", "preAllocatedVUs": 20, "maxVUs": 50, "stages": []}}`, exp{validationError: true}},

--- a/lib/executor/ramping_arrival_rate.go
+++ b/lib/executor/ramping_arrival_rate.go
@@ -124,6 +124,7 @@ func (varc *RampingArrivalRateConfig) Validate() []error {
 	}
 
 	if !varc.MaxVUs.Valid {
+		// TODO: don't change the config while validating
 		varc.MaxVUs.Int64 = varc.PreAllocatedVUs.Int64
 	} else if varc.MaxVUs.Int64 < varc.PreAllocatedVUs.Int64 {
 		errors = append(errors, fmt.Errorf("maxVUs shouldn't be less than preAllocatedVUs"))

--- a/lib/executor/ramping_arrival_rate.go
+++ b/lib/executor/ramping_arrival_rate.go
@@ -66,8 +66,8 @@ type RampingArrivalRateConfig struct {
 }
 
 // NewRampingArrivalRateConfig returns a RampingArrivalRateConfig with default values
-func NewRampingArrivalRateConfig(name string) RampingArrivalRateConfig {
-	return RampingArrivalRateConfig{
+func NewRampingArrivalRateConfig(name string) *RampingArrivalRateConfig {
+	return &RampingArrivalRateConfig{
 		BaseConfig: NewBaseConfig(name, rampingArrivalRateType),
 		TimeUnit:   types.NewNullDuration(1*time.Second, false),
 	}
@@ -104,7 +104,7 @@ func (varc RampingArrivalRateConfig) GetDescription(et *lib.ExecutionTuple) stri
 }
 
 // Validate makes sure all options are configured and valid
-func (varc RampingArrivalRateConfig) Validate() []error {
+func (varc *RampingArrivalRateConfig) Validate() []error {
 	errors := varc.BaseConfig.Validate()
 
 	if varc.StartRate.Int64 < 0 {
@@ -124,7 +124,7 @@ func (varc RampingArrivalRateConfig) Validate() []error {
 	}
 
 	if !varc.MaxVUs.Valid {
-		errors = append(errors, fmt.Errorf("the number of maxVUs isn't specified"))
+		varc.MaxVUs.Int64 = varc.PreAllocatedVUs.Int64
 	} else if varc.MaxVUs.Int64 < varc.PreAllocatedVUs.Int64 {
 		errors = append(errors, fmt.Errorf("maxVUs shouldn't be less than preAllocatedVUs"))
 	}
@@ -157,7 +157,7 @@ func (varc RampingArrivalRateConfig) NewExecutor(
 	es *lib.ExecutionState, logger *logrus.Entry,
 ) (lib.Executor, error) {
 	return RampingArrivalRate{
-		BaseExecutor: NewBaseExecutor(varc, es, logger),
+		BaseExecutor: NewBaseExecutor(&varc, es, logger),
 		config:       varc,
 	}, nil
 }

--- a/lib/executor/ramping_arrival_rate_test.go
+++ b/lib/executor/ramping_arrival_rate_test.go
@@ -39,8 +39,8 @@ import (
 	"github.com/loadimpact/k6/stats"
 )
 
-func getTestRampingArrivalRateConfig() RampingArrivalRateConfig {
-	return RampingArrivalRateConfig{
+func getTestRampingArrivalRateConfig() *RampingArrivalRateConfig {
+	return &RampingArrivalRateConfig{
 		BaseConfig: BaseConfig{GracefulStop: types.NullDurationFrom(1 * time.Second)},
 		TimeUnit:   types.NullDurationFrom(time.Second),
 		StartRate:  null.IntFrom(10),
@@ -140,7 +140,7 @@ func TestRampingArrivalRateRunCorrectRateWithSlowRate(t *testing.T) {
 		time.Millisecond * 3464, time.Millisecond * 4898, time.Second * 6,
 	}
 	ctx, cancel, executor, logHook := setupExecutor(
-		t, RampingArrivalRateConfig{
+		t, &RampingArrivalRateConfig{
 			TimeUnit: types.NullDurationFrom(time.Second),
 			Stages: []Stage{
 				{


### PR DESCRIPTION
fixes #1317