### PR TITLE
Rewrite js test to not fail with the goja es6 branch

### DIFF
--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -117,7 +117,8 @@ func TestNewBundle(t *testing.T) {
 				CompatibilityMode: null.StringFrom(lib.CompatibilityModeExtended.String()),
 			}
 			_, err := getSimpleBundle("/script.js",
-				`export default function() {}; new Set([1, 2, 3, 2, 1]);`, rtOpts)
+				`module.exports.default = function() {}; new Promise(function(resolve, reject){});`, rtOpts)
+
 			assert.NoError(t, err)
 		})
 		t.Run("Base/ok/Minimal", func(t *testing.T) {
@@ -150,11 +151,11 @@ func TestNewBundle(t *testing.T) {
 					`module.exports.default = function() {}; () => {};`,
 					"file:///script.js: Line 1:42 Unexpected token ) (and 1 more errors)",
 				},
-				// ES2015 objects polyfilled by core.js are not supported
+				// some ES2015 objects polyfilled by core.js are not supported
 				{
 					"CoreJS", "base",
-					`module.exports.default = function() {}; new Set([1, 2, 3, 2, 1]);`,
-					"ReferenceError: Set is not defined at file:///script.js:1:45(5)",
+					`module.exports.default = function() {}; new Promise(function(resolve, reject){});`,
+					"ReferenceError: Promise is not defined at file:///script.js:1:45(5)",
 				},
 			}
 

--- a/js/common/bridge_test.go
+++ b/js/common/bridge_test.go
@@ -348,7 +348,7 @@ func TestBind(t *testing.T) {
 		}},
 		{"Error", bridgeTestErrorType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
 			_, err := RunString(rt, `obj.error()`)
-			assert.EqualError(t, err, "GoError: error")
+			assert.Contains(t, err.Error(), "GoError: error")
 		}},
 		{"JSValue", bridgeTestJSValueType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
 			v, err := RunString(rt, `obj.func(1234)`)
@@ -358,7 +358,7 @@ func TestBind(t *testing.T) {
 		}},
 		{"JSValueError", bridgeTestJSValueErrorType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
 			_, err := RunString(rt, `obj.func()`)
-			assert.EqualError(t, err, "GoError: missing argument")
+			assert.Contains(t, err.Error(), "GoError: missing argument")
 
 			t.Run("Valid", func(t *testing.T) {
 				v, err := RunString(rt, `obj.func(1234)`)
@@ -369,7 +369,7 @@ func TestBind(t *testing.T) {
 		}},
 		{"JSValueContext", bridgeTestJSValueContextType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
 			_, err := RunString(rt, `obj.func()`)
-			assert.EqualError(t, err, "GoError: func() can only be called from within default()")
+			assert.Contains(t, err.Error(), "GoError: func() can only be called from within default()")
 
 			t.Run("Context", func(t *testing.T) {
 				*ctxPtr = context.Background()
@@ -383,14 +383,14 @@ func TestBind(t *testing.T) {
 		}},
 		{"JSValueContextError", bridgeTestJSValueContextErrorType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
 			_, err := RunString(rt, `obj.func()`)
-			assert.EqualError(t, err, "GoError: func() can only be called from within default()")
+			assert.Contains(t, err.Error(), "GoError: func() can only be called from within default()")
 
 			t.Run("Context", func(t *testing.T) {
 				*ctxPtr = context.Background()
 				defer func() { *ctxPtr = nil }()
 
 				_, err := RunString(rt, `obj.func()`)
-				assert.EqualError(t, err, "GoError: missing argument")
+				assert.Contains(t, err.Error(), "GoError: missing argument")
 
 				t.Run("Valid", func(t *testing.T) {
 					v, err := RunString(rt, `obj.func(1234)`)
@@ -408,7 +408,7 @@ func TestBind(t *testing.T) {
 		}},
 		{"NativeFunctionError", bridgeTestNativeFunctionErrorType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
 			_, err := RunString(rt, `obj.func()`)
-			assert.EqualError(t, err, "GoError: missing argument")
+			assert.Contains(t, err.Error(), "GoError: missing argument")
 
 			t.Run("Valid", func(t *testing.T) {
 				v, err := RunString(rt, `obj.func(1234)`)
@@ -419,7 +419,7 @@ func TestBind(t *testing.T) {
 		}},
 		{"NativeFunctionContext", bridgeTestNativeFunctionContextType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
 			_, err := RunString(rt, `obj.func()`)
-			assert.EqualError(t, err, "GoError: func() can only be called from within default()")
+			assert.Contains(t, err.Error(), "GoError: func() can only be called from within default()")
 
 			t.Run("Context", func(t *testing.T) {
 				*ctxPtr = context.Background()
@@ -433,14 +433,14 @@ func TestBind(t *testing.T) {
 		}},
 		{"NativeFunctionContextError", bridgeTestNativeFunctionContextErrorType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
 			_, err := RunString(rt, `obj.func()`)
-			assert.EqualError(t, err, "GoError: func() can only be called from within default()")
+			assert.Contains(t, err.Error(), "GoError: func() can only be called from within default()")
 
 			t.Run("Context", func(t *testing.T) {
 				*ctxPtr = context.Background()
 				defer func() { *ctxPtr = nil }()
 
 				_, err := RunString(rt, `obj.func()`)
-				assert.EqualError(t, err, "GoError: missing argument")
+				assert.Contains(t, err.Error(), "GoError: missing argument")
 
 				t.Run("Valid", func(t *testing.T) {
 					v, err := RunString(rt, `obj.func(1234)`)
@@ -464,7 +464,7 @@ func TestBind(t *testing.T) {
 
 			t.Run("Negative", func(t *testing.T) {
 				_, err := RunString(rt, `obj.addWithError(0, -1)`)
-				assert.EqualError(t, err, "GoError: answer is negative")
+				assert.Contains(t, err.Error(), "GoError: answer is negative")
 			})
 		}},
 		{"AddWithError", bridgeTestAddWithErrorType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
@@ -475,12 +475,12 @@ func TestBind(t *testing.T) {
 
 			t.Run("Negative", func(t *testing.T) {
 				_, err := RunString(rt, `obj.addWithError(0, -1)`)
-				assert.EqualError(t, err, "GoError: answer is negative")
+				assert.Contains(t, err.Error(), "GoError: answer is negative")
 			})
 		}},
 		{"Context", bridgeTestContextType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
 			_, err := RunString(rt, `obj.context()`)
-			assert.EqualError(t, err, "GoError: context() can only be called from within default()")
+			assert.Contains(t, err.Error(), "GoError: context() can only be called from within default()")
 
 			t.Run("Valid", func(t *testing.T) {
 				*ctxPtr = context.Background()
@@ -492,7 +492,7 @@ func TestBind(t *testing.T) {
 		}},
 		{"ContextAdd", bridgeTestContextAddType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
 			_, err := RunString(rt, `obj.contextAdd(1, 2)`)
-			assert.EqualError(t, err, "GoError: contextAdd() can only be called from within default()")
+			assert.Contains(t, err.Error(), "GoError: contextAdd() can only be called from within default()")
 
 			t.Run("Valid", func(t *testing.T) {
 				*ctxPtr = context.Background()
@@ -506,7 +506,7 @@ func TestBind(t *testing.T) {
 		}},
 		{"ContextAddWithError", bridgeTestContextAddWithErrorType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
 			_, err := RunString(rt, `obj.contextAddWithError(1, 2)`)
-			assert.EqualError(t, err, "GoError: contextAddWithError() can only be called from within default()")
+			assert.Contains(t, err.Error(), "GoError: contextAddWithError() can only be called from within default()")
 
 			t.Run("Valid", func(t *testing.T) {
 				*ctxPtr = context.Background()
@@ -519,7 +519,7 @@ func TestBind(t *testing.T) {
 
 				t.Run("Negative", func(t *testing.T) {
 					_, err := RunString(rt, `obj.contextAddWithError(0, -1)`)
-					assert.EqualError(t, err, "GoError: answer is negative")
+					assert.Contains(t, err.Error(), "GoError: answer is negative")
 				})
 			})
 		}},
@@ -529,7 +529,7 @@ func TestBind(t *testing.T) {
 			case bridgeTestContextInjectType:
 				assert.EqualError(t, err, "TypeError: Object has no member 'contextInject' at <eval>:1:18(3)")
 			case *bridgeTestContextInjectType:
-				assert.EqualError(t, err, "GoError: contextInject() can only be called from within default()")
+				assert.Contains(t, err.Error(), "GoError: contextInject() can only be called from within default()")
 				assert.Equal(t, nil, impl.ctx)
 
 				t.Run("Valid", func(t *testing.T) {
@@ -588,7 +588,7 @@ func TestBind(t *testing.T) {
 		}},
 		{"SumWithContext", bridgeTestSumWithContextType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
 			_, err := RunString(rt, `obj.sumWithContext(1, 2)`)
-			assert.EqualError(t, err, "GoError: sumWithContext() can only be called from within default()")
+			assert.Contains(t, err.Error(), "GoError: sumWithContext() can only be called from within default()")
 
 			t.Run("Valid", func(t *testing.T) {
 				*ctxPtr = context.Background()
@@ -626,7 +626,7 @@ func TestBind(t *testing.T) {
 		}},
 		{"SumWithContextAndError", bridgeTestSumWithContextAndErrorType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
 			_, err := RunString(rt, `obj.sumWithContextAndError(1, 2)`)
-			assert.EqualError(t, err, "GoError: sumWithContextAndError() can only be called from within default()")
+			assert.Contains(t, err.Error(), "GoError: sumWithContextAndError() can only be called from within default()")
 
 			t.Run("Valid", func(t *testing.T) {
 				*ctxPtr = context.Background()

--- a/js/initcontext_test.go
+++ b/js/initcontext_test.go
@@ -49,7 +49,7 @@ func TestInitContextRequire(t *testing.T) {
 	t.Run("Modules", func(t *testing.T) {
 		t.Run("Nonexistent", func(t *testing.T) {
 			_, err := getSimpleBundle("/script.js", `import "k6/NONEXISTENT";`)
-			assert.EqualError(t, err, "GoError: unknown builtin module: k6/NONEXISTENT")
+			assert.Contains(t, err.Error(), "GoError: unknown builtin module: k6/NONEXISTENT")
 		})
 
 		t.Run("k6", func(t *testing.T) {
@@ -315,7 +315,7 @@ func TestInitContextOpen(t *testing.T) {
 	t.Run("Nonexistent", func(t *testing.T) {
 		path := filepath.FromSlash("/nonexistent.txt")
 		_, err := getSimpleBundle("/script.js", `open("/nonexistent.txt"); export default function() {}`)
-		assert.EqualError(t, err, fmt.Sprintf("GoError: open %s: file does not exist", path))
+		assert.Contains(t, err.Error(), fmt.Sprintf("GoError: open %s: file does not exist", path))
 	})
 
 	t.Run("Directory", func(t *testing.T) {
@@ -323,7 +323,7 @@ func TestInitContextOpen(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		assert.NoError(t, fs.MkdirAll(path, 0755))
 		_, err := getSimpleBundle("/script.js", `open("/some/dir"); export default function() {}`, fs)
-		assert.EqualError(t, err, fmt.Sprintf("GoError: open() can't be used with directories, path: %q", path))
+		assert.Contains(t, err.Error(), fmt.Sprintf("GoError: open() can't be used with directories, path: %q", path))
 	})
 }
 

--- a/js/modules/k6/crypto/crypto_test.go
+++ b/js/modules/k6/crypto/crypto_test.go
@@ -316,7 +316,7 @@ func TestOutputEncoding(t *testing.T) {
 		hasher.update("hello world");
 		hasher.digest("someInvalidEncoding");
 		`)
-		assert.EqualError(t, err, "GoError: Invalid output encoding: someInvalidEncoding")
+		assert.Contains(t, err.Error(), "GoError: Invalid output encoding: someInvalidEncoding")
 	})
 }
 
@@ -382,6 +382,7 @@ func TestHMac(t *testing.T) {
 		"sha348": "d331e169e2dcfc742e80a3bf4dcc76d0e6425ab3777a3ac217ac6b2552aad5529ed4d40135b06e53a495ac7425d1e462",
 	}
 	for algorithm, value := range invalidData {
+		algorithm := algorithm
 		rt.Set("correctHex", rt.ToValue(value))
 		rt.Set("algorithm", rt.ToValue(algorithm))
 		t.Run(algorithm+" hasher: invalid", func(t *testing.T) {
@@ -394,7 +395,7 @@ func TestHMac(t *testing.T) {
 				throw new Error("Hex encoding mismatch: " + resultHex);
 			}`)
 
-			assert.EqualError(t, err, "GoError: Invalid algorithm: "+algorithm)
+			assert.Contains(t, err.Error(), "GoError: Invalid algorithm: "+algorithm)
 		})
 
 		t.Run(algorithm+" wrapper: invalid", func(t *testing.T) {
@@ -404,7 +405,7 @@ func TestHMac(t *testing.T) {
 				throw new Error("Hex encoding mismatch: " + resultHex);
 			}`)
 
-			assert.EqualError(t, err, "GoError: Invalid algorithm: "+algorithm)
+			assert.Contains(t, err.Error(), "GoError: Invalid algorithm: "+algorithm)
 		})
 	}
 }

--- a/js/modules/k6/crypto/x509/x509_test.go
+++ b/js/modules/k6/crypto/x509/x509_test.go
@@ -149,8 +149,8 @@ func TestParse(t *testing.T) {
 	t.Run("DecodeFailure", func(t *testing.T) {
 		_, err := common.RunString(rt, `
 		x509.parse("bad-certificate");`)
-		assert.EqualError(
-			t, err, "GoError: failed to decode certificate PEM file")
+		assert.Contains(
+			t, err.Error(), "GoError: failed to decode certificate PEM file")
 	})
 
 	t.Run("ParseFailure", func(t *testing.T) {

--- a/js/modules/k6/http/response_test.go
+++ b/js/modules/k6/http/response_test.go
@@ -198,13 +198,13 @@ func TestResponse(t *testing.T) {
 		t.Run("Invalid", func(t *testing.T) {
 			_, err := common.RunString(rt, sr(`http.request("GET", "HTTPBIN_URL/html").json();`))
 			//nolint:lll
-			assert.EqualError(t, err, "GoError: cannot parse json due to an error at line 1, character 2 , error: invalid character '<' looking for beginning of value")
+			assert.Contains(t, err.Error(), "GoError: cannot parse json due to an error at line 1, character 2 , error: invalid character '<' looking for beginning of value")
 		})
 
 		t.Run("Invalid", func(t *testing.T) {
 			_, err := common.RunString(rt, sr(`http.request("GET", "HTTPBIN_URL/invalidjson").json();`))
 			//nolint:lll
-			assert.EqualError(t, err, "GoError: cannot parse json due to an error at line 3, character 9 , error: invalid character 'e' in literal true (expecting 'r')")
+			assert.Contains(t, err.Error(), "GoError: cannot parse json due to an error at line 3, character 9 , error: invalid character 'e' in literal true (expecting 'r')")
 		})
 	})
 	t.Run("JsonSelector", func(t *testing.T) {
@@ -327,7 +327,7 @@ func TestResponse(t *testing.T) {
 				if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				res.submitForm({ formSelector: "#doesNotExist" })
 			`))
-			assert.EqualError(t, err, sr("GoError: no form found for selector '#doesNotExist' in response 'HTTPBIN_URL/forms/post'"))
+			assert.Contains(t, err.Error(), sr("GoError: no form found for selector '#doesNotExist' in response 'HTTPBIN_URL/forms/post'"))
 		})
 
 		t.Run("withGetMethod", func(t *testing.T) {
@@ -378,7 +378,7 @@ func TestResponse(t *testing.T) {
 				if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				res = res.clickLink({ selector: 'a#doesNotExist' })
 			`))
-			assert.EqualError(t, err, sr("GoError: no element found for selector 'a#doesNotExist' in response 'HTTPBIN_URL/links/10/0'"))
+			assert.Contains(t, err.Error(), sr("GoError: no element found for selector 'a#doesNotExist' in response 'HTTPBIN_URL/links/10/0'"))
 		})
 
 		t.Run("withRequestParams", func(t *testing.T) {

--- a/js/modules/k6/k6_test.go
+++ b/js/modules/k6/k6_test.go
@@ -41,7 +41,7 @@ func TestFail(t *testing.T) {
 	rt := goja.New()
 	rt.Set("k6", common.Bind(rt, New(), nil))
 	_, err := common.RunString(rt, `k6.fail("blah")`)
-	assert.EqualError(t, err, "GoError: blah")
+	assert.Contains(t, err.Error(), "GoError: blah")
 }
 
 func TestSleep(t *testing.T) {
@@ -132,7 +132,7 @@ func TestGroup(t *testing.T) {
 
 	t.Run("Invalid", func(t *testing.T) {
 		_, err := common.RunString(rt, `k6.group("::", function() { throw new Error("nooo") })`)
-		assert.EqualError(t, err, "GoError: group and check names may not contain '::'")
+		assert.Contains(t, err.Error(), "GoError: group and check names may not contain '::'")
 	})
 }
 func TestCheck(t *testing.T) {
@@ -211,7 +211,7 @@ func TestCheck(t *testing.T) {
 
 		t.Run("Invalid", func(t *testing.T) {
 			_, err := common.RunString(rt, `k6.check(null, { "::": true })`)
-			assert.EqualError(t, err, "GoError: group and check names may not contain '::'")
+			assert.Contains(t, err.Error(), "GoError: group and check names may not contain '::'")
 		})
 	})
 

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -1365,10 +1365,10 @@ func TestHTTPRequestInInitContext(t *testing.T) {
 					}
 				`))
 	if assert.Error(t, err) {
-		assert.Equal(
+		assert.Contains(
 			t,
-			"GoError: "+k6http.ErrHTTPForbiddenInInitContext.Error(),
-			err.Error())
+			err.Error(),
+			k6http.ErrHTTPForbiddenInInitContext.Error())
 	}
 }
 
@@ -1440,10 +1440,10 @@ func TestInitContextForbidden(t *testing.T) {
 		t.Run(test[0], func(t *testing.T) {
 			_, err := getSimpleRunner("/script.js", tb.Replacer.Replace(test[1]))
 			if assert.Error(t, err) {
-				assert.Equal(
+				assert.Contains(
 					t,
-					"GoError: "+test[2],
-					err.Error())
+					err.Error(),
+					test[2])
 			}
 		})
 	}


### PR DESCRIPTION
No functional changes, this is just changing the test so if/when we update to the goja's es6 branch we get fewer test failures