### PR TITLE
Flaky test fixes

### DIFF
--- a/lib/executor/constant_vus_test.go
+++ b/lib/executor/constant_vus_test.go
@@ -36,7 +36,7 @@ import (
 
 func getTestConstantVUsConfig() ConstantVUsConfig {
 	return ConstantVUsConfig{
-		BaseConfig: BaseConfig{GracefulStop: types.NullDurationFrom(1 * time.Second)},
+		BaseConfig: BaseConfig{GracefulStop: types.NullDurationFrom(100 * time.Millisecond)},
 		VUs:        null.IntFrom(10),
 		Duration:   types.NullDurationFrom(1 * time.Second),
 	}

--- a/lib/executor/per_vu_iterations_test.go
+++ b/lib/executor/per_vu_iterations_test.go
@@ -63,7 +63,8 @@ func TestPerVUIterationsRun(t *testing.T) {
 		}),
 	)
 	defer cancel()
-	err = executor.Run(ctx, nil)
+	engineOut := make(chan stats.SampleContainer, 1000)
+	err = executor.Run(ctx, engineOut)
 	require.NoError(t, err)
 
 	var totalIters uint64
@@ -105,7 +106,8 @@ func TestPerVUIterationsRunVariableVU(t *testing.T) {
 		}),
 	)
 	defer cancel()
-	err = executor.Run(ctx, nil)
+	engineOut := make(chan stats.SampleContainer, 1000)
+	err = executor.Run(ctx, engineOut)
 	require.NoError(t, err)
 
 	val, ok := result.Load(slowVUID)

--- a/lib/executor/ramping_arrival_rate_test.go
+++ b/lib/executor/ramping_arrival_rate_test.go
@@ -164,19 +164,19 @@ func TestRampingArrivalRateRunUnplannedVUs(t *testing.T) {
 		},
 		es, runner)
 	defer cancel()
-	var engineOut = make(chan stats.SampleContainer, 1000)
+	engineOut := make(chan stats.SampleContainer, 1000)
 	es.SetInitVUFunc(func(_ context.Context, logger *logrus.Entry) (lib.InitializedVU, error) {
 		cur := atomic.LoadInt64(&count)
 		require.Equal(t, cur, int64(1))
 		time.Sleep(time.Second / 2)
 
 		close(ch)
-		time.Sleep(time.Millisecond * 50)
+		time.Sleep(time.Millisecond * 150)
 
 		cur = atomic.LoadInt64(&count)
 		require.Equal(t, cur, int64(2))
 
-		time.Sleep(time.Millisecond * 50)
+		time.Sleep(time.Millisecond * 150)
 		cur = atomic.LoadInt64(&count)
 		require.Equal(t, cur, int64(2))
 


### PR DESCRIPTION
this also fixes a  (very unlikely to be noticed issue) in per-vu-iterations where some/all `droppedIterations` metrics might not be emitted in time:
for release notes, under bugs:
```
fix unlikely case where droppedIterations won't be emitted by per-vu-iterations on time
```