### PR TITLE
Fix wrong name tag for HTTP metrics from redirects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ test.debug
 
 .vscode
 *.sublime-workspace
+*.log
 .idea
 .vagrant
 

--- a/lib/netext/httpext/transport.go
+++ b/lib/netext/httpext/transport.go
@@ -115,9 +115,23 @@ func (t *transport) measureAndEmitMetrics(unfReq *unfinishedRequest) *finishedRe
 			tags["status"] = "0"
 		}
 	} else {
-		if enabledTags.Has(stats.TagURL) {
-			u := URL{u: unfReq.request.URL, URL: unfReq.request.URL.String()}
-			tags["url"] = u.Clean()
+		urlEnabled := enabledTags.Has(stats.TagURL)
+		var setName bool
+		if _, ok := tags["name"]; !ok && enabledTags.Has(stats.TagName) {
+			setName = true
+		}
+		if urlEnabled || setName {
+			cleanURL := URL{u: unfReq.request.URL, URL: unfReq.request.URL.String()}.Clean()
+			if urlEnabled {
+				tags["url"] = cleanURL
+			}
+			if setName {
+				tags["name"] = cleanURL
+			}
+		}
+
+		if enabledTags.Has(stats.TagMethod) {
+			tags["method"] = unfReq.request.Method
 		}
 		if enabledTags.Has(stats.TagStatus) {
 			tags["status"] = strconv.Itoa(unfReq.response.StatusCode)


### PR DESCRIPTION
Closes #1474

The root cause was reusing the same 'name' tag for all requests processed by a transport. In the case of redirects and digest auth the transport would process more than one request and needs to update the 'name' tag in the same way as 'url' is. For the initial request we need the originally parsed one to be consistent with the credential masking feature (as this gets stripped in the request passed to `RoundTrip()`), and tags for subsequent requests will be dynamically generated.

I'm not sure if this confirms @MStoykov's gut feeling that it will break aggregation somehow, but I'd argue this is the correct approach so we'll have to deal with it. :smile:

I didn't add more tests for this as the current ones are quite thorough.