### PR TITLE
Make ASCII logo characters more proportional

### DIFF
--- a/lib/consts/consts.go
+++ b/lib/consts/consts.go
@@ -52,9 +52,9 @@ func FullVersion() string {
 // TODO: make these into methods, only the version needs to be a variable
 //nolint:gochecknoglobals
 var Banner = strings.Join([]string{
-	`          /\      |‾‾|  /‾‾/  /‾/   `,
-	`     /\  /  \     |  |_/  /  / /    `,
-	`    /  \/    \    |      |  /  ‾‾\  `,
-	`   /          \   |  |‾\  \ | (_) | `,
-	`  / __________ \  |__|  \__\ \___/ .io`,
+	`          /\      |‾‾| /‾‾/   /‾‾/   `,
+	`     /\  /  \     |  |/  /   /  /    `,
+	`    /  \/    \    |     (   /   ‾‾\  `,
+	`   /          \   |  |\  \ |  (‾)  | `,
+	`  / __________ \  |__| \__\ \_____/ .io`,
 }, "\n")


### PR DESCRIPTION
Quick patch to make the ASCII logo look a bit less squeezed on the digit part. Use this if you want to, or don't, perhaps you think it looks worse now :)