### PR TITLE
Fix UI panic and login errors on mintty/Windows

### DIFF
--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -22,10 +22,13 @@ package cmd
 
 import (
 	"os"
+	"syscall"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh/terminal"
 	"gopkg.in/guregu/null.v3"
 
 	"github.com/loadimpact/k6/lib/consts"
@@ -51,6 +54,8 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
   k6 login cloud`[1:],
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// TODO: don't use a global... or maybe change the logger?
+		logger := logrus.StandardLogger()
 		fs := afero.NewOsFs()
 
 		k6Conf, err := getConsolidatedConfig(fs, Config{}, nil)
@@ -88,6 +93,9 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 						Label: "Password",
 					},
 				},
+			}
+			if !terminal.IsTerminal(syscall.Stdin) {
+				logger.Warn("Stdin is not a terminal, falling back to plain text input")
 			}
 			vals, err := form.Run(os.Stdin, stdout)
 			if err != nil {

--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -94,7 +94,7 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 					},
 				},
 			}
-			if !terminal.IsTerminal(syscall.Stdin) {
+			if !terminal.IsTerminal(int(syscall.Stdin)) { // nolint: unconvert
 				logger.Warn("Stdin is not a terminal, falling back to plain text input")
 			}
 			vals, err := form.Run(os.Stdin, stdout)

--- a/cmd/login_influxdb.go
+++ b/cmd/login_influxdb.go
@@ -85,7 +85,7 @@ This will set the default server used when just "-o influxdb" is passed.`,
 				},
 			},
 		}
-		if !terminal.IsTerminal(syscall.Stdin) {
+		if !terminal.IsTerminal(int(syscall.Stdin)) { // nolint: unconvert
 			logger.Warn("Stdin is not a terminal, falling back to plain text input")
 		}
 		vals, err := form.Run(os.Stdin, stdout)

--- a/cmd/login_influxdb.go
+++ b/cmd/login_influxdb.go
@@ -22,11 +22,14 @@ package cmd
 
 import (
 	"os"
+	"syscall"
 	"time"
 
 	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/stats/influxdb"
@@ -42,6 +45,8 @@ var loginInfluxDBCommand = &cobra.Command{
 This will set the default server used when just "-o influxdb" is passed.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// TODO: don't use a global... or maybe change the logger?
+		logger := logrus.StandardLogger()
 		fs := afero.NewOsFs()
 		config, configPath, err := readDiskConfig(fs)
 		if err != nil {
@@ -79,6 +84,9 @@ This will set the default server used when just "-o influxdb" is passed.`,
 					Label: "Password",
 				},
 			},
+		}
+		if !terminal.IsTerminal(syscall.Stdin) {
+			logger.Warn("Stdin is not a terminal, falling back to plain text input")
 		}
 		vals, err := form.Run(os.Stdin, stdout)
 		if err != nil {


### PR DESCRIPTION
Closes #1559

Confirmed working on the latest Git Bash (2.27.0) and mintty 3.1.6 on Windows 10 x64 1903.

The "error getting terminal size" warning will still be shown and the progressbars will be static, but at least it doesn't panic :sweat_smile: