### PR TITLE
Add an arm64 build for linux to the semi-automated script

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -82,6 +82,7 @@ build_dist win32   zip .exe GOOS=windows GOARCH=386
 build_dist win64   zip .exe GOOS=windows GOARCH=amd64
 build_dist linux32 tgz ""   GOOS=linux   GOARCH=386    CGO_ENABLED=0
 build_dist linux64 tgz ""   GOOS=linux   GOARCH=amd64  CGO_ENABLED=0
+build_dist arm64   tgz ""   GOOS=linux   GOARCH=arm64  CGO_ENABLED=0
 
 echo "-> Generating checksum file..."
 checksum


### PR DESCRIPTION
I briefly tested this on my phone, `k6 version` at least seems to work. Closes https://github.com/loadimpact/k6/issues/842