### PR TITLE
Use a provided logger in the loader module

### DIFF
--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -23,6 +23,7 @@ package cmd
 import (
 	"os"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -54,7 +55,8 @@ An archive is a fully self-contained test run, and can be executed identically e
 		}
 		filename := args[0]
 		filesystems := loader.CreateFilesystems()
-		src, err := loader.ReadSource(filename, pwd, filesystems, os.Stdin)
+		// TODO: don't use the Global logger
+		src, err := loader.ReadSource(logrus.StandardLogger(), filename, pwd, filesystems, os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -78,7 +78,8 @@ This will execute the test on the Load Impact cloud service. Use "k6 login cloud
 
 		filename := args[0]
 		filesystems := loader.CreateFilesystems()
-		src, err := loader.ReadSource(filename, pwd, filesystems, os.Stdin)
+		// TODO: don't use the Global logger
+		src, err := loader.ReadSource(logrus.StandardLogger(), filename, pwd, filesystems, os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/loadimpact/k6/js"
@@ -45,7 +46,8 @@ var inspectCmd = &cobra.Command{
 			return err
 		}
 		filesystems := loader.CreateFilesystems()
-		src, err := loader.ReadSource(args[0], pwd, filesystems, os.Stdin)
+		// TODO: don't use the Global logger
+		src, err := loader.ReadSource(logrus.StandardLogger(), args[0], pwd, filesystems, os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -96,6 +96,9 @@ a commandline interface for interacting with it.`,
   k6 run -o influxdb=http://1.2.3.4:8086/k6`[1:],
 	Args: exactArgsWithMsg(1, "arg should either be \"-\", if reading script from stdin, or a path to a script file"),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// TODO: don't use a global... or maybe change the logger?
+		logger := logrus.StandardLogger()
+
 		// TODO: disable in quiet mode?
 		_, _ = BannerColor.Fprintf(stdout, "\n%s\n\n", consts.Banner)
 
@@ -109,7 +112,7 @@ a commandline interface for interacting with it.`,
 		}
 		filename := args[0]
 		filesystems := loader.CreateFilesystems()
-		src, err := loader.ReadSource(filename, pwd, filesystems, os.Stdin)
+		src, err := loader.ReadSource(logger, filename, pwd, filesystems, os.Stdin)
 		if err != nil {
 			return err
 		}
@@ -144,9 +147,6 @@ a commandline interface for interacting with it.`,
 		if err = r.SetOptions(conf.Options); err != nil {
 			return err
 		}
-
-		// TODO: don't use a global... or maybe change the logger?
-		logger := logrus.StandardLogger()
 
 		// We prepare a bunch of contexts:
 		//  - The runCtx is cancelled as soon as the Engine's run() lambda finishes,

--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 
 	"github.com/loadimpact/k6/js/common"
@@ -154,7 +155,8 @@ func (i *InitContext) requireFile(name string) (goja.Value, error) {
 
 		if pgm.pgm == nil {
 			// Load the sources; the loader takes care of remote loading, etc.
-			data, err := loader.Load(i.filesystems, fileURL, name)
+			// TODO: don't use the Global logger
+			data, err := loader.Load(logrus.StandardLogger(), i.filesystems, fileURL, name)
 			if err != nil {
 				return goja.Undefined(), err
 			}

--- a/loader/cdnjs.go
+++ b/loader/cdnjs.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type cdnjsEnvelope struct {
@@ -36,12 +37,12 @@ type cdnjsEnvelope struct {
 	}
 }
 
-func cdnjs(path string, parts []string) (string, error) {
+func cdnjs(logger logrus.FieldLogger, path string, parts []string) (string, error) {
 	name := parts[0]
 	version := parts[1]
 	filename := parts[2]
 
-	data, err := fetch("https://api.cdnjs.com/libraries/" + name)
+	data, err := fetch(logger, "https://api.cdnjs.com/libraries/"+name)
 	if err != nil {
 		return "", err
 	}

--- a/loader/cdnjs_test.go
+++ b/loader/cdnjs_test.go
@@ -24,6 +24,8 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/loadimpact/k6/lib/testutils"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,6 +69,8 @@ func TestCDNJS(t *testing.T) {
 	}
 
 	var root = &url.URL{Scheme: "https", Host: "example.com", Path: "/something/"}
+	logger := logrus.New()
+	logger.SetOutput(testutils.NewTestOutput(t))
 	for path, expected := range paths {
 		path, expected := path, expected
 		t.Run(path, func(t *testing.T) {
@@ -74,7 +78,7 @@ func TestCDNJS(t *testing.T) {
 			assert.Equal(t, "cdnjs", name)
 			assert.Equal(t, expected.parts, parts)
 
-			src, err := loader(path, parts)
+			src, err := loader(logger, path, parts)
 			require.NoError(t, err)
 			assert.Regexp(t, expected.src, src)
 
@@ -83,7 +87,7 @@ func TestCDNJS(t *testing.T) {
 			require.Empty(t, resolvedURL.Scheme)
 			require.Equal(t, path, resolvedURL.Opaque)
 
-			data, err := Load(map[string]afero.Fs{"https": afero.NewMemMapFs()}, resolvedURL, path)
+			data, err := Load(logger, map[string]afero.Fs{"https": afero.NewMemMapFs()}, resolvedURL, path)
 			require.NoError(t, err)
 			assert.Equal(t, resolvedURL, data.URL)
 			assert.NotEmpty(t, data.Data)
@@ -95,7 +99,7 @@ func TestCDNJS(t *testing.T) {
 		name, loader, parts := pickLoader(path)
 		assert.Equal(t, "cdnjs", name)
 		assert.Equal(t, []string{"nonexistent", "", ""}, parts)
-		_, err := loader(path, parts)
+		_, err := loader(logger, path, parts)
 		assert.EqualError(t, err, "cdnjs: no such library: nonexistent")
 	})
 
@@ -104,14 +108,14 @@ func TestCDNJS(t *testing.T) {
 		name, loader, parts := pickLoader(path)
 		assert.Equal(t, "cdnjs", name)
 		assert.Equal(t, []string{"Faker", "3.1.0", "nonexistent.js"}, parts)
-		src, err := loader(path, parts)
+		src, err := loader(logger, path, parts)
 		require.NoError(t, err)
 		assert.Equal(t, "https://cdnjs.cloudflare.com/ajax/libs/Faker/3.1.0/nonexistent.js", src)
 
 		pathURL, err := url.Parse(src)
 		require.NoError(t, err)
 
-		_, err = Load(map[string]afero.Fs{"https": afero.NewMemMapFs()}, pathURL, path)
+		_, err = Load(logger, map[string]afero.Fs{"https": afero.NewMemMapFs()}, pathURL, path)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found: https://cdnjs.cloudflare.com/ajax/libs/Faker/3.1.0/nonexistent.js")
 	})

--- a/loader/github.go
+++ b/loader/github.go
@@ -20,7 +20,9 @@
 
 package loader
 
-func github(path string, parts []string) (string, error) {
+import "github.com/sirupsen/logrus"
+
+func github(_ logrus.FieldLogger, path string, parts []string) (string, error) {
 	username := parts[0]
 	repo := parts[1]
 	filepath := parts[2]

--- a/loader/github_test.go
+++ b/loader/github_test.go
@@ -24,18 +24,22 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/loadimpact/k6/lib/testutils"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGithub(t *testing.T) {
+	logger := logrus.New()
+	logger.SetOutput(testutils.NewTestOutput(t))
 	path := "github.com/github/gitignore/Go.gitignore"
 	expectedEndSrc := "https://raw.githubusercontent.com/github/gitignore/master/Go.gitignore"
 	name, loader, parts := pickLoader(path)
 	assert.Equal(t, "github", name)
 	assert.Equal(t, []string{"github", "gitignore", "Go.gitignore"}, parts)
-	src, err := loader(path, parts)
+	src, err := loader(logger, path, parts)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEndSrc, src)
 
@@ -45,7 +49,7 @@ func TestGithub(t *testing.T) {
 	require.Empty(t, resolvedURL.Scheme)
 	require.Equal(t, path, resolvedURL.Opaque)
 	t.Run("not cached", func(t *testing.T) {
-		data, err := Load(map[string]afero.Fs{"https": afero.NewMemMapFs()}, resolvedURL, path)
+		data, err := Load(logger, map[string]afero.Fs{"https": afero.NewMemMapFs()}, resolvedURL, path)
 		require.NoError(t, err)
 		assert.Equal(t, data.URL, resolvedURL)
 		assert.Equal(t, path, data.URL.String())
@@ -59,7 +63,7 @@ func TestGithub(t *testing.T) {
 		err := afero.WriteFile(fs, "/github.com/github/gitignore/Go.gitignore", testData, 0644)
 		require.NoError(t, err)
 
-		data, err := Load(map[string]afero.Fs{"https": fs}, resolvedURL, path)
+		data, err := Load(logger, map[string]afero.Fs{"https": fs}, resolvedURL, path)
 		require.NoError(t, err)
 		assert.Equal(t, path, data.URL.String())
 		assert.Equal(t, data.Data, testData)

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -43,7 +43,7 @@ type SourceData struct {
 	URL  *url.URL
 }
 
-type loaderFunc func(path string, parts []string) (string, error)
+type loaderFunc func(logger logrus.FieldLogger, path string, parts []string) (string, error)
 
 //nolint: gochecknoglobals
 var (
@@ -167,9 +167,9 @@ func Dir(old *url.URL) *url.URL {
 // for a given scheme which is they key of the map. If the scheme is https then a request will
 // be made if the files is not found in the map and written to the map.
 func Load(
-	filesystems map[string]afero.Fs, moduleSpecifier *url.URL, originalModuleSpecifier string,
+	logger logrus.FieldLogger, filesystems map[string]afero.Fs, moduleSpecifier *url.URL, originalModuleSpecifier string,
 ) (*SourceData, error) {
-	logrus.WithFields(
+	logger.WithFields(
 		logrus.Fields{
 			"moduleSpecifier":         moduleSpecifier,
 			"originalModuleSpecifier": originalModuleSpecifier,
@@ -207,12 +207,12 @@ func Load(
 
 		switch {
 		case moduleSpecifier.Opaque != "": // This is loader
-			finalModuleSpecifierURL, err = resolveUsingLoaders(moduleSpecifier.Opaque)
+			finalModuleSpecifierURL, err = resolveUsingLoaders(logger, moduleSpecifier.Opaque)
 			if err != nil {
 				return nil, err
 			}
 		case moduleSpecifier.Scheme == "":
-			logrus.Warningf(`The moduleSpecifier "%s" has no scheme but we will try to resolve it as remote module. `+
+			logger.Warningf(`The moduleSpecifier "%s" has no scheme but we will try to resolve it as remote module. `+
 				`This will be deprecated in the future and all remote modules will `+
 				`need to explicitly use "https" as scheme.`, originalModuleSpecifier)
 			*finalModuleSpecifierURL = *moduleSpecifier
@@ -221,7 +221,7 @@ func Load(
 			finalModuleSpecifierURL = moduleSpecifier
 		}
 		var result *SourceData
-		result, err = loadRemoteURL(finalModuleSpecifierURL)
+		result, err = loadRemoteURL(logger, finalModuleSpecifierURL)
 		if err == nil {
 			result.URL = moduleSpecifier
 			// TODO maybe make an afero.Fs which makes request directly and than use CacheOnReadFs
@@ -241,10 +241,10 @@ func Load(
 	return nil, errors.Errorf(fileSchemeCouldntBeLoadedMsg, originalModuleSpecifier)
 }
 
-func resolveUsingLoaders(name string) (*url.URL, error) {
+func resolveUsingLoaders(logger logrus.FieldLogger, name string) (*url.URL, error) {
 	_, loader, loaderArgs := pickLoader(name)
 	if loader != nil {
-		urlString, err := loader(name, loaderArgs)
+		urlString, err := loader(logger, name, loaderArgs)
 		if err != nil {
 			return nil, err
 		}
@@ -254,19 +254,19 @@ func resolveUsingLoaders(name string) (*url.URL, error) {
 	return nil, errNoLoaderMatched
 }
 
-func loadRemoteURL(u *url.URL) (*SourceData, error) {
+func loadRemoteURL(logger logrus.FieldLogger, u *url.URL) (*SourceData, error) {
 	var oldQuery = u.RawQuery
 	if u.RawQuery != "" {
 		u.RawQuery += "&"
 	}
 	u.RawQuery += "_k6=1"
 
-	data, err := fetch(u.String())
+	data, err := fetch(logger, u.String())
 
 	u.RawQuery = oldQuery
 	// If this fails, try to fetch without ?_k6=1 - some sources act weird around unknown GET args.
 	if err != nil {
-		data, err = fetch(u.String())
+		data, err = fetch(logger, u.String())
 		if err != nil {
 			return nil, err
 		}
@@ -289,8 +289,8 @@ func pickLoader(path string) (string, loaderFunc, []string) {
 	return "", nil, nil
 }
 
-func fetch(u string) ([]byte, error) {
-	logrus.WithField("url", u).Debug("Fetching source...")
+func fetch(logger logrus.FieldLogger, u string) ([]byte, error) {
+	logger.WithField("url", u).Debug("Fetching source...")
 	startTime := time.Now()
 	res, err := http.Get(u)
 	if err != nil {
@@ -312,7 +312,7 @@ func fetch(u string) ([]byte, error) {
 		return nil, err
 	}
 
-	logrus.WithFields(logrus.Fields{
+	logger.WithFields(logrus.Fields{
 		"url": u,
 		"t":   time.Since(startTime),
 		"len": len(data),

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -27,10 +27,12 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/loadimpact/k6/lib/testutils"
 	"github.com/loadimpact/k6/lib/testutils/httpmultibin"
 	"github.com/loadimpact/k6/loader"
 )
@@ -101,6 +103,8 @@ func TestResolve(t *testing.T) {
 
 }
 func TestLoad(t *testing.T) {
+	logger := logrus.New()
+	logger.SetOutput(testutils.NewTestOutput(t))
 	tb := httpmultibin.NewHTTPMultiBin(t)
 	sr := tb.Replacer.Replace
 
@@ -132,7 +136,7 @@ func TestLoad(t *testing.T) {
 				moduleURL, err := loader.Resolve(pwdURL, data.path)
 				require.NoError(t, err)
 
-				src, err := loader.Load(filesystems, moduleURL, data.path)
+				src, err := loader.Load(logger, filesystems, moduleURL, data.path)
 				require.NoError(t, err)
 
 				assert.Equal(t, "file:///path/to/file.txt", src.URL.String())
@@ -148,7 +152,7 @@ func TestLoad(t *testing.T) {
 			pathURL, err := loader.Resolve(root, "/nonexistent")
 			require.NoError(t, err)
 
-			_, err = loader.Load(filesystems, pathURL, path)
+			_, err = loader.Load(logger, filesystems, pathURL, path)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(),
 				fmt.Sprintf(`The moduleSpecifier "%s" couldn't be found on local disk. `,
@@ -166,7 +170,7 @@ func TestLoad(t *testing.T) {
 			moduleSpecifierURL, err := loader.Resolve(root, moduleSpecifier)
 			require.NoError(t, err)
 
-			src, err := loader.Load(filesystems, moduleSpecifierURL, moduleSpecifier)
+			src, err := loader.Load(logger, filesystems, moduleSpecifierURL, moduleSpecifier)
 			require.NoError(t, err)
 			assert.Equal(t, src.URL, moduleSpecifierURL)
 			assert.Contains(t, string(src.Data), "Herman Melville - Moby-Dick")
@@ -180,7 +184,7 @@ func TestLoad(t *testing.T) {
 			moduleSpecifierURL, err := loader.Resolve(pwdURL, moduleSpecifier)
 			require.NoError(t, err)
 
-			src, err := loader.Load(filesystems, moduleSpecifierURL, moduleSpecifier)
+			src, err := loader.Load(logger, filesystems, moduleSpecifierURL, moduleSpecifier)
 			require.NoError(t, err)
 			assert.Equal(t, src.URL.String(), sr("HTTPSBIN_URL/robots.txt"))
 			assert.Equal(t, string(src.Data), "User-agent: *\nDisallow: /deny\n")
@@ -194,7 +198,7 @@ func TestLoad(t *testing.T) {
 			moduleSpecifierURL, err := loader.Resolve(pwdURL, moduleSpecifier)
 			require.NoError(t, err)
 
-			src, err := loader.Load(filesystems, moduleSpecifierURL, moduleSpecifier)
+			src, err := loader.Load(logger, filesystems, moduleSpecifierURL, moduleSpecifier)
 			require.NoError(t, err)
 			assert.Equal(t, sr("HTTPSBIN_URL/robots.txt"), src.URL.String())
 			assert.Equal(t, "User-agent: *\nDisallow: /deny\n", string(src.Data))
@@ -220,7 +224,7 @@ func TestLoad(t *testing.T) {
 		require.NoError(t, err)
 
 		filesystems := map[string]afero.Fs{"https": afero.NewMemMapFs()}
-		src, err := loader.Load(filesystems, moduleSpecifierURL, moduleSpecifier)
+		src, err := loader.Load(logger, filesystems, moduleSpecifierURL, moduleSpecifier)
 
 		require.NoError(t, err)
 		assert.Equal(t, src.URL.String(), sr("HTTPSBIN_URL/raw/something"))
@@ -255,7 +259,7 @@ func TestLoad(t *testing.T) {
 				moduleSpecifierURL, err := loader.Resolve(root, moduleSpecifier)
 				require.NoError(t, err)
 
-				_, err = loader.Load(filesystems, moduleSpecifierURL, moduleSpecifier)
+				_, err = loader.Load(logger, filesystems, moduleSpecifierURL, moduleSpecifier)
 				require.Error(t, err)
 			})
 		}

--- a/loader/readsource_test.go
+++ b/loader/readsource_test.go
@@ -44,16 +44,20 @@ func (e errorReader) Read(_ []byte) (int, error) {
 var _ io.Reader = errorReader("")
 
 func TestReadSourceSTDINError(t *testing.T) {
-	_, err := ReadSource(nil, "-", "", nil, errorReader("1234"))
+	logger := logrus.New()
+	logger.SetOutput(testutils.NewTestOutput(t))
+	_, err := ReadSource(logger, "-", "", nil, errorReader("1234"))
 	require.Error(t, err)
 	require.Equal(t, "1234", err.Error())
 }
 
 func TestReadSourceSTDINCache(t *testing.T) {
+	logger := logrus.New()
+	logger.SetOutput(testutils.NewTestOutput(t))
 	var data = []byte(`test contents`)
 	var r = bytes.NewReader(data)
 	var fs = afero.NewMemMapFs()
-	sourceData, err := ReadSource(nil, "-", "/path/to/pwd",
+	sourceData, err := ReadSource(logger, "-", "/path/to/pwd",
 		map[string]afero.Fs{"file": fsext.NewCacheOnReadFs(nil, fs, 0)}, r)
 	require.NoError(t, err)
 	require.Equal(t, &SourceData{


### PR DESCRIPTION
This doesn't change anything functionally just removes the (direct) usage of the global logrus logger from the loader module. 

I debated refactoring the module into a struct again that takes a `logger` but decided that will be MUCH bigger change with literally no benefits apart from removing 1 argument from a couple of function calls, only 2 of which actually get called outside the module.