### PR TITLE
Make __VU available in init context

### DIFF
--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -436,7 +436,7 @@ func TestNewBundleFromArchive(t *testing.T) {
 		assert.Equal(t, lib.Options{VUs: null.IntFrom(12345)}, b.Options)
 		bi, err := b.Instantiate()
 		require.NoError(t, err)
-		val, err := bi.exports["default"](goja.Undefined())
+		val, err := bi.exports[consts.DefaultFn](goja.Undefined())
 		require.NoError(t, err)
 		assert.Equal(t, "hi!", val.Export())
 	}
@@ -669,7 +669,7 @@ func TestOpen(t *testing.T) {
 						t.Run(source, func(t *testing.T) {
 							bi, err := b.Instantiate()
 							require.NoError(t, err)
-							v, err := bi.exports["default"](goja.Undefined())
+							v, err := bi.exports[consts.DefaultFn](goja.Undefined())
 							require.NoError(t, err)
 							assert.Equal(t, "hi", v.Export())
 						})
@@ -707,7 +707,7 @@ func TestBundleInstantiate(t *testing.T) {
 	}
 
 	t.Run("Run", func(t *testing.T) {
-		v, err := bi.exports["default"](goja.Undefined())
+		v, err := bi.exports[consts.DefaultFn](goja.Undefined())
 		if assert.NoError(t, err) {
 			assert.Equal(t, true, v.Export())
 		}
@@ -715,7 +715,7 @@ func TestBundleInstantiate(t *testing.T) {
 
 	t.Run("SetAndRun", func(t *testing.T) {
 		bi.Runtime.Set("val", false)
-		v, err := bi.exports["default"](goja.Undefined())
+		v, err := bi.exports[consts.DefaultFn](goja.Undefined())
 		if assert.NoError(t, err) {
 			assert.Equal(t, false, v.Export())
 		}
@@ -770,7 +770,7 @@ func TestBundleEnv(t *testing.T) {
 
 			bi, err := b.Instantiate()
 			if assert.NoError(t, err) {
-				_, err := bi.exports["default"](goja.Undefined())
+				_, err := bi.exports[consts.DefaultFn](goja.Undefined())
 				assert.NoError(t, err)
 			}
 		})
@@ -811,7 +811,7 @@ func TestBundleNotSharable(t *testing.T) {
 				require.NoError(t, err)
 				for j := 0; j < iters; j++ {
 					bi.Runtime.Set("__ITER", j)
-					_, err := bi.exports["default"](goja.Undefined())
+					_, err := bi.exports[consts.DefaultFn](goja.Undefined())
 					assert.NoError(t, err)
 				}
 			}

--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -434,7 +434,7 @@ func TestNewBundleFromArchive(t *testing.T) {
 
 	checkBundle := func(t *testing.T, b *Bundle) {
 		assert.Equal(t, lib.Options{VUs: null.IntFrom(12345)}, b.Options)
-		bi, err := b.Instantiate()
+		bi, err := b.Instantiate(0)
 		require.NoError(t, err)
 		val, err := bi.exports[consts.DefaultFn](goja.Undefined())
 		require.NoError(t, err)
@@ -527,7 +527,7 @@ func TestNewBundleFromArchive(t *testing.T) {
 		}
 		b, err := NewBundleFromArchive(arc, lib.RuntimeOptions{})
 		require.NoError(t, err)
-		bi, err := b.Instantiate()
+		bi, err := b.Instantiate(0)
 		require.NoError(t, err)
 		val, err := bi.exports[consts.DefaultFn](goja.Undefined())
 		require.NoError(t, err)
@@ -667,7 +667,7 @@ func TestOpen(t *testing.T) {
 					for source, b := range map[string]*Bundle{"source": sourceBundle, "archive": arcBundle} {
 						b := b
 						t.Run(source, func(t *testing.T) {
-							bi, err := b.Instantiate()
+							bi, err := b.Instantiate(0)
 							require.NoError(t, err)
 							v, err := bi.exports[consts.DefaultFn](goja.Undefined())
 							require.NoError(t, err)
@@ -701,7 +701,7 @@ func TestBundleInstantiate(t *testing.T) {
 		return
 	}
 
-	bi, err := b.Instantiate()
+	bi, err := b.Instantiate(0)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -732,7 +732,7 @@ func TestBundleInstantiate(t *testing.T) {
 		// Ensure options propagate correctly from outside to the script
 		optOrig := b.Options.VUs
 		b.Options.VUs = null.IntFrom(10)
-		bi2, err := b.Instantiate()
+		bi2, err := b.Instantiate(0)
 		assert.NoError(t, err)
 		jsOptions = bi2.Runtime.Get("options").ToObject(bi2.Runtime)
 		vus = jsOptions.Get("vus").Export()
@@ -764,11 +764,12 @@ func TestBundleEnv(t *testing.T) {
 
 	bundles := map[string]*Bundle{"Source": b1, "Archive": b2}
 	for name, b := range bundles {
+		b := b
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, "1", b.Env["TEST_A"])
 			assert.Equal(t, "", b.Env["TEST_B"])
 
-			bi, err := b.Instantiate()
+			bi, err := b.Instantiate(0)
 			if assert.NoError(t, err) {
 				_, err := bi.exports[consts.DefaultFn](goja.Undefined())
 				assert.NoError(t, err)
@@ -806,8 +807,7 @@ func TestBundleNotSharable(t *testing.T) {
 		b := b
 		t.Run(name, func(t *testing.T) {
 			for i := 0; i < vus; i++ {
-				bi, err := b.Instantiate()
-				bi.Runtime.Set("__VU", i)
+				bi, err := b.Instantiate(int64(i))
 				require.NoError(t, err)
 				for j := 0; j < iters; j++ {
 					bi.Runtime.Set("__ITER", j)

--- a/js/initcontext_test.go
+++ b/js/initcontext_test.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/loadimpact/k6/js/common"
 	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/consts"
 	"github.com/loadimpact/k6/lib/netext"
 	"github.com/loadimpact/k6/stats"
 )
@@ -229,7 +230,7 @@ func TestInitContextRequire(t *testing.T) {
 			if !assert.NoError(t, err) {
 				return
 			}
-			_, err = bi.exports["default"](goja.Undefined())
+			_, err = bi.exports[consts.DefaultFn](goja.Undefined())
 			assert.NoError(t, err)
 		})
 	})
@@ -401,7 +402,7 @@ func TestRequestWithBinaryFile(t *testing.T) {
 	ctx = common.WithRuntime(ctx, bi.Runtime)
 	*bi.Context = ctx
 
-	v, err := bi.exports["default"](goja.Undefined())
+	v, err := bi.exports[consts.DefaultFn](goja.Undefined())
 	assert.NoError(t, err)
 	assert.NotNil(t, v)
 	assert.Equal(t, true, v.Export())

--- a/js/initcontext_test.go
+++ b/js/initcontext_test.go
@@ -63,7 +63,7 @@ func TestInitContextRequire(t *testing.T) {
 				return
 			}
 
-			bi, err := b.Instantiate()
+			bi, err := b.Instantiate(0)
 			if !assert.NoError(t, err, "instance error") {
 				return
 			}
@@ -92,7 +92,7 @@ func TestInitContextRequire(t *testing.T) {
 					return
 				}
 
-				bi, err := b.Instantiate()
+				bi, err := b.Instantiate(0)
 				if !assert.NoError(t, err) {
 					return
 				}
@@ -200,7 +200,7 @@ func TestInitContextRequire(t *testing.T) {
 							assert.Contains(t, b.BaseInitContext.programs, "file://"+constPath)
 						}
 
-						_, err = b.Instantiate()
+						_, err = b.Instantiate(0)
 						if !assert.NoError(t, err) {
 							return
 						}
@@ -226,7 +226,7 @@ func TestInitContextRequire(t *testing.T) {
 				return
 			}
 
-			bi, err := b.Instantiate()
+			bi, err := b.Instantiate(0)
 			if !assert.NoError(t, err) {
 				return
 			}
@@ -260,7 +260,7 @@ func createAndReadFile(t *testing.T, file string, content []byte, expectedLength
 		return nil, err
 	}
 
-	bi, err := b.Instantiate()
+	bi, err := b.Instantiate(0)
 	if !assert.NoError(t, err) {
 		return nil, err
 	}
@@ -372,7 +372,7 @@ func TestRequestWithBinaryFile(t *testing.T) {
 			`, srv.URL), fs)
 	require.NoError(t, err)
 
-	bi, err := b.Instantiate()
+	bi, err := b.Instantiate(0)
 	assert.NoError(t, err)
 
 	root, err := lib.NewGroup("", nil)
@@ -408,4 +408,17 @@ func TestRequestWithBinaryFile(t *testing.T) {
 	assert.Equal(t, true, v.Export())
 
 	<-ch
+}
+
+func TestInitContextVU(t *testing.T) {
+	b, err := getSimpleBundle("/script.js", `
+		let vu = __VU;
+		export default function() { return vu; }
+	`)
+	require.NoError(t, err)
+	bi, err := b.Instantiate(5)
+	require.NoError(t, err)
+	v, err := bi.exports[consts.DefaultFn](goja.Undefined())
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), v.Export())
 }

--- a/js/runner.go
+++ b/js/runner.go
@@ -123,7 +123,7 @@ func (r *Runner) NewVU(id int64, samplesOut chan<- stats.SampleContainer) (lib.I
 // nolint:funlen
 func (r *Runner) newVU(id int64, samplesOut chan<- stats.SampleContainer) (*VU, error) {
 	// Instantiate a new bundle, make a VU out of it.
-	bi, err := r.Bundle.Instantiate()
+	bi, err := r.Bundle.Instantiate(id)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +211,6 @@ func (r *Runner) newVU(id int64, samplesOut chan<- stats.SampleContainer) (*VU, 
 		Tags:      vu.Runner.Bundle.Options.RunTags.CloneTags(),
 		Group:     r.defaultGroup,
 	}
-	vu.Runtime.Set("__VU", vu.ID)
 	vu.Runtime.Set("console", common.Bind(vu.Runtime, vu.Console, vu.Context))
 
 	// This is here mostly so if someone tries they get a nice message


### PR DESCRIPTION
Closes #889

I started adding more tests for this, but a `js.Runner` test would basically be a duplicate of the `TestInitContextVU` one, and a higher level one to replicate the example in the issue would need to involve an executor, and those tests rely on `MiniRunner` which kind of defeats the purpose. Still, let me know if there should be other cases covered.