### PR TITLE
Thread a logrus.Logger through the js package

### DIFF
--- a/api/v1/setup_teardown_routes_test.go
+++ b/api/v1/setup_teardown_routes_test.go
@@ -139,6 +139,7 @@ func TestSetupData(t *testing.T) {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			runner, err := js.New(
+				logger,
 				&loader.SourceData{URL: &url.URL{Path: "/script.js"}, Data: testCase.script},
 				nil,
 				lib.RuntimeOptions{},

--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -48,6 +48,8 @@ An archive is a fully self-contained test run, and can be executed identically e
   k6 run myarchive.tar`[1:],
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// TODO: don't use the Global logger
+		logger := logrus.StandardLogger()
 		// Runner.
 		pwd, err := os.Getwd()
 		if err != nil {
@@ -55,8 +57,7 @@ An archive is a fully self-contained test run, and can be executed identically e
 		}
 		filename := args[0]
 		filesystems := loader.CreateFilesystems()
-		// TODO: don't use the Global logger
-		src, err := loader.ReadSource(logrus.StandardLogger(), filename, pwd, filesystems, os.Stdin)
+		src, err := loader.ReadSource(logger, filename, pwd, filesystems, os.Stdin)
 		if err != nil {
 			return err
 		}
@@ -66,7 +67,7 @@ An archive is a fully self-contained test run, and can be executed identically e
 			return err
 		}
 
-		r, err := newRunner(src, runType, filesystems, runtimeOptions)
+		r, err := newRunner(logger, src, runType, filesystems, runtimeOptions)
 		if err != nil {
 			return err
 		}
@@ -104,7 +105,7 @@ func archiveCmdFlagSet() *pflag.FlagSet {
 	flags.SortFlags = false
 	flags.AddFlagSet(optionFlagSet())
 	flags.AddFlagSet(runtimeOptionFlagSet(false))
-	//TODO: figure out a better way to handle the CLI flags - global variables are not very testable... :/
+	// TODO: figure out a better way to handle the CLI flags - global variables are not very testable... :/
 	flags.StringVarP(&archiveOut, "archive-out", "O", archiveOut, "archive output filename")
 	return flags
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -41,13 +41,14 @@ var inspectCmd = &cobra.Command{
 	Long:  `Inspect a script or archive.`,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// TODO: don't use the Global logger
+		logger := logrus.StandardLogger()
 		pwd, err := os.Getwd()
 		if err != nil {
 			return err
 		}
 		filesystems := loader.CreateFilesystems()
-		// TODO: don't use the Global logger
-		src, err := loader.ReadSource(logrus.StandardLogger(), args[0], pwd, filesystems, os.Stdin)
+		src, err := loader.ReadSource(logger, args[0], pwd, filesystems, os.Stdin)
 		if err != nil {
 			return err
 		}
@@ -73,13 +74,13 @@ var inspectCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			b, err = js.NewBundleFromArchive(arc, runtimeOptions)
+			b, err = js.NewBundleFromArchive(logger, arc, runtimeOptions)
 			if err != nil {
 				return err
 			}
 			opts = b.Options
 		case typeJS:
-			b, err = js.NewBundle(src, filesystems, runtimeOptions)
+			b, err = js.NewBundle(logger, src, filesystems, runtimeOptions)
 			if err != nil {
 				return err
 			}

--- a/cmd/runtime_options_test.go
+++ b/cmd/runtime_options_test.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -233,6 +234,7 @@ func testRuntimeOptionsCase(t *testing.T, tc runtimeOptionsTestCase) {
 	fs := afero.NewMemMapFs()
 	require.NoError(t, afero.WriteFile(fs, "/script.js", jsCode.Bytes(), 0644))
 	runner, err := newRunner(
+		logrus.StandardLogger(),
 		&loader.SourceData{Data: jsCode.Bytes(), URL: &url.URL{Path: "/script.js", Scheme: "file"}},
 		typeJS,
 		map[string]afero.Fs{"file": fs},
@@ -246,6 +248,7 @@ func testRuntimeOptionsCase(t *testing.T, tc runtimeOptionsTestCase) {
 
 	getRunnerErr := func(rtOpts lib.RuntimeOptions) (lib.Runner, error) {
 		return newRunner(
+			logrus.StandardLogger(),
 			&loader.SourceData{
 				Data: archiveBuf.Bytes(),
 				URL:  &url.URL{Path: "/script.js"},

--- a/cmd/runtime_options_test.go
+++ b/cmd/runtime_options_test.go
@@ -26,13 +26,13 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v3"
 
 	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/testutils"
 	"github.com/loadimpact/k6/loader"
 )
 
@@ -232,9 +232,9 @@ func testRuntimeOptionsCase(t *testing.T, tc runtimeOptionsTestCase) {
 	fmt.Fprint(jsCode, "}")
 
 	fs := afero.NewMemMapFs()
-	require.NoError(t, afero.WriteFile(fs, "/script.js", jsCode.Bytes(), 0644))
+	require.NoError(t, afero.WriteFile(fs, "/script.js", jsCode.Bytes(), 0o644))
 	runner, err := newRunner(
-		logrus.StandardLogger(),
+		testutils.NewLogger(t),
 		&loader.SourceData{Data: jsCode.Bytes(), URL: &url.URL{Path: "/script.js", Scheme: "file"}},
 		typeJS,
 		map[string]afero.Fs{"file": fs},
@@ -248,7 +248,7 @@ func testRuntimeOptionsCase(t *testing.T, tc runtimeOptionsTestCase) {
 
 	getRunnerErr := func(rtOpts lib.RuntimeOptions) (lib.Runner, error) {
 		return newRunner(
-			logrus.StandardLogger(),
+			testutils.NewLogger(t),
 			&loader.SourceData{
 				Data: archiveBuf.Bytes(),
 				URL:  &url.URL{Path: "/script.js"},

--- a/converter/har/converter_test.go
+++ b/converter/har/converter_test.go
@@ -25,11 +25,11 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/loadimpact/k6/js"
 	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/testutils"
 	"github.com/loadimpact/k6/loader"
 )
 
@@ -58,7 +58,7 @@ func TestBuildK6RequestObject(t *testing.T) {
 	}
 	v, err := buildK6RequestObject(req)
 	assert.NoError(t, err)
-	_, err = js.New(logrus.StandardLogger(), &loader.SourceData{
+	_, err = js.New(testutils.NewLogger(t), &loader.SourceData{
 		URL:  &url.URL{Path: "/script.js"},
 		Data: []byte(fmt.Sprintf("export default function() { res = http.batch([%v]); }", v)),
 	}, nil, lib.RuntimeOptions{})

--- a/converter/har/converter_test.go
+++ b/converter/har/converter_test.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/loadimpact/k6/js"
@@ -33,7 +34,7 @@ import (
 )
 
 func TestBuildK6Headers(t *testing.T) {
-	var headers = []struct {
+	headers := []struct {
 		values   []Header
 		expected []string
 	}{
@@ -57,7 +58,7 @@ func TestBuildK6RequestObject(t *testing.T) {
 	}
 	v, err := buildK6RequestObject(req)
 	assert.NoError(t, err)
-	_, err = js.New(&loader.SourceData{
+	_, err = js.New(logrus.StandardLogger(), &loader.SourceData{
 		URL:  &url.URL{Path: "/script.js"},
 		Data: []byte(fmt.Sprintf("export default function() { res = http.batch([%v]); }", v)),
 	}, nil, lib.RuntimeOptions{})
@@ -65,7 +66,6 @@ func TestBuildK6RequestObject(t *testing.T) {
 }
 
 func TestBuildK6Body(t *testing.T) {
-
 	bodyText := "ccustemail=ppcano%40gmail.com&size=medium&topping=cheese&delivery=12%3A00&comments="
 
 	req := &Request{

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -441,6 +441,7 @@ func TestSentReceivedMetrics(t *testing.T) {
 
 	runTest := func(t *testing.T, ts testScript, tc testCase, noConnReuse bool) (float64, float64) {
 		r, err := js.New(
+			logrus.StandardLogger(),
 			&loader.SourceData{URL: &url.URL{Path: "/script.js"}, Data: []byte(ts.Code)},
 			nil,
 			lib.RuntimeOptions{},
@@ -574,6 +575,7 @@ func TestRunTags(t *testing.T) {
 	`))
 
 	r, err := js.New(
+		logrus.StandardLogger(),
 		&loader.SourceData{URL: &url.URL{Path: "/script.js"}, Data: script},
 		nil,
 		lib.RuntimeOptions{},
@@ -665,6 +667,7 @@ func TestSetupTeardownThresholds(t *testing.T) {
 	`))
 
 	runner, err := js.New(
+		logrus.StandardLogger(),
 		&loader.SourceData{URL: &url.URL{Path: "/script.js"}, Data: script},
 		nil,
 		lib.RuntimeOptions{},
@@ -728,6 +731,7 @@ func TestEmittedMetricsWhenScalingDown(t *testing.T) {
 	`))
 
 	runner, err := js.New(
+		logrus.StandardLogger(),
 		&loader.SourceData{URL: &url.URL{Path: "/script.js"}, Data: script},
 		nil,
 		lib.RuntimeOptions{},
@@ -811,6 +815,7 @@ func TestMetricsEmission(t *testing.T) {
 				t.Parallel()
 			}
 			runner, err := js.New(
+				logrus.StandardLogger(),
 				&loader.SourceData{URL: &url.URL{Path: "/script.js"}, Data: []byte(fmt.Sprintf(`
 				import { sleep } from "k6";
 				import { Counter } from "k6/metrics";
@@ -917,6 +922,7 @@ func TestMinIterationDurationInSetupTeardownStage(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			runner, err := js.New(
+				logrus.StandardLogger(),
 				&loader.SourceData{URL: &url.URL{Path: "/script.js"}, Data: []byte(tc.script)},
 				nil,
 				lib.RuntimeOptions{},

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -441,7 +441,7 @@ func TestSentReceivedMetrics(t *testing.T) {
 
 	runTest := func(t *testing.T, ts testScript, tc testCase, noConnReuse bool) (float64, float64) {
 		r, err := js.New(
-			logrus.StandardLogger(),
+			testutils.NewLogger(t),
 			&loader.SourceData{URL: &url.URL{Path: "/script.js"}, Data: []byte(ts.Code)},
 			nil,
 			lib.RuntimeOptions{},
@@ -575,7 +575,7 @@ func TestRunTags(t *testing.T) {
 	`))
 
 	r, err := js.New(
-		logrus.StandardLogger(),
+		testutils.NewLogger(t),
 		&loader.SourceData{URL: &url.URL{Path: "/script.js"}, Data: script},
 		nil,
 		lib.RuntimeOptions{},
@@ -667,7 +667,7 @@ func TestSetupTeardownThresholds(t *testing.T) {
 	`))
 
 	runner, err := js.New(
-		logrus.StandardLogger(),
+		testutils.NewLogger(t),
 		&loader.SourceData{URL: &url.URL{Path: "/script.js"}, Data: script},
 		nil,
 		lib.RuntimeOptions{},
@@ -731,7 +731,7 @@ func TestEmittedMetricsWhenScalingDown(t *testing.T) {
 	`))
 
 	runner, err := js.New(
-		logrus.StandardLogger(),
+		testutils.NewLogger(t),
 		&loader.SourceData{URL: &url.URL{Path: "/script.js"}, Data: script},
 		nil,
 		lib.RuntimeOptions{},
@@ -815,7 +815,7 @@ func TestMetricsEmission(t *testing.T) {
 				t.Parallel()
 			}
 			runner, err := js.New(
-				logrus.StandardLogger(),
+				testutils.NewLogger(t),
 				&loader.SourceData{URL: &url.URL{Path: "/script.js"}, Data: []byte(fmt.Sprintf(`
 				import { sleep } from "k6";
 				import { Counter } from "k6/metrics";
@@ -922,7 +922,7 @@ func TestMinIterationDurationInSetupTeardownStage(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			runner, err := js.New(
-				logrus.StandardLogger(),
+				testutils.NewLogger(t),
 				&loader.SourceData{URL: &url.URL{Path: "/script.js"}, Data: []byte(tc.script)},
 				nil,
 				lib.RuntimeOptions{},

--- a/js/common/util.go
+++ b/js/common/util.go
@@ -22,6 +22,7 @@ package common
 
 import (
 	"github.com/dop251/goja"
+	"github.com/sirupsen/logrus"
 
 	"github.com/loadimpact/k6/js/compiler"
 )
@@ -34,7 +35,7 @@ func RunString(rt *goja.Runtime, src string) (goja.Value, error) {
 // RunES6String Runs an ES6 string in the given runtime. Use this rather than writing ES5 in tests.
 func RunES6String(rt *goja.Runtime, src string) (goja.Value, error) {
 	var err error
-	c := compiler.New()
+	c := compiler.New(logrus.StandardLogger()) // TODO drop it ? maybe we will drop babel and this will be less needed
 	src, _, err = c.Transform(src, "__string__")
 	if err != nil {
 		return goja.Undefined(), err
@@ -42,7 +43,7 @@ func RunES6String(rt *goja.Runtime, src string) (goja.Value, error) {
 	return RunString(rt, src)
 }
 
-// Throws a JS error; avoids re-wrapping GoErrors.
+// Throw a JS error; avoids re-wrapping GoErrors.
 func Throw(rt *goja.Runtime, err error) {
 	if e, ok := err.(*goja.Exception); ok {
 		panic(e)

--- a/js/common/util.go
+++ b/js/common/util.go
@@ -21,28 +21,12 @@
 package common
 
 import (
-	"testing"
-
 	"github.com/dop251/goja"
-
-	"github.com/loadimpact/k6/js/compiler"
-	"github.com/loadimpact/k6/lib/testutils"
 )
 
 // RunString Runs an string in the given runtime. Use this if writing ES5 in tests isn't a problem.
 func RunString(rt *goja.Runtime, src string) (goja.Value, error) {
 	return rt.RunString(src)
-}
-
-// RunES6String Runs an ES6 string in the given runtime. Use this rather than writing ES5 in tests.
-func RunES6String(tb testing.TB, rt *goja.Runtime, src string) (goja.Value, error) {
-	var err error
-	c := compiler.New(testutils.NewLogger(tb)) // TODO drop it ? maybe we will drop babel and this will be less needed
-	src, _, err = c.Transform(src, "__string__")
-	if err != nil {
-		return goja.Undefined(), err
-	}
-	return RunString(rt, src)
 }
 
 // Throw a JS error; avoids re-wrapping GoErrors.

--- a/js/common/util.go
+++ b/js/common/util.go
@@ -21,10 +21,12 @@
 package common
 
 import (
+	"testing"
+
 	"github.com/dop251/goja"
-	"github.com/sirupsen/logrus"
 
 	"github.com/loadimpact/k6/js/compiler"
+	"github.com/loadimpact/k6/lib/testutils"
 )
 
 // RunString Runs an string in the given runtime. Use this if writing ES5 in tests isn't a problem.
@@ -33,9 +35,9 @@ func RunString(rt *goja.Runtime, src string) (goja.Value, error) {
 }
 
 // RunES6String Runs an ES6 string in the given runtime. Use this rather than writing ES5 in tests.
-func RunES6String(rt *goja.Runtime, src string) (goja.Value, error) {
+func RunES6String(tb testing.TB, rt *goja.Runtime, src string) (goja.Value, error) {
 	var err error
-	c := compiler.New(logrus.StandardLogger()) // TODO drop it ? maybe we will drop babel and this will be less needed
+	c := compiler.New(testutils.NewLogger(tb)) // TODO drop it ? maybe we will drop babel and this will be less needed
 	src, _, err = c.Transform(src, "__string__")
 	if err != nil {
 		return goja.Undefined(), err

--- a/js/common/util_test.go
+++ b/js/common/util_test.go
@@ -28,18 +28,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRunString(t *testing.T) {
-	t.Run("Valid", func(t *testing.T) {
-		_, err := RunES6String(t, goja.New(), `let a = 1;`)
-		assert.NoError(t, err)
-	})
-	t.Run("Invalid", func(t *testing.T) {
-		_, err := RunES6String(t, goja.New(), `let a = #;`)
-		assert.NotNil(t, err)
-		assert.Contains(t, err.Error(), "SyntaxError: __string__: Unexpected character '#' (1:8)\n> 1 | let a = #;\n")
-	})
-}
-
 func TestThrow(t *testing.T) {
 	rt := goja.New()
 	fn1, ok := goja.AssertFunction(rt.ToValue(func() { Throw(rt, errors.New("aaaa")) }))

--- a/js/common/util_test.go
+++ b/js/common/util_test.go
@@ -30,11 +30,11 @@ import (
 
 func TestRunString(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
-		_, err := RunES6String(goja.New(), `let a = 1;`)
+		_, err := RunES6String(t, goja.New(), `let a = 1;`)
 		assert.NoError(t, err)
 	})
 	t.Run("Invalid", func(t *testing.T) {
-		_, err := RunES6String(goja.New(), `let a = #;`)
+		_, err := RunES6String(t, goja.New(), `let a = #;`)
 		assert.NotNil(t, err)
 		assert.Contains(t, err.Error(), "SyntaxError: __string__: Unexpected character '#' (1:8)\n> 1 | let a = #;\n")
 	})

--- a/js/compiler/compiler_test.go
+++ b/js/compiler/compiler_test.go
@@ -24,14 +24,14 @@ import (
 	"testing"
 
 	"github.com/dop251/goja"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/testutils"
 )
 
 func TestTransform(t *testing.T) {
-	c := New(logrus.StandardLogger())
+	c := New(testutils.NewLogger(t))
 	t.Run("blank", func(t *testing.T) {
 		src, _, err := c.Transform("", "test.js")
 		assert.NoError(t, err)
@@ -71,7 +71,7 @@ func TestTransform(t *testing.T) {
 }
 
 func TestCompile(t *testing.T) {
-	c := New(logrus.StandardLogger())
+	c := New(testutils.NewLogger(t))
 	t.Run("ES5", func(t *testing.T) {
 		src := `1+(function() { return 2; })()`
 		pgm, code, err := c.Compile(src, "script.js", "", "", true, lib.CompatibilityModeBase)

--- a/js/compiler/compiler_test.go
+++ b/js/compiler/compiler_test.go
@@ -24,13 +24,14 @@ import (
 	"testing"
 
 	"github.com/dop251/goja"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/loadimpact/k6/lib"
 )
 
 func TestTransform(t *testing.T) {
-	c := New()
+	c := New(logrus.StandardLogger())
 	t.Run("blank", func(t *testing.T) {
 		src, _, err := c.Transform("", "test.js")
 		assert.NoError(t, err)
@@ -70,7 +71,7 @@ func TestTransform(t *testing.T) {
 }
 
 func TestCompile(t *testing.T) {
-	c := New()
+	c := New(logrus.StandardLogger())
 	t.Run("ES5", func(t *testing.T) {
 		src := `1+(function() { return 2; })()`
 		pgm, code, err := c.Compile(src, "script.js", "", "", true, lib.CompatibilityModeBase)

--- a/js/console.go
+++ b/js/console.go
@@ -35,8 +35,8 @@ type console struct {
 }
 
 // Creates a console with the standard logrus logger.
-func newConsole() *console {
-	return &console{logrus.StandardLogger().WithField("source", "console")}
+func newConsole(logger logrus.FieldLogger) *console {
+	return &console{logger.WithField("source", "console")}
 }
 
 // Creates a console logger with its output set to the file at the provided `filepath`.

--- a/js/console_test.go
+++ b/js/console_test.go
@@ -85,6 +85,7 @@ func getSimpleRunner(filename, data string, opts ...interface{}) (*Runner, error
 		}
 	}
 	return New(
+		logrus.StandardLogger(),
 		&loader.SourceData{
 			URL:  &url.URL{Path: filename, Scheme: "file"},
 			Data: []byte(data),

--- a/js/console_test.go
+++ b/js/console_test.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/loadimpact/k6/js/common"
 	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/testutils"
 	"github.com/loadimpact/k6/loader"
 	"github.com/loadimpact/k6/stats"
 )
@@ -71,7 +72,7 @@ func TestConsoleContext(t *testing.T) {
 	}
 }
 
-func getSimpleRunner(filename, data string, opts ...interface{}) (*Runner, error) {
+func getSimpleRunner(tb testing.TB, filename, data string, opts ...interface{}) (*Runner, error) {
 	var (
 		fs     = afero.NewMemMapFs()
 		rtOpts = lib.RuntimeOptions{CompatibilityMode: null.NewString("base", true)}
@@ -85,7 +86,7 @@ func getSimpleRunner(filename, data string, opts ...interface{}) (*Runner, error
 		}
 	}
 	return New(
-		logrus.StandardLogger(),
+		testutils.NewLogger(tb),
 		&loader.SourceData{
 			URL:  &url.URL{Path: filename, Scheme: "file"},
 			Data: []byte(data),
@@ -128,7 +129,7 @@ func TestConsole(t *testing.T) {
 			for args, result := range argsets {
 				args, result := args, result
 				t.Run(args, func(t *testing.T) {
-					r, err := getSimpleRunner("/script.js", fmt.Sprintf(
+					r, err := getSimpleRunner(t, "/script.js", fmt.Sprintf(
 						`exports.default = function() { console.%s(%s); }`,
 						name, args,
 					))
@@ -220,7 +221,7 @@ func TestFileConsole(t *testing.T) {
 								}
 
 							}
-							r, err := getSimpleRunner("/script",
+							r, err := getSimpleRunner(t, "/script",
 								fmt.Sprintf(
 									`exports.default = function() { console.%s(%s); }`,
 									name, args,

--- a/js/empty_iteartions_bench_test.go
+++ b/js/empty_iteartions_bench_test.go
@@ -13,13 +13,13 @@ import (
 func BenchmarkEmptyIteration(b *testing.B) {
 	b.StopTimer()
 
-	r, err := getSimpleRunner("/script.js", `exports.default = function() { }`)
+	r, err := getSimpleRunner(b, "/script.js", `exports.default = function() { }`)
 	if !assert.NoError(b, err) {
 		return
 	}
 	require.NoError(b, err)
 
-	var ch = make(chan stats.SampleContainer, 100)
+	ch := make(chan stats.SampleContainer, 100)
 	defer close(ch)
 	go func() { // read the channel so it doesn't block
 		for range ch {

--- a/js/http_bench_test.go
+++ b/js/http_bench_test.go
@@ -38,7 +38,7 @@ func BenchmarkHTTPRequests(b *testing.B) {
 	tb := httpmultibin.NewHTTPMultiBin(b)
 	defer tb.Cleanup()
 
-	r, err := getSimpleRunner("/script.js", tb.Replacer.Replace(`
+	r, err := getSimpleRunner(b, "/script.js", tb.Replacer.Replace(`
 			import http from "k6/http";
 			export default function() {
 				let url = "HTTPBIN_URL";
@@ -57,7 +57,7 @@ func BenchmarkHTTPRequests(b *testing.B) {
 	})
 	require.NoError(b, err)
 
-	var ch = make(chan stats.SampleContainer, 100)
+	ch := make(chan stats.SampleContainer, 100)
 	defer close(ch)
 	go func() { // read the channel so it doesn't block
 		for range ch {
@@ -82,7 +82,7 @@ func BenchmarkHTTPRequestsBase(b *testing.B) {
 	tb := httpmultibin.NewHTTPMultiBin(b)
 	defer tb.Cleanup()
 
-	r, err := getSimpleRunner("/script.js", tb.Replacer.Replace(`
+	r, err := getSimpleRunner(b, "/script.js", tb.Replacer.Replace(`
 			var http = require("k6/http");
 			exports.default = function() {
 				var url = "HTTPBIN_URL";
@@ -101,7 +101,7 @@ func BenchmarkHTTPRequestsBase(b *testing.B) {
 	})
 	require.NoError(b, err)
 
-	var ch = make(chan stats.SampleContainer, 100)
+	ch := make(chan stats.SampleContainer, 100)
 	defer close(ch)
 	go func() { // read the channel so it doesn't block
 		for range ch {

--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -65,11 +65,13 @@ type InitContext struct {
 	programs map[string]programWithSource
 
 	compatibilityMode lib.CompatibilityMode
+
+	logger logrus.FieldLogger
 }
 
 // NewInitContext creates a new initcontext with the provided arguments
 func NewInitContext(
-	rt *goja.Runtime, c *compiler.Compiler, compatMode lib.CompatibilityMode,
+	logger logrus.FieldLogger, rt *goja.Runtime, c *compiler.Compiler, compatMode lib.CompatibilityMode,
 	ctxPtr *context.Context, filesystems map[string]afero.Fs, pwd *url.URL,
 ) *InitContext {
 	return &InitContext{
@@ -80,6 +82,7 @@ func NewInitContext(
 		pwd:               pwd,
 		programs:          make(map[string]programWithSource),
 		compatibilityMode: compatMode,
+		logger:            logger,
 	}
 }
 
@@ -104,6 +107,7 @@ func newBoundInitContext(base *InitContext, ctxPtr *context.Context, rt *goja.Ru
 
 		programs:          programs,
 		compatibilityMode: base.compatibilityMode,
+		logger:            base.logger,
 	}
 }
 
@@ -156,7 +160,7 @@ func (i *InitContext) requireFile(name string) (goja.Value, error) {
 		if pgm.pgm == nil {
 			// Load the sources; the loader takes care of remote loading, etc.
 			// TODO: don't use the Global logger
-			data, err := loader.Load(logrus.StandardLogger(), i.filesystems, fileURL, name)
+			data, err := loader.Load(i.logger, i.filesystems, fileURL, name)
 			if err != nil {
 				return goja.Undefined(), err
 			}

--- a/js/initcontext_test.go
+++ b/js/initcontext_test.go
@@ -42,19 +42,20 @@ import (
 	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/lib/consts"
 	"github.com/loadimpact/k6/lib/netext"
+	"github.com/loadimpact/k6/lib/testutils"
 	"github.com/loadimpact/k6/stats"
 )
 
 func TestInitContextRequire(t *testing.T) {
-	logger := logrus.StandardLogger()
+	logger := testutils.NewLogger(t)
 	t.Run("Modules", func(t *testing.T) {
 		t.Run("Nonexistent", func(t *testing.T) {
-			_, err := getSimpleBundle("/script.js", `import "k6/NONEXISTENT";`)
+			_, err := getSimpleBundle(t, "/script.js", `import "k6/NONEXISTENT";`)
 			assert.Contains(t, err.Error(), "GoError: unknown builtin module: k6/NONEXISTENT")
 		})
 
 		t.Run("k6", func(t *testing.T) {
-			b, err := getSimpleBundle("/script.js", `
+			b, err := getSimpleBundle(t, "/script.js", `
 					import k6 from "k6";
 					export let _k6 = k6;
 					export let dummy = "abc123";
@@ -83,7 +84,7 @@ func TestInitContextRequire(t *testing.T) {
 			}
 
 			t.Run("group", func(t *testing.T) {
-				b, err := getSimpleBundle("/script.js", `
+				b, err := getSimpleBundle(t, "/script.js", `
 						import { group } from "k6";
 						export let _group = group;
 						export let dummy = "abc123";
@@ -114,21 +115,21 @@ func TestInitContextRequire(t *testing.T) {
 	t.Run("Files", func(t *testing.T) {
 		t.Run("Nonexistent", func(t *testing.T) {
 			path := filepath.FromSlash("/nonexistent.js")
-			_, err := getSimpleBundle("/script.js", `import "/nonexistent.js"; export default function() {}`)
+			_, err := getSimpleBundle(t, "/script.js", `import "/nonexistent.js"; export default function() {}`)
 			assert.NotNil(t, err)
 			assert.Contains(t, err.Error(), fmt.Sprintf(`"%s" couldn't be found on local disk`, filepath.ToSlash(path)))
 		})
 		t.Run("Invalid", func(t *testing.T) {
 			fs := afero.NewMemMapFs()
-			assert.NoError(t, afero.WriteFile(fs, "/file.js", []byte{0x00}, 0755))
-			_, err := getSimpleBundle("/script.js", `import "/file.js"; export default function() {}`, fs)
+			assert.NoError(t, afero.WriteFile(fs, "/file.js", []byte{0x00}, 0o755))
+			_, err := getSimpleBundle(t, "/script.js", `import "/file.js"; export default function() {}`, fs)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "SyntaxError: file:///file.js: Unexpected character '\x00' (1:0)\n> 1 | \x00\n")
 		})
 		t.Run("Error", func(t *testing.T) {
 			fs := afero.NewMemMapFs()
-			assert.NoError(t, afero.WriteFile(fs, "/file.js", []byte(`throw new Error("aaaa")`), 0755))
-			_, err := getSimpleBundle("/script.js", `import "/file.js"; export default function() {}`, fs)
+			assert.NoError(t, afero.WriteFile(fs, "/file.js", []byte(`throw new Error("aaaa")`), 0o755))
+			_, err := getSimpleBundle(t, "/script.js", `import "/file.js"; export default function() {}`, fs)
 			assert.EqualError(t, err, "Error: aaaa at file:///file.js:2:7(4)")
 		})
 
@@ -181,19 +182,19 @@ func TestInitContextRequire(t *testing.T) {
 							)
 
 							constsrc := `export let c = 12345;`
-							assert.NoError(t, fs.MkdirAll(filepath.Dir(constPath), 0755))
-							assert.NoError(t, afero.WriteFile(fs, constPath, []byte(constsrc), 0644))
+							assert.NoError(t, fs.MkdirAll(filepath.Dir(constPath), 0o755))
+							assert.NoError(t, afero.WriteFile(fs, constPath, []byte(constsrc), 0o644))
 						}
 
-						assert.NoError(t, fs.MkdirAll(filepath.Dir(data.LibPath), 0755))
-						assert.NoError(t, afero.WriteFile(fs, data.LibPath, []byte(jsLib), 0644))
+						assert.NoError(t, fs.MkdirAll(filepath.Dir(data.LibPath), 0o755))
+						assert.NoError(t, afero.WriteFile(fs, data.LibPath, []byte(jsLib), 0o644))
 
 						data := fmt.Sprintf(`
 								import fn from "%s";
 								let v = fn();
 								export default function() {};`,
 							libName)
-						b, err := getSimpleBundle("/path/to/script.js", data, fs)
+						b, err := getSimpleBundle(t, "/path/to/script.js", data, fs)
 						if !assert.NoError(t, err) {
 							return
 						}
@@ -212,8 +213,8 @@ func TestInitContextRequire(t *testing.T) {
 
 		t.Run("Isolation", func(t *testing.T) {
 			fs := afero.NewMemMapFs()
-			assert.NoError(t, afero.WriteFile(fs, "/a.js", []byte(`const myvar = "a";`), 0644))
-			assert.NoError(t, afero.WriteFile(fs, "/b.js", []byte(`const myvar = "b";`), 0644))
+			assert.NoError(t, afero.WriteFile(fs, "/a.js", []byte(`const myvar = "a";`), 0o644))
+			assert.NoError(t, afero.WriteFile(fs, "/b.js", []byte(`const myvar = "b";`), 0o644))
 			data := `
 				import "./a.js";
 				import "./b.js";
@@ -222,7 +223,7 @@ func TestInitContextRequire(t *testing.T) {
 						throw new Error("myvar is set in global scope");
 					}
 				};`
-			b, err := getSimpleBundle("/script.js", data, fs)
+			b, err := getSimpleBundle(t, "/script.js", data, fs)
 			if !assert.NoError(t, err) {
 				return
 			}
@@ -239,8 +240,8 @@ func TestInitContextRequire(t *testing.T) {
 
 func createAndReadFile(t *testing.T, file string, content []byte, expectedLength int, binary bool) (*BundleInstance, error) {
 	fs := afero.NewMemMapFs()
-	assert.NoError(t, fs.MkdirAll("/path/to", 0755))
-	assert.NoError(t, afero.WriteFile(fs, "/path/to/"+file, content, 0644))
+	assert.NoError(t, fs.MkdirAll("/path/to", 0o755))
+	assert.NoError(t, afero.WriteFile(fs, "/path/to/"+file, content, 0o644))
 
 	binaryArg := ""
 	if binary {
@@ -255,13 +256,13 @@ func createAndReadFile(t *testing.T, file string, content []byte, expectedLength
 		}
 		export default function() {}
 	`, file, binaryArg, expectedLength)
-	b, err := getSimpleBundle("/path/to/script.js", data, fs)
+	b, err := getSimpleBundle(t, "/path/to/script.js", data, fs)
 
 	if !assert.NoError(t, err) {
 		return nil, err
 	}
 
-	bi, err := b.Instantiate(logrus.StandardLogger(), 0)
+	bi, err := b.Instantiate(testutils.NewLogger(t), 0)
 	if !assert.NoError(t, err) {
 		return nil, err
 	}
@@ -276,7 +277,7 @@ func TestInitContextOpen(t *testing.T) {
 	}{
 		{[]byte("hello world!"), "ascii", 12},
 		{[]byte("?((¯°·._.• ţ€$ţɨɲǥ µɲɨȼ๏ď€ΣSЫ ɨɲ Ќ6 •._.·°¯))؟•"), "utf", 47},
-		{[]byte{044, 226, 130, 172}, "utf-8", 2}, // $€
+		{[]byte{0o44, 226, 130, 172}, "utf-8", 2}, // $€
 		//{[]byte{00, 36, 32, 127}, "utf-16", 2},   // $€
 	}
 	for _, tc := range testCases {
@@ -314,15 +315,15 @@ func TestInitContextOpen(t *testing.T) {
 
 	t.Run("Nonexistent", func(t *testing.T) {
 		path := filepath.FromSlash("/nonexistent.txt")
-		_, err := getSimpleBundle("/script.js", `open("/nonexistent.txt"); export default function() {}`)
+		_, err := getSimpleBundle(t, "/script.js", `open("/nonexistent.txt"); export default function() {}`)
 		assert.Contains(t, err.Error(), fmt.Sprintf("GoError: open %s: file does not exist", path))
 	})
 
 	t.Run("Directory", func(t *testing.T) {
 		path := filepath.FromSlash("/some/dir")
 		fs := afero.NewMemMapFs()
-		assert.NoError(t, fs.MkdirAll(path, 0755))
-		_, err := getSimpleBundle("/script.js", `open("/some/dir"); export default function() {}`, fs)
+		assert.NoError(t, fs.MkdirAll(path, 0o755))
+		_, err := getSimpleBundle(t, "/script.js", `open("/some/dir"); export default function() {}`, fs)
 		assert.Contains(t, err.Error(), fmt.Sprintf("GoError: open() can't be used with directories, path: %q", path))
 	})
 }
@@ -354,10 +355,10 @@ func TestRequestWithBinaryFile(t *testing.T) {
 	defer srv.Close()
 
 	fs := afero.NewMemMapFs()
-	assert.NoError(t, fs.MkdirAll("/path/to", 0755))
-	assert.NoError(t, afero.WriteFile(fs, "/path/to/file.bin", []byte("hi!"), 0644))
+	assert.NoError(t, fs.MkdirAll("/path/to", 0o755))
+	assert.NoError(t, afero.WriteFile(fs, "/path/to/file.bin", []byte("hi!"), 0o644))
 
-	b, err := getSimpleBundle("/path/to/script.js",
+	b, err := getSimpleBundle(t, "/path/to/script.js",
 		fmt.Sprintf(`
 			import http from "k6/http";
 			let binFile = open("/path/to/file.bin", "b");
@@ -372,7 +373,7 @@ func TestRequestWithBinaryFile(t *testing.T) {
 			`, srv.URL), fs)
 	require.NoError(t, err)
 
-	bi, err := b.Instantiate(logrus.StandardLogger(), 0)
+	bi, err := b.Instantiate(testutils.NewLogger(t), 0)
 	assert.NoError(t, err)
 
 	root, err := lib.NewGroup("", nil)
@@ -411,12 +412,12 @@ func TestRequestWithBinaryFile(t *testing.T) {
 }
 
 func TestInitContextVU(t *testing.T) {
-	b, err := getSimpleBundle("/script.js", `
+	b, err := getSimpleBundle(t, "/script.js", `
 		let vu = __VU;
 		export default function() { return vu; }
 	`)
 	require.NoError(t, err)
-	bi, err := b.Instantiate(logrus.StandardLogger(), 5)
+	bi, err := b.Instantiate(testutils.NewLogger(t), 5)
 	require.NoError(t, err)
 	v, err := bi.exports[consts.DefaultFn](goja.Undefined())
 	require.NoError(t, err)

--- a/js/initcontext_test.go
+++ b/js/initcontext_test.go
@@ -46,6 +46,7 @@ import (
 )
 
 func TestInitContextRequire(t *testing.T) {
+	logger := logrus.StandardLogger()
 	t.Run("Modules", func(t *testing.T) {
 		t.Run("Nonexistent", func(t *testing.T) {
 			_, err := getSimpleBundle("/script.js", `import "k6/NONEXISTENT";`)
@@ -63,7 +64,7 @@ func TestInitContextRequire(t *testing.T) {
 				return
 			}
 
-			bi, err := b.Instantiate(0)
+			bi, err := b.Instantiate(logger, 0)
 			if !assert.NoError(t, err, "instance error") {
 				return
 			}
@@ -92,7 +93,7 @@ func TestInitContextRequire(t *testing.T) {
 					return
 				}
 
-				bi, err := b.Instantiate(0)
+				bi, err := b.Instantiate(logger, 0)
 				if !assert.NoError(t, err) {
 					return
 				}
@@ -200,7 +201,7 @@ func TestInitContextRequire(t *testing.T) {
 							assert.Contains(t, b.BaseInitContext.programs, "file://"+constPath)
 						}
 
-						_, err = b.Instantiate(0)
+						_, err = b.Instantiate(logger, 0)
 						if !assert.NoError(t, err) {
 							return
 						}
@@ -226,7 +227,7 @@ func TestInitContextRequire(t *testing.T) {
 				return
 			}
 
-			bi, err := b.Instantiate(0)
+			bi, err := b.Instantiate(logger, 0)
 			if !assert.NoError(t, err) {
 				return
 			}
@@ -260,7 +261,7 @@ func createAndReadFile(t *testing.T, file string, content []byte, expectedLength
 		return nil, err
 	}
 
-	bi, err := b.Instantiate(0)
+	bi, err := b.Instantiate(logrus.StandardLogger(), 0)
 	if !assert.NoError(t, err) {
 		return nil, err
 	}
@@ -268,7 +269,6 @@ func createAndReadFile(t *testing.T, file string, content []byte, expectedLength
 }
 
 func TestInitContextOpen(t *testing.T) {
-
 	testCases := []struct {
 		content []byte
 		file    string
@@ -372,7 +372,7 @@ func TestRequestWithBinaryFile(t *testing.T) {
 			`, srv.URL), fs)
 	require.NoError(t, err)
 
-	bi, err := b.Instantiate(0)
+	bi, err := b.Instantiate(logrus.StandardLogger(), 0)
 	assert.NoError(t, err)
 
 	root, err := lib.NewGroup("", nil)
@@ -416,7 +416,7 @@ func TestInitContextVU(t *testing.T) {
 		export default function() { return vu; }
 	`)
 	require.NoError(t, err)
-	bi, err := b.Instantiate(5)
+	bi, err := b.Instantiate(logrus.StandardLogger(), 5)
 	require.NoError(t, err)
 	v, err := bi.exports[consts.DefaultFn](goja.Undefined())
 	require.NoError(t, err)

--- a/js/module_loading_test.go
+++ b/js/module_loading_test.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v3"
@@ -36,7 +37,7 @@ import (
 )
 
 func newDevNullSampleChannel() chan stats.SampleContainer {
-	var ch = make(chan stats.SampleContainer, 100)
+	ch := make(chan stats.SampleContainer, 100)
 	go func() {
 		for range ch {
 		}
@@ -45,7 +46,7 @@ func newDevNullSampleChannel() chan stats.SampleContainer {
 }
 
 func TestLoadOnceGlobalVars(t *testing.T) {
-	var testCases = map[string]string{
+	testCases := map[string]string{
 		"module.exports": `
 			var globalVar;
 			if (!globalVar) {
@@ -72,7 +73,6 @@ func TestLoadOnceGlobalVars(t *testing.T) {
 	for name, data := range testCases {
 		cData := data
 		t.Run(name, func(t *testing.T) {
-
 			fs := afero.NewMemMapFs()
 			require.NoError(t, afero.WriteFile(fs, "/C.js", []byte(cData), os.ModePerm))
 
@@ -104,7 +104,7 @@ func TestLoadOnceGlobalVars(t *testing.T) {
 			require.NoError(t, err)
 
 			arc := r1.MakeArchive()
-			r2, err := NewFromArchive(arc, lib.RuntimeOptions{})
+			r2, err := NewFromArchive(logrus.StandardLogger(), arc, lib.RuntimeOptions{})
 			require.NoError(t, err)
 
 			runners := map[string]*Runner{"Source": r1, "Archive": r2}
@@ -153,7 +153,7 @@ func TestLoadExportsIsUsableInModule(t *testing.T) {
 	require.NoError(t, err)
 
 	arc := r1.MakeArchive()
-	r2, err := NewFromArchive(arc, lib.RuntimeOptions{})
+	r2, err := NewFromArchive(logrus.StandardLogger(), arc, lib.RuntimeOptions{})
 	require.NoError(t, err)
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
@@ -200,7 +200,7 @@ func TestLoadDoesntBreakHTTPGet(t *testing.T) {
 
 	require.NoError(t, r1.SetOptions(lib.Options{Hosts: tb.Dialer.Hosts}))
 	arc := r1.MakeArchive()
-	r2, err := NewFromArchive(arc, lib.RuntimeOptions{})
+	r2, err := NewFromArchive(logrus.StandardLogger(), arc, lib.RuntimeOptions{})
 	require.NoError(t, err)
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
@@ -244,7 +244,7 @@ func TestLoadGlobalVarsAreNotSharedBetweenVUs(t *testing.T) {
 	require.NoError(t, err)
 
 	arc := r1.MakeArchive()
-	r2, err := NewFromArchive(arc, lib.RuntimeOptions{})
+	r2, err := NewFromArchive(logrus.StandardLogger(), arc, lib.RuntimeOptions{})
 	require.NoError(t, err)
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
@@ -307,7 +307,7 @@ func TestLoadCycle(t *testing.T) {
 	require.NoError(t, err)
 
 	arc := r1.MakeArchive()
-	r2, err := NewFromArchive(arc, lib.RuntimeOptions{})
+	r2, err := NewFromArchive(logrus.StandardLogger(), arc, lib.RuntimeOptions{})
 	require.NoError(t, err)
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
@@ -325,7 +325,6 @@ func TestLoadCycle(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
-
 }
 
 func TestLoadCycleBinding(t *testing.T) {
@@ -369,7 +368,7 @@ func TestLoadCycleBinding(t *testing.T) {
 	require.NoError(t, err)
 
 	arc := r1.MakeArchive()
-	r2, err := NewFromArchive(arc, lib.RuntimeOptions{})
+	r2, err := NewFromArchive(logrus.StandardLogger(), arc, lib.RuntimeOptions{})
 	require.NoError(t, err)
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
@@ -433,7 +432,7 @@ func TestBrowserified(t *testing.T) {
 	require.NoError(t, err)
 
 	arc := r1.MakeArchive()
-	r2, err := NewFromArchive(arc, lib.RuntimeOptions{})
+	r2, err := NewFromArchive(logrus.StandardLogger(), arc, lib.RuntimeOptions{})
 	require.NoError(t, err)
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
@@ -452,6 +451,7 @@ func TestBrowserified(t *testing.T) {
 		})
 	}
 }
+
 func TestLoadingUnexistingModuleDoesntPanic(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	data := `var b;
@@ -470,11 +470,11 @@ func TestLoadingUnexistingModuleDoesntPanic(t *testing.T) {
 	require.NoError(t, err)
 
 	arc := r1.MakeArchive()
-	var buf = &bytes.Buffer{}
+	buf := &bytes.Buffer{}
 	require.NoError(t, arc.Write(buf))
 	arc, err = lib.ReadArchive(buf)
 	require.NoError(t, err)
-	r2, err := NewFromArchive(arc, lib.RuntimeOptions{})
+	r2, err := NewFromArchive(logrus.StandardLogger(), arc, lib.RuntimeOptions{})
 	require.NoError(t, err)
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}

--- a/js/modules/k6/http/http_test.go
+++ b/js/modules/k6/http/http_test.go
@@ -48,7 +48,7 @@ func TestTagURL(t *testing.T) {
 		t.Run("expr="+expr, func(t *testing.T) {
 			tag, err := httpext.NewURL(data.u, data.n)
 			require.NoError(t, err)
-			v, err := common.RunES6String(t, rt, "http.url`"+expr+"`")
+			v, err := runES6String(t, rt, "http.url`"+expr+"`")
 			if assert.NoError(t, err) {
 				assert.Equal(t, tag, v.Export())
 			}

--- a/js/modules/k6/http/http_test.go
+++ b/js/modules/k6/http/http_test.go
@@ -48,7 +48,7 @@ func TestTagURL(t *testing.T) {
 		t.Run("expr="+expr, func(t *testing.T) {
 			tag, err := httpext.NewURL(data.u, data.n)
 			require.NoError(t, err)
-			v, err := common.RunES6String(rt, "http.url`"+expr+"`")
+			v, err := common.RunES6String(t, rt, "http.url`"+expr+"`")
 			if assert.NoError(t, err) {
 				assert.Equal(t, tag, v.Export())
 			}

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -126,7 +126,7 @@ func newRuntime(
 		SystemTags:   &stats.DefaultSystemTagSet,
 		Batch:        null.IntFrom(20),
 		BatchPerHost: null.IntFrom(20),
-		//HTTPDebug:    null.StringFrom("full"),
+		// HTTPDebug:    null.StringFrom("full"),
 	}
 	samples := make(chan stats.SampleContainer, 1000)
 
@@ -240,7 +240,6 @@ func TestRequestAndBatch(t *testing.T) {
 		})
 
 		t.Run("post body", func(t *testing.T) {
-
 			tb.Mux.HandleFunc("/post-redirect", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				require.Equal(t, r.Method, "POST")
 				_, _ = io.Copy(ioutil.Discard, r.Body)
@@ -255,7 +254,6 @@ func TestRequestAndBatch(t *testing.T) {
 			`))
 			assert.NoError(t, err)
 		})
-
 	})
 	t.Run("Timeout", func(t *testing.T) {
 		t.Run("10s", func(t *testing.T) {
@@ -1277,13 +1275,13 @@ func TestRequestCompression(t *testing.T) {
 	// We don't expect any failed requests
 	state.Options.Throw = null.BoolFrom(true)
 
-	var text = `
+	text := `
 	Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 	Maecenas sed pharetra sapien. Nunc laoreet molestie ante ac gravida.
 	Etiam interdum dui viverra posuere egestas. Pellentesque at dolor tristique,
 	mattis turpis eget, commodo purus. Nunc orci aliquam.`
 
-	var decompress = func(algo string, input io.Reader) io.Reader {
+	decompress := func(algo string, input io.Reader) io.Reader {
 		switch algo {
 		case "br":
 			w := brotli.NewReader(input)
@@ -1321,8 +1319,8 @@ func TestRequestCompression(t *testing.T) {
 
 		expectedLength, err := strconv.Atoi(r.Header.Get("Content-Length"))
 		require.NoError(t, err)
-		var algos = strings.Split(actualEncoding, ", ")
-		var compressedBuf = new(bytes.Buffer)
+		algos := strings.Split(actualEncoding, ", ")
+		compressedBuf := new(bytes.Buffer)
 		n, err := io.Copy(compressedBuf, r.Body)
 		require.Equal(t, int(n), expectedLength)
 		require.NoError(t, err)
@@ -1340,7 +1338,7 @@ func TestRequestCompression(t *testing.T) {
 		require.Equal(t, text, buf.String())
 	}))
 
-	var testCases = []struct {
+	testCases := []struct {
 		name          string
 		compression   string
 		expectedError string
@@ -1371,7 +1369,7 @@ func TestRequestCompression(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.compression, func(t *testing.T) {
-			var algos = strings.Split(testCase.compression, ",")
+			algos := strings.Split(testCase.compression, ",")
 			for i, algo := range algos {
 				algos[i] = strings.TrimSpace(algo)
 			}
@@ -1386,7 +1384,6 @@ func TestRequestCompression(t *testing.T) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), testCase.expectedError)
 			}
-
 		})
 	}
 
@@ -1433,7 +1430,7 @@ func TestRequestCompression(t *testing.T) {
 			require.Empty(t, logHook.Drain())
 		})
 
-		//TODO: move to some other test?
+		// TODO: move to some other test?
 		t.Run("correct length", func(t *testing.T) {
 			_, err := common.RunString(rt, tb.Replacer.Replace(
 				`http.post("HTTPBIN_URL/post", "0123456789", { "headers": {"Content-Length": "10"}});`,
@@ -1568,7 +1565,7 @@ func TestResponseTypes(t *testing.T) {
 }
 
 func checkErrorCode(t testing.TB, tags *stats.SampleTags, code int, msg string) {
-	var errorMsg, ok = tags.Get("error")
+	errorMsg, ok := tags.Get("error")
 	if msg == "" {
 		assert.False(t, ok)
 	} else {
@@ -1578,7 +1575,7 @@ func checkErrorCode(t testing.TB, tags *stats.SampleTags, code int, msg string) 
 	if code == 0 {
 		assert.False(t, ok)
 	} else {
-		var errorCode, err = strconv.Atoi(errorCodeStr)
+		errorCode, err := strconv.Atoi(errorCodeStr)
 		assert.NoError(t, err)
 		assert.Equal(t, code, errorCode)
 	}
@@ -1600,7 +1597,7 @@ func TestErrorCodes(t *testing.T) {
 		w.WriteHeader(302)
 	}))
 
-	var testCases = []struct {
+	testCases := []struct {
 		name                string
 		status              int
 		moreSamples         int
@@ -1684,7 +1681,7 @@ func TestErrorCodes(t *testing.T) {
 				require.Error(t, err)
 				require.Equal(t, err.Error(), testCase.expectedScriptError)
 			}
-			var cs = stats.GetBufferedSamples(samples)
+			cs := stats.GetBufferedSamples(samples)
 			assert.Len(t, cs, 1+testCase.moreSamples)
 			for _, c := range cs[len(cs)-1:] {
 				assert.NotZero(t, len(c.GetSamples()))

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -965,7 +965,7 @@ func TestRequestAndBatch(t *testing.T) {
 		assertRequestMetricsEmitted(t, stats.GetBufferedSamples(samples), "GET", sr("HTTPBIN_URL/get?a=1&b=2"), "", 200, "")
 
 		t.Run("Tagged", func(t *testing.T) {
-			_, err := common.RunES6String(rt, `
+			_, err := common.RunES6String(t, rt, `
 			var a = "1";
 			var b = "2";
 			var res = http.get(http.url`+"`"+sr(`HTTPBIN_URL/get?a=${a}&b=${b}`)+"`"+`);
@@ -1075,7 +1075,7 @@ func TestRequestAndBatch(t *testing.T) {
 			assertRequestMetricsEmitted(t, bufSamples, "GET", sr("HTTPBIN_IP_URL/"), "", 200, "")
 
 			t.Run("Tagged", func(t *testing.T) {
-				_, err := common.RunES6String(rt, sr(`
+				_, err := common.RunES6String(t, rt, sr(`
 				let fragment = "get";
 				let reqs = [
 					["GET", http.url`+"`"+`HTTPBIN_URL/${fragment}`+"`"+`],
@@ -1109,7 +1109,7 @@ func TestRequestAndBatch(t *testing.T) {
 				assertRequestMetricsEmitted(t, bufSamples, "GET", sr("HTTPBIN_IP_URL/"), "", 200, "")
 
 				t.Run("Tagged", func(t *testing.T) {
-					_, err := common.RunES6String(rt, sr(`
+					_, err := common.RunES6String(t, rt, sr(`
 					let fragment = "get";
 					let reqs = [
 						http.url`+"`"+`HTTPBIN_URL/${fragment}`+"`"+`,
@@ -1375,7 +1375,7 @@ func TestRequestCompression(t *testing.T) {
 			}
 			expectedEncoding = strings.Join(algos, ", ")
 			actualEncoding = expectedEncoding
-			_, err := common.RunES6String(rt, tb.Replacer.Replace(`
+			_, err := common.RunES6String(t, rt, tb.Replacer.Replace(`
 		http.post("HTTPBIN_URL/compressed-text", `+"`"+text+"`"+`,  {"compression": "`+testCase.compression+`"});
 	`))
 			if testCase.expectedError == "" {
@@ -1393,7 +1393,7 @@ func TestRequestCompression(t *testing.T) {
 
 		logHook.Drain()
 		t.Run("encoding", func(t *testing.T) {
-			_, err := common.RunES6String(rt, tb.Replacer.Replace(`
+			_, err := common.RunES6String(t, rt, tb.Replacer.Replace(`
 				http.post("HTTPBIN_URL/compressed-text", `+"`"+text+"`"+`,
 					{"compression": "`+actualEncoding+`",
 					 "headers": {"Content-Encoding": "`+expectedEncoding+`"}
@@ -1405,7 +1405,7 @@ func TestRequestCompression(t *testing.T) {
 		})
 
 		t.Run("encoding and length", func(t *testing.T) {
-			_, err := common.RunES6String(rt, tb.Replacer.Replace(`
+			_, err := common.RunES6String(t, rt, tb.Replacer.Replace(`
 				http.post("HTTPBIN_URL/compressed-text", `+"`"+text+"`"+`,
 					{"compression": "`+actualEncoding+`",
 					 "headers": {"Content-Encoding": "`+expectedEncoding+`",
@@ -1419,7 +1419,7 @@ func TestRequestCompression(t *testing.T) {
 
 		expectedEncoding = actualEncoding
 		t.Run("correct encoding", func(t *testing.T) {
-			_, err := common.RunES6String(rt, tb.Replacer.Replace(`
+			_, err := common.RunES6String(t, rt, tb.Replacer.Replace(`
 				http.post("HTTPBIN_URL/compressed-text", `+"`"+text+"`"+`,
 					{"compression": "`+actualEncoding+`",
 					 "headers": {"Content-Encoding": "`+actualEncoding+`"}

--- a/js/modules/k6/marshalling_test.go
+++ b/js/modules/k6/marshalling_test.go
@@ -26,12 +26,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/loadimpact/k6/js"
 	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/testutils"
 	"github.com/loadimpact/k6/lib/testutils/httpmultibin"
 	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/loader"
@@ -117,7 +117,7 @@ func TestSetupDataMarshalling(t *testing.T) {
 	`))
 
 	runner, err := js.New(
-		logrus.StandardLogger(),
+		testutils.NewLogger(t),
 		&loader.SourceData{URL: &url.URL{Path: "/script.js"}, Data: script},
 		nil,
 		lib.RuntimeOptions{},

--- a/js/modules/k6/marshalling_test.go
+++ b/js/modules/k6/marshalling_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -116,6 +117,7 @@ func TestSetupDataMarshalling(t *testing.T) {
 	`))
 
 	runner, err := js.New(
+		logrus.StandardLogger(),
 		&loader.SourceData{URL: &url.URL{Path: "/script.js"}, Data: script},
 		nil,
 		lib.RuntimeOptions{},

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -99,7 +99,7 @@ func TestRunnerGetDefaultGroup(t *testing.T) {
 		assert.NotNil(t, r1.GetDefaultGroup())
 	}
 
-	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
 	if assert.NoError(t, err) {
 		assert.NotNil(t, r2.GetDefaultGroup())
 	}
@@ -111,7 +111,7 @@ func TestRunnerOptions(t *testing.T) {
 		return
 	}
 
-	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -199,7 +199,7 @@ func TestOptionsPropagationToScript(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expScriptOptions, r1.GetOptions())
 
-	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{Env: map[string]string{"expectedSetupTimeout": "3s"}})
+	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{Env: map[string]string{"expectedSetupTimeout": "3s"}})
 
 	require.NoError(t, err)
 	require.Equal(t, expScriptOptions, r2.GetOptions())
@@ -478,7 +478,7 @@ func TestRunnerIntegrationImports(t *testing.T) {
 					}`, data.path), fs)
 				require.NoError(t, err)
 
-				r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
+				r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
 				require.NoError(t, err)
 
 				testdata := map[string]*Runner{"Source": r1, "Archive": r2}
@@ -507,7 +507,7 @@ func TestVURunContext(t *testing.T) {
 	require.NoError(t, err)
 	r1.SetOptions(r1.GetOptions().Apply(lib.Options{Throw: null.BoolFrom(true)}))
 
-	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -558,7 +558,7 @@ func TestVURunInterrupt(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, r1.SetOptions(lib.Options{Throw: null.BoolFrom(true)}))
 
-	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
 	require.NoError(t, err)
 	testdata := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range testdata {
@@ -596,7 +596,7 @@ func TestVURunInterruptDoesntPanic(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, r1.SetOptions(lib.Options{Throw: null.BoolFrom(true)}))
 
-	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
 	require.NoError(t, err)
 	testdata := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range testdata {
@@ -651,7 +651,7 @@ func TestVUIntegrationGroups(t *testing.T) {
 		`)
 	require.NoError(t, err)
 
-	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
 	require.NoError(t, err)
 
 	testdata := map[string]*Runner{"Source": r1, "Archive": r2}
@@ -704,7 +704,7 @@ func TestVUIntegrationMetrics(t *testing.T) {
 		`)
 	require.NoError(t, err)
 
-	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
 	require.NoError(t, err)
 
 	testdata := map[string]*Runner{"Source": r1, "Archive": r2}
@@ -778,7 +778,7 @@ func TestVUIntegrationInsecureRequests(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, r1.SetOptions(lib.Options{Throw: null.BoolFrom(true)}.Apply(data.opts)))
 
-			r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
+			r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
 			require.NoError(t, err)
 			runners := map[string]*Runner{"Source": r1, "Archive": r2}
 			for name, r := range runners {
@@ -824,7 +824,7 @@ func TestVUIntegrationBlacklistOption(t *testing.T) {
 		BlacklistIPs: []*lib.IPNet{cidr},
 	}))
 
-	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -862,7 +862,7 @@ func TestVUIntegrationBlacklistScript(t *testing.T) {
 		return
 	}
 
-	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -914,7 +914,7 @@ func TestVUIntegrationHosts(t *testing.T) {
 		},
 	})
 
-	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -988,7 +988,7 @@ func TestVUIntegrationTLSConfig(t *testing.T) {
 			}
 			require.NoError(t, r1.SetOptions(lib.Options{Throw: null.BoolFrom(true)}.Apply(data.opts)))
 
-			r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
+			r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
 			if !assert.NoError(t, err) {
 				return
 			}
@@ -1082,7 +1082,7 @@ func TestVUIntegrationCookiesReset(t *testing.T) {
 		Hosts:        tb.Dialer.Hosts,
 	})
 
-	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -1141,7 +1141,7 @@ func TestVUIntegrationCookiesNoReset(t *testing.T) {
 		NoCookiesReset: null.BoolFrom(true),
 	})
 
-	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -1178,7 +1178,7 @@ func TestVUIntegrationVUID(t *testing.T) {
 	}
 	r1.SetOptions(lib.Options{Throw: null.BoolFrom(true)})
 
-	r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -1278,7 +1278,7 @@ func TestVUIntegrationClientCerts(t *testing.T) {
 	}))
 
 	t.Run("Unauthenticated", func(t *testing.T) {
-		r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
+		r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -1328,7 +1328,7 @@ func TestVUIntegrationClientCerts(t *testing.T) {
 	}))
 
 	t.Run("Authenticated", func(t *testing.T) {
-		r2, err := NewFromArchive(r1.MakeArchive(), lib.RuntimeOptions{})
+		r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -1476,7 +1476,7 @@ func TestArchiveRunningIntegrity(t *testing.T) {
 
 	arc, err := lib.ReadArchive(buf)
 	require.NoError(t, err)
-	r2, err := NewFromArchive(arc, lib.RuntimeOptions{})
+	r2, err := NewFromArchive(logrus.StandardLogger(), arc, lib.RuntimeOptions{})
 	require.NoError(t, err)
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
@@ -1511,7 +1511,7 @@ func TestArchiveNotPanicking(t *testing.T) {
 
 	arc := r1.MakeArchive()
 	arc.Filesystems = map[string]afero.Fs{"file": afero.NewMemMapFs()}
-	r2, err := NewFromArchive(arc, lib.RuntimeOptions{})
+	r2, err := NewFromArchive(logrus.StandardLogger(), arc, lib.RuntimeOptions{})
 	// we do want this to error here as this is where we find out that a given file is not in the
 	// archive
 	require.Error(t, err)
@@ -1630,7 +1630,7 @@ func TestSystemTags(t *testing.T) {
 		{"error", "bad_url_get", `dial: connection refused`},
 		{"error_code", "bad_url_get", "1212"},
 		{"scenario", "http_get", "default"},
-		//TODO: add more tests
+		// TODO: add more tests
 	}
 
 	samples := make(chan stats.SampleContainer, 100)

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -37,8 +37,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -55,6 +53,7 @@ import (
 	"github.com/loadimpact/k6/lib"
 	_ "github.com/loadimpact/k6/lib/executor" // TODO: figure out something better
 	"github.com/loadimpact/k6/lib/metrics"
+	"github.com/loadimpact/k6/lib/testutils"
 	"github.com/loadimpact/k6/lib/testutils/httpmultibin"
 	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/stats"
@@ -63,7 +62,7 @@ import (
 
 func TestRunnerNew(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
-		r, err := getSimpleRunner("/script.js", `
+		r, err := getSimpleRunner(t, "/script.js", `
 			var counter = 0;
 			exports.default = function() { counter++; }
 		`)
@@ -88,30 +87,30 @@ func TestRunnerNew(t *testing.T) {
 	})
 
 	t.Run("Invalid", func(t *testing.T) {
-		_, err := getSimpleRunner("/script.js", `blarg`)
+		_, err := getSimpleRunner(t, "/script.js", `blarg`)
 		assert.EqualError(t, err, "ReferenceError: blarg is not defined at file:///script.js:1:1(0)")
 	})
 }
 
 func TestRunnerGetDefaultGroup(t *testing.T) {
-	r1, err := getSimpleRunner("/script.js", `exports.default = function() {};`)
+	r1, err := getSimpleRunner(t, "/script.js", `exports.default = function() {};`)
 	if assert.NoError(t, err) {
 		assert.NotNil(t, r1.GetDefaultGroup())
 	}
 
-	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(testutils.NewLogger(t), r1.MakeArchive(), lib.RuntimeOptions{})
 	if assert.NoError(t, err) {
 		assert.NotNil(t, r2.GetDefaultGroup())
 	}
 }
 
 func TestRunnerOptions(t *testing.T) {
-	r1, err := getSimpleRunner("/script.js", `exports.default = function() {};`)
+	r1, err := getSimpleRunner(t, "/script.js", `exports.default = function() {};`)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(testutils.NewLogger(t), r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -155,7 +154,7 @@ func TestOptionsSettingToScript(t *testing.T) {
 							throw new Error("expected teardownTimeout to be " + __ENV.expectedTeardownTimeout + " but it was " + options.teardownTimeout);
 						}
 					};`
-			r, err := getSimpleRunner("/script.js", data,
+			r, err := getSimpleRunner(t, "/script.js", data,
 				lib.RuntimeOptions{Env: map[string]string{"expectedTeardownTimeout": "4s"}})
 			require.NoError(t, err)
 
@@ -194,12 +193,12 @@ func TestOptionsPropagationToScript(t *testing.T) {
 			};`
 
 	expScriptOptions := lib.Options{SetupTimeout: types.NullDurationFrom(1 * time.Second)}
-	r1, err := getSimpleRunner("/script.js", data,
+	r1, err := getSimpleRunner(t, "/script.js", data,
 		lib.RuntimeOptions{Env: map[string]string{"expectedSetupTimeout": "1s"}})
 	require.NoError(t, err)
 	require.Equal(t, expScriptOptions, r1.GetOptions())
 
-	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{Env: map[string]string{"expectedSetupTimeout": "3s"}})
+	r2, err := NewFromArchive(testutils.NewLogger(t), r1.MakeArchive(), lib.RuntimeOptions{Env: map[string]string{"expectedSetupTimeout": "3s"}})
 
 	require.NoError(t, err)
 	require.Equal(t, expScriptOptions, r2.GetOptions())
@@ -240,7 +239,7 @@ func TestMetricName(t *testing.T) {
 		}
 	`)
 
-	_, err := getSimpleRunner("/script.js", script)
+	_, err := getSimpleRunner(t, "/script.js", script)
 	require.Error(t, err)
 }
 
@@ -284,15 +283,15 @@ func TestSetupDataIsolation(t *testing.T) {
 		}
 	`)
 
-	runner, err := getSimpleRunner("/script.js", script)
+	runner, err := getSimpleRunner(t, "/script.js", script)
 	require.NoError(t, err)
 
 	options := runner.GetOptions()
 	require.Empty(t, options.Validate())
 
-	execScheduler, err := local.NewExecutionScheduler(runner, logrus.StandardLogger())
+	execScheduler, err := local.NewExecutionScheduler(runner, testutils.NewLogger(t))
 	require.NoError(t, err)
-	engine, err := core.NewEngine(execScheduler, options, logrus.StandardLogger())
+	engine, err := core.NewEngine(execScheduler, options, testutils.NewLogger(t))
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -333,7 +332,7 @@ func testSetupDataHelper(t *testing.T, data string) {
 		SetupTimeout:    types.NullDurationFrom(1 * time.Second),
 		TeardownTimeout: types.NullDurationFrom(1 * time.Second),
 	}
-	r1, err := getSimpleRunner("/script.js", data) // TODO fix this
+	r1, err := getSimpleRunner(t, "/script.js", data) // TODO fix this
 	require.NoError(t, err)
 	require.Equal(t, expScriptOptions, r1.GetOptions())
 
@@ -395,7 +394,7 @@ func TestSetupDataNoSetup(t *testing.T) {
 }
 
 func TestConsoleInInitContext(t *testing.T) {
-	r1, err := getSimpleRunner("/script.js", `
+	r1, err := getSimpleRunner(t, "/script.js", `
 			console.log("1");
 			exports.default = function(data) {
 			};
@@ -449,7 +448,7 @@ func TestRunnerIntegrationImports(t *testing.T) {
 			mod := mod
 			t.Run(mod, func(t *testing.T) {
 				t.Run("Source", func(t *testing.T) {
-					_, err := getSimpleRunner("/script.js", fmt.Sprintf(`import "%s"; exports.default = function() {}`, mod), rtOpts)
+					_, err := getSimpleRunner(t, "/script.js", fmt.Sprintf(`import "%s"; exports.default = function() {}`, mod), rtOpts)
 					assert.NoError(t, err)
 				})
 			})
@@ -458,8 +457,8 @@ func TestRunnerIntegrationImports(t *testing.T) {
 
 	t.Run("Files", func(t *testing.T) {
 		fs := afero.NewMemMapFs()
-		require.NoError(t, fs.MkdirAll("/path/to", 0755))
-		require.NoError(t, afero.WriteFile(fs, "/path/to/lib.js", []byte(`exports.default = "hi!";`), 0644))
+		require.NoError(t, fs.MkdirAll("/path/to", 0o755))
+		require.NoError(t, afero.WriteFile(fs, "/path/to/lib.js", []byte(`exports.default = "hi!";`), 0o644))
 
 		testdata := map[string]struct{ filename, path string }{
 			"Absolute":       {"/path/script.js", "/path/to/lib.js"},
@@ -471,14 +470,14 @@ func TestRunnerIntegrationImports(t *testing.T) {
 		for name, data := range testdata {
 			name, data := name, data
 			t.Run(name, func(t *testing.T) {
-				r1, err := getSimpleRunner(data.filename, fmt.Sprintf(`
+				r1, err := getSimpleRunner(t, data.filename, fmt.Sprintf(`
 					var hi = require("%s").default;
 					exports.default = function() {
 						if (hi != "hi!") { throw new Error("incorrect value"); }
 					}`, data.path), fs)
 				require.NoError(t, err)
 
-				r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
+				r2, err := NewFromArchive(testutils.NewLogger(t), r1.MakeArchive(), lib.RuntimeOptions{})
 				require.NoError(t, err)
 
 				testdata := map[string]*Runner{"Source": r1, "Archive": r2}
@@ -500,14 +499,14 @@ func TestRunnerIntegrationImports(t *testing.T) {
 }
 
 func TestVURunContext(t *testing.T) {
-	r1, err := getSimpleRunner("/script.js", `
+	r1, err := getSimpleRunner(t, "/script.js", `
 		exports.options = { vus: 10 };
 		exports.default = function() { fn(); }
 		`)
 	require.NoError(t, err)
 	r1.SetOptions(r1.GetOptions().Apply(lib.Options{Throw: null.BoolFrom(true)}))
 
-	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(testutils.NewLogger(t), r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -552,13 +551,13 @@ func TestVURunInterrupt(t *testing.T) {
 		t.Skip()
 	}
 
-	r1, err := getSimpleRunner("/script.js", `
+	r1, err := getSimpleRunner(t, "/script.js", `
 		exports.default = function() { while(true) {} }
 		`)
 	require.NoError(t, err)
 	require.NoError(t, r1.SetOptions(lib.Options{Throw: null.BoolFrom(true)}))
 
-	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(testutils.NewLogger(t), r1.MakeArchive(), lib.RuntimeOptions{})
 	require.NoError(t, err)
 	testdata := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range testdata {
@@ -590,13 +589,13 @@ func TestVURunInterruptDoesntPanic(t *testing.T) {
 		t.Skip()
 	}
 
-	r1, err := getSimpleRunner("/script.js", `
+	r1, err := getSimpleRunner(t, "/script.js", `
 		exports.default = function() { while(true) {} }
 		`)
 	require.NoError(t, err)
 	require.NoError(t, r1.SetOptions(lib.Options{Throw: null.BoolFrom(true)}))
 
-	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(testutils.NewLogger(t), r1.MakeArchive(), lib.RuntimeOptions{})
 	require.NoError(t, err)
 	testdata := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range testdata {
@@ -637,7 +636,7 @@ func TestVURunInterruptDoesntPanic(t *testing.T) {
 }
 
 func TestVUIntegrationGroups(t *testing.T) {
-	r1, err := getSimpleRunner("/script.js", `
+	r1, err := getSimpleRunner(t, "/script.js", `
 		var group = require("k6").group;
 		exports.default = function() {
 			fnOuter();
@@ -651,7 +650,7 @@ func TestVUIntegrationGroups(t *testing.T) {
 		`)
 	require.NoError(t, err)
 
-	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(testutils.NewLogger(t), r1.MakeArchive(), lib.RuntimeOptions{})
 	require.NoError(t, err)
 
 	testdata := map[string]*Runner{"Source": r1, "Archive": r2}
@@ -696,7 +695,7 @@ func TestVUIntegrationGroups(t *testing.T) {
 }
 
 func TestVUIntegrationMetrics(t *testing.T) {
-	r1, err := getSimpleRunner("/script.js", `
+	r1, err := getSimpleRunner(t, "/script.js", `
 		var group = require("k6").group;
 		var Trend = require("k6/metrics").Trend;
 		var myMetric = new Trend("my_metric");
@@ -704,7 +703,7 @@ func TestVUIntegrationMetrics(t *testing.T) {
 		`)
 	require.NoError(t, err)
 
-	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(testutils.NewLogger(t), r1.MakeArchive(), lib.RuntimeOptions{})
 	require.NoError(t, err)
 
 	testdata := map[string]*Runner{"Source": r1, "Archive": r2}
@@ -771,14 +770,14 @@ func TestVUIntegrationInsecureRequests(t *testing.T) {
 	for name, data := range testdata {
 		data := data
 		t.Run(name, func(t *testing.T) {
-			r1, err := getSimpleRunner("/script.js", `
+			r1, err := getSimpleRunner(t, "/script.js", `
 					var http = require("k6/http");;
 					exports.default = function() { http.get("https://expired.badssl.com/"); }
 				`)
 			require.NoError(t, err)
 			require.NoError(t, r1.SetOptions(lib.Options{Throw: null.BoolFrom(true)}.Apply(data.opts)))
 
-			r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
+			r2, err := NewFromArchive(testutils.NewLogger(t), r1.MakeArchive(), lib.RuntimeOptions{})
 			require.NoError(t, err)
 			runners := map[string]*Runner{"Source": r1, "Archive": r2}
 			for name, r := range runners {
@@ -808,7 +807,7 @@ func TestVUIntegrationInsecureRequests(t *testing.T) {
 }
 
 func TestVUIntegrationBlacklistOption(t *testing.T) {
-	r1, err := getSimpleRunner("/script.js", `
+	r1, err := getSimpleRunner(t, "/script.js", `
 					var http = require("k6/http");;
 					exports.default = function() { http.get("http://10.1.2.3/"); }
 				`)
@@ -824,7 +823,7 @@ func TestVUIntegrationBlacklistOption(t *testing.T) {
 		BlacklistIPs: []*lib.IPNet{cidr},
 	}))
 
-	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(testutils.NewLogger(t), r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -848,7 +847,7 @@ func TestVUIntegrationBlacklistOption(t *testing.T) {
 }
 
 func TestVUIntegrationBlacklistScript(t *testing.T) {
-	r1, err := getSimpleRunner("/script.js", `
+	r1, err := getSimpleRunner(t, "/script.js", `
 					var http = require("k6/http");;
 
 					exports.options = {
@@ -862,7 +861,7 @@ func TestVUIntegrationBlacklistScript(t *testing.T) {
 		return
 	}
 
-	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(testutils.NewLogger(t), r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -890,7 +889,7 @@ func TestVUIntegrationHosts(t *testing.T) {
 	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 
-	r1, err := getSimpleRunner("/script.js",
+	r1, err := getSimpleRunner(t, "/script.js",
 		tb.Replacer.Replace(`
 					var k6 = require("k6");
 					var check = k6.check;
@@ -914,7 +913,7 @@ func TestVUIntegrationHosts(t *testing.T) {
 		},
 	})
 
-	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(testutils.NewLogger(t), r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -979,7 +978,7 @@ func TestVUIntegrationTLSConfig(t *testing.T) {
 	for name, data := range testdata {
 		data := data
 		t.Run(name, func(t *testing.T) {
-			r1, err := getSimpleRunner("/script.js", `
+			r1, err := getSimpleRunner(t, "/script.js", `
 					var http = require("k6/http");;
 					exports.default = function() { http.get("https://sha256.badssl.com/"); }
 				`)
@@ -988,7 +987,7 @@ func TestVUIntegrationTLSConfig(t *testing.T) {
 			}
 			require.NoError(t, r1.SetOptions(lib.Options{Throw: null.BoolFrom(true)}.Apply(data.opts)))
 
-			r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
+			r2, err := NewFromArchive(testutils.NewLogger(t), r1.MakeArchive(), lib.RuntimeOptions{})
 			if !assert.NoError(t, err) {
 				return
 			}
@@ -1020,7 +1019,7 @@ func TestVUIntegrationTLSConfig(t *testing.T) {
 }
 
 func TestVUIntegrationOpenFunctionError(t *testing.T) {
-	r, err := getSimpleRunner("/script.js", `
+	r, err := getSimpleRunner(t, "/script.js", `
 			exports.default = function() { open("/tmp/foo") }
 		`)
 	assert.NoError(t, err)
@@ -1036,7 +1035,7 @@ func TestVUIntegrationOpenFunctionError(t *testing.T) {
 }
 
 func TestVUIntegrationOpenFunctionErrorWhenSneaky(t *testing.T) {
-	r, err := getSimpleRunner("/script.js", `
+	r, err := getSimpleRunner(t, "/script.js", `
 			var sneaky = open;
 			exports.default = function() { sneaky("/tmp/foo") }
 		`)
@@ -1056,7 +1055,7 @@ func TestVUIntegrationCookiesReset(t *testing.T) {
 	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 
-	r1, err := getSimpleRunner("/script.js", tb.Replacer.Replace(`
+	r1, err := getSimpleRunner(t, "/script.js", tb.Replacer.Replace(`
 			var http = require("k6/http");;
 			exports.default = function() {
 				var url = "HTTPBIN_URL";
@@ -1082,7 +1081,7 @@ func TestVUIntegrationCookiesReset(t *testing.T) {
 		Hosts:        tb.Dialer.Hosts,
 	})
 
-	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(testutils.NewLogger(t), r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -1110,7 +1109,7 @@ func TestVUIntegrationCookiesNoReset(t *testing.T) {
 	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 
-	r1, err := getSimpleRunner("/script.js", tb.Replacer.Replace(`
+	r1, err := getSimpleRunner(t, "/script.js", tb.Replacer.Replace(`
 			var http = require("k6/http");;
 			exports.default = function() {
 				var url = "HTTPBIN_URL";
@@ -1141,7 +1140,7 @@ func TestVUIntegrationCookiesNoReset(t *testing.T) {
 		NoCookiesReset: null.BoolFrom(true),
 	})
 
-	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(testutils.NewLogger(t), r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -1168,7 +1167,7 @@ func TestVUIntegrationCookiesNoReset(t *testing.T) {
 }
 
 func TestVUIntegrationVUID(t *testing.T) {
-	r1, err := getSimpleRunner("/script.js", `
+	r1, err := getSimpleRunner(t, "/script.js", `
 			exports.default = function() {
 				if (__VU != 1234) { throw new Error("wrong __VU: " + __VU); }
 			}`,
@@ -1178,7 +1177,7 @@ func TestVUIntegrationVUID(t *testing.T) {
 	}
 	r1.SetOptions(lib.Options{Throw: null.BoolFrom(true)})
 
-	r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
+	r2, err := NewFromArchive(testutils.NewLogger(t), r1.MakeArchive(), lib.RuntimeOptions{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -1265,7 +1264,7 @@ func TestVUIntegrationClientCerts(t *testing.T) {
 	}
 	go func() { _ = srv.Serve(listener) }()
 
-	r1, err := getSimpleRunner("/script.js", fmt.Sprintf(`
+	r1, err := getSimpleRunner(t, "/script.js", fmt.Sprintf(`
 			var http = require("k6/http");;
 			exports.default = function() { http.get("https://%s")}
 		`, listener.Addr().String()))
@@ -1278,7 +1277,7 @@ func TestVUIntegrationClientCerts(t *testing.T) {
 	}))
 
 	t.Run("Unauthenticated", func(t *testing.T) {
-		r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
+		r2, err := NewFromArchive(testutils.NewLogger(t), r1.MakeArchive(), lib.RuntimeOptions{})
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -1328,7 +1327,7 @@ func TestVUIntegrationClientCerts(t *testing.T) {
 	}))
 
 	t.Run("Authenticated", func(t *testing.T) {
-		r2, err := NewFromArchive(logrus.StandardLogger(), r1.MakeArchive(), lib.RuntimeOptions{})
+		r2, err := NewFromArchive(testutils.NewLogger(t), r1.MakeArchive(), lib.RuntimeOptions{})
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -1354,7 +1353,7 @@ func TestHTTPRequestInInitContext(t *testing.T) {
 	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 
-	_, err := getSimpleRunner("/script.js", tb.Replacer.Replace(`
+	_, err := getSimpleRunner(t, "/script.js", tb.Replacer.Replace(`
 					var k6 = require("k6");
 					var check = k6.check;
 					var fail = k6.fail;
@@ -1438,7 +1437,7 @@ func TestInitContextForbidden(t *testing.T) {
 	for _, test := range table {
 		test := test
 		t.Run(test[0], func(t *testing.T) {
-			_, err := getSimpleRunner("/script.js", tb.Replacer.Replace(test[1]))
+			_, err := getSimpleRunner(t, "/script.js", tb.Replacer.Replace(test[1]))
 			if assert.Error(t, err) {
 				assert.Contains(
 					t,
@@ -1468,7 +1467,7 @@ func TestArchiveRunningIntegrity(t *testing.T) {
 		`)
 	require.NoError(t, afero.WriteFile(fs, "/home/somebody/test.json", []byte(`42`), os.ModePerm))
 	require.NoError(t, afero.WriteFile(fs, "/script.js", []byte(data), os.ModePerm))
-	r1, err := getSimpleRunner("/script.js", data, fs)
+	r1, err := getSimpleRunner(t, "/script.js", data, fs)
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(nil)
@@ -1476,7 +1475,7 @@ func TestArchiveRunningIntegrity(t *testing.T) {
 
 	arc, err := lib.ReadArchive(buf)
 	require.NoError(t, err)
-	r2, err := NewFromArchive(logrus.StandardLogger(), arc, lib.RuntimeOptions{})
+	r2, err := NewFromArchive(testutils.NewLogger(t), arc, lib.RuntimeOptions{})
 	require.NoError(t, err)
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
@@ -1503,7 +1502,7 @@ func TestArchiveNotPanicking(t *testing.T) {
 
 	fs := afero.NewMemMapFs()
 	require.NoError(t, afero.WriteFile(fs, "/non/existent", []byte(`42`), os.ModePerm))
-	r1, err := getSimpleRunner("/script.js", tb.Replacer.Replace(`
+	r1, err := getSimpleRunner(t, "/script.js", tb.Replacer.Replace(`
 			var fput = open("/non/existent");
 			exports.default = function(data) {}
 		`), fs)
@@ -1511,7 +1510,7 @@ func TestArchiveNotPanicking(t *testing.T) {
 
 	arc := r1.MakeArchive()
 	arc.Filesystems = map[string]afero.Fs{"file": afero.NewMemMapFs()}
-	r2, err := NewFromArchive(logrus.StandardLogger(), arc, lib.RuntimeOptions{})
+	r2, err := NewFromArchive(testutils.NewLogger(t), arc, lib.RuntimeOptions{})
 	// we do want this to error here as this is where we find out that a given file is not in the
 	// archive
 	require.Error(t, err)
@@ -1522,7 +1521,7 @@ func TestStuffNotPanicking(t *testing.T) {
 	tb := httpmultibin.NewHTTPMultiBin(t)
 	defer tb.Cleanup()
 
-	r, err := getSimpleRunner("/script.js", tb.Replacer.Replace(`
+	r, err := getSimpleRunner(t, "/script.js", tb.Replacer.Replace(`
 			var http = require("k6/http");
 			var ws = require("k6/ws");
 			var group = require("k6").group;
@@ -1593,7 +1592,7 @@ func TestSystemTags(t *testing.T) {
 		w.WriteHeader(http.StatusTemporaryRedirect)
 	})
 
-	r, err := getSimpleRunner("/script.js", tb.Replacer.Replace(`
+	r, err := getSimpleRunner(t, "/script.js", tb.Replacer.Replace(`
 		var http = require("k6/http");
 
 		exports.http_get = function() {

--- a/lib/state.go
+++ b/lib/state.go
@@ -45,6 +45,7 @@ type State struct {
 	Options Options
 
 	// Logger. Avoid using the global logger.
+	// TODO change to logrus.FieldLogger when there is time to fix all the tests
 	Logger *logrus.Logger
 
 	// Current group; all emitted metrics are tagged with this.

--- a/lib/testutils/test_output.go
+++ b/lib/testutils/test_output.go
@@ -23,19 +23,30 @@ package testutils
 import (
 	"io"
 	"testing"
+
+	"github.com/sirupsen/logrus"
 )
 
 // Something that makes the test also be a valid io.Writer, useful for passing it
 // as an output for logs and CLI flag help messages...
-type testOutput struct{ *testing.T }
+type testOutput struct{ testing.TB }
 
 func (to testOutput) Write(p []byte) (n int, err error) {
 	to.Logf("%s", p)
+
 	return len(p), nil
 }
 
 // NewTestOutput returns a simple io.Writer implementation that uses the test's
 // logger as an output.
-func NewTestOutput(t *testing.T) io.Writer {
+func NewTestOutput(t testing.TB) io.Writer {
 	return testOutput{t}
+}
+
+// NewLogger Returns new logger that will log to the testing.TB.Logf
+func NewLogger(t testing.TB) *logrus.Logger {
+	l := logrus.New()
+	logrus.SetOutput(NewTestOutput(t))
+
+	return l
 }


### PR DESCRIPTION
This isn't a functional change but it makes certain that all parts of
the js package that aren't for test use provided logger instead of the
global one.

Unfortunately changing to logrus.FieldLogger in lib.State turned out
to require rewriting way too many tests and as it really isn't required,