### PR TITLE
Fix golangci-lint in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,8 @@ jobs:
     docker:
       - image: circleci/golang:1.14
     environment:
-      GOPATH: /home/circleci/.go_workspace
       GOLANGCI_VERSION: v1.27.0
+      GO111MODULE: 'on'
     working_directory: /home/circleci/.go_workspace/src/github.com/loadimpact/k6
     steps:
       # Workaround for custom env vars not available in cache keys
@@ -32,7 +32,6 @@ jobs:
       - run:
           name: Install golangci-lint
           command: |
-            export PATH="$GOPATH/bin:$PATH"
             command -v golangci-lint && exit
             go get github.com/golangci/golangci-lint/cmd/golangci-lint@$GOLANGCI_VERSION
       - save_cache:
@@ -44,7 +43,6 @@ jobs:
       - run:
           name: Run golangci-lint
           command: |
-            export PATH="$GOPATH/bin:$PATH"
             golangci-lint run --out-format=tab --new-from-rev origin/master ./...
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
     docker:
       - image: circleci/golang:1.14
     environment:
-      GOLANGCI_VERSION: v1.27.0
+      GOLANGCI_VERSION: v1.30.0
       GO111MODULE: 'on'
     working_directory: /home/circleci/.go_workspace/src/github.com/loadimpact/k6
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,9 @@ jobs:
       - run:
           name: Run golangci-lint
           command: |
-            golangci-lint run --out-format=tab --new-from-rev origin/master ./...
+            BASEREV=$(git merge-base HEAD origin/master)
+            echo "Base revision: $BASEREV"
+            golangci-lint run --out-format=tab --new-from-rev "$BASEREV" ./...
 
 
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           name: Restore golangci-lint cache
           key: golangci-lint-{{ arch }}-{{ checksum "/tmp/.golangci.version" }}-{{ .Environment.CACHE_VERSION }}
           paths:
-            - /home/circleci/.go_workspace/bin/golangci-lint
+            - /go/bin/golangci-lint
       - run:
           name: Install golangci-lint
           command: |
@@ -38,7 +38,7 @@ jobs:
           name: Save golangci-lint cache
           key: golangci-lint-{{ arch }}-{{ checksum "/tmp/.golangci.version" }}-{{ .Environment.CACHE_VERSION }}
           paths:
-            - /home/circleci/.go_workspace/bin/golangci-lint
+            - /go/bin/golangci-lint
       - checkout
       - run:
           name: Run golangci-lint


### PR DESCRIPTION
After the Go modules switch, the golangci-lint job in CircleCI [started failing](https://app.circleci.com/pipelines/github/loadimpact/k6/597/workflows/af28bcf6-e3fd-4e28-ab1f-c979bc4f662d/jobs/12303) with `go: cannot use path@version syntax in GOPATH mode`.

Removing `GOPATH` from the job's env vars and forcing `GO111MODULE=on` fixes it. This also adds `git-merge-base` to determine the base commit to lint from, which should be more reliable than before, and upgrades golangci-lint to the latest version, which resolves some warnings.