### PR TITLE
Override with env variables the cloud config

### DIFF
--- a/cmd/collectors.go
+++ b/cmd/collectors.go
@@ -87,15 +87,15 @@ func getCollector(
 
 		return influxdb.New(logger, config)
 	case collectorCloud:
-		config := cloud.NewConfig().Apply(conf.Collectors.Cloud)
-		if err := envconfig.Process("", &config); err != nil {
+		config, err := fixLoadimpactCloudConfig(&conf)
+		if err != nil {
 			return nil, err
 		}
 		if arg != "" {
 			config.Name = null.StringFrom(arg)
 		}
 
-		return cloud.New(logger, config, src, conf.Options, executionPlan, consts.Version)
+		return cloud.New(logger, *config, src, conf.Options, executionPlan, consts.Version)
 	case collectorKafka:
 		config := kafka.NewConfig().Apply(conf.Collectors.Kafka)
 		if err := envconfig.Process("", &config); err != nil {


### PR DESCRIPTION
This is how it should've been but ... because of the way this is
configurable ... it is somewhat complicated ...

The alternative to this (at this point) is to have the output know how
to merge the env variables back ... which seems even worse