### PR TITLE
Add a Counter.rps sink

### DIFF
--- a/stats/sink.go
+++ b/stats/sink.go
@@ -56,9 +56,11 @@ func (c *CounterSink) Add(s Sample) {
 func (c *CounterSink) Calc() {}
 
 func (c *CounterSink) Format(t time.Duration) map[string]float64 {
+	rps := c.Value / (float64(t) / float64(time.Second))
 	return map[string]float64{
 		"count": c.Value,
-		"rate":  c.Value / (float64(t) / float64(time.Second)),
+		"rate":  rps,
+		"rps":   rps,
 	}
 }
 

--- a/stats/sink_test.go
+++ b/stats/sink_test.go
@@ -58,7 +58,7 @@ func TestCounterSink(t *testing.T) {
 		for _, s := range samples10 {
 			sink.Add(Sample{Metric: &Metric{}, Value: s, Time: now})
 		}
-		assert.Equal(t, map[string]float64{"count": 145, "rate": 145.0}, sink.Format(1*time.Second))
+		assert.Equal(t, map[string]float64{"count": 145, "rate": 145.0, "rps": 145.0}, sink.Format(1*time.Second))
 	})
 }
 


### PR DESCRIPTION
This is an alias to the `Counter.rate` sink we recently re-discovered exists, which has a totally different meaning to `Rate.rate`... :man_facepalming: It's a minor UX improvement, until we can design a better thresholds architecture and fix all of the issues (https://github.com/loadimpact/k6/issues/1443#issuecomment-626957527) properly.