### PR TITLE
Release k6 v0.28.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
   # specific to go
   VERSION: "%APPVEYOR_REPO_TAG_NAME:v=%"
   GOPATH: c:\gopath
-  GOVERSION: 1.14.6
+  GOVERSION: 1.14.9
   GOMAXPROCS: 2
   CGO_ENABLED: '0'
   GOARCH: amd64

--- a/lib/consts/consts.go
+++ b/lib/consts/consts.go
@@ -28,7 +28,7 @@ import (
 )
 
 // Version contains the current semantic version of k6.
-const Version = "0.27.1"
+const Version = "0.28.0"
 
 // VersionDetails can be set externally as part of the build process
 var VersionDetails = "" // nolint:gochecknoglobals

--- a/release notes/v0.28.0.md
+++ b/release notes/v0.28.0.md
@@ -80,6 +80,7 @@ _Note: If you have existing InfluxDB databases that contain fields whose data ty
 - Various spacing and progress bar rendering issues were improved ([#1580](https://github.com/loadimpact/k6/issues/1580)).
 - The k6 ASCII logo was made a bit more proportional ([#1615](https://github.com/loadimpact/k6/pull/1615/commits/54a3168f0945fa8243edb7540fe78ad7ac66a8dc)). Thanks, @rawtaz!
 - The docker-compose example setup from the k6 repo now contains a built-in simple dashboard ([#1610](https://github.com/loadimpact/k6/pull/1610)). Thanks, @jeevananthank!
+- Some logs now have a `source` field specifying if a log comes from `console`, `http-debug` or `stacktrace` (when an exception has bubbled to the top of the iteration).
 
 ## Bugs fixed!
 
@@ -92,7 +93,7 @@ _Note: If you have existing InfluxDB databases that contain fields whose data ty
 
 ## Internals
 
-- goja, the JavaScript runtime k6 uses, was updated to the latest version. This means that k6 with `--compatibility-mode=base` now supports some standard library features from ES6 ([goja's PR](https://github.com/dop251/goja/pull/180)), though no new syntax yet. In future versions we plan to drop some current core.js modules that are no longer needed, which should greadly reduce memory usage per VU ([#1588](https://github.com/loadimpact/k6/pull/1588)).
+- goja, the JavaScript runtime k6 uses, was updated to the latest version. This means that k6 with `--compatibility-mode=base` now supports some standard library features from ES6 ([goja's PR](https://github.com/dop251/goja/pull/180)), though no new syntax yet. In future versions we plan to drop some current core.js modules that are no longer needed, which should greatly reduce memory usage per VU ([#1588](https://github.com/loadimpact/k6/pull/1588)).
 - Go modules are now used to manage the k6 dependencies instead of `dep` ([#1584](https://github.com/loadimpact/k6/pull/1584)).
 
 ## Breaking changes

--- a/release notes/v0.28.0.md
+++ b/release notes/v0.28.0.md
@@ -1,0 +1,104 @@
+k6 v0.28.0 is here! :tada: It's a small release that adds some much requested features and a few important bugfixes!
+
+Starting with this release, we'll be trying to stick to a new 8-week fixed release schedule for new k6 versions. This release comes ~8 weeks after v0.27.0 was released, and k6 v0.29.0 should be released in mid-November.
+
+## New features and enhancements!
+
+### Cloud execution logs ([#1599](https://github.com/loadimpact/k6/pull/1599))
+
+Logs from distributed k6 cloud test runs will now be shown in the terminal that executed the `k6 cloud` command, as well as in the k6 cloud web app on [app.k6.io](https://app.k6.io/)! :tada: This means that, if your script contains `console.log()` / `console.warn()` / etc. calls, or some of your requests or iterations fail, you'd be able to see that and debug them much more easily! Even `--http-debug` data should be proxied, up to 10000 bytes per message. To prevent abuse and not to overwhelm any user terminals, cloud logs are rate-limited at 10 messages per second per instance, for now, but that should be more than enough to debug most issues!
+
+This feature is enabled by default, though you can disable it with `k6 cloud --show-logs=false script.js`.
+
+### New options for configuring k6 DNS resolution ([#1612](https://github.com/loadimpact/k6/pull/1612))
+
+You can now control some aspects of how k6 performs DNS resolution! Previously, k6 would have cached DNS responses indefinitely ([#726](https://github.com/loadimpact/k6/issues/726)) and always picked the first resolved IP ([#738](https://github.com/loadimpact/k6/issues/738)) for all connections. This caused issues, especially when load testing services that relied on DNS for load-balancing or auto-scaling.
+
+For technical reasons explored in ([#726](https://github.com/loadimpact/k6/issues/726)), k6 v0.28.0 still doesn't respect the actual TTL value of resolved IPs, that will be fixed in a future k6 version. For now, it simply allows users to specify a global DNS TTL value and resolution strategy manually. It also has better defaults! Now, by default, the global DNS TTL value is 5 minutes and, if the DNS resolution returned multiple IPs, k6 will pick a random one for each connection.
+
+You can also configure this behavior with the new `--dns` CLI flag, the `K6_DNS` environment variable, or the `dns` script/JSON option. Only 2 DNS resolution options are exposed in this k6 version, `ttl` and `strategy`.
+
+Possible `ttl` values are :
+- `0`, which means no caching at all - each request triggers a new DNS lookup
+- `inf`, which will cause k6 to cache any resolved IPs forever (the old k6 behavior)
+- any time duration like `60s`, `5m30s`, `10m`, `2h`, etc.; if no unit is specified (e.g. `ttl=3000`), k6 assumes milliseconds
+
+Possible `strategy` values are:
+- `first` - always pick the first resolved IP (the old k6 behavior)
+- `random` - pick a random IP for every new connection (the new default value)
+- `round-robin` - iterate sequentially over the resolved IPs
+
+Here are some configuration examples:
+
+```bash
+k6 run --dns "strategy=first,ttl=inf" script.js # this is the old k6 behavior
+K6_DNS="strategy=random,ttl=5m" k6 cloud script.js # new default behavior
+
+# syntax for the JSON config file or for the exported script `options`:
+echo '{"dns": {"strategy": "round-robin", "ttl": "1h33m7s"}}' > config.json
+k6 run --config "config.json" script.js
+```
+
+### Pushing k6 logs to loki ([#1576](https://github.com/loadimpact/k6/pull/1576))
+
+k6 can now push its execution logs to a loki server! This can be done via the new `--log-output` CLI flag or the `K6_LOG_OUTPUT` environment variable option. For example, `k6 run --log-output "loki=https://my-loki-server/loki/api/v1/push,limit=100,level=info,msgMaxSize=10000"` will push up to 100 k6 log messages per second, of severity `INFO` and up, truncated to `10000` bytes, to `https://my-loki-server`.
+
+### Optional port to host mappings ([#1489](https://github.com/loadimpact/k6/pull/1489))
+
+@calavera added an extension for the host mapping feature. Now you can specify different port numbers via the [`hosts` option](https://k6.io/docs/using-k6/options#hosts), like this:
+
+```js
+import http from 'k6/http';
+
+export let options = {
+    hosts: {
+        'test.k6.io': '127.0.0.1:8080',
+    },
+};
+```
+
+### Support for specifying data types to InfluxDB fields ([#1395](https://github.com/loadimpact/k6/pull/1395))
+
+@TamiTakamiya added support for specifying the data type (int/float/bool/string) of fields that are emitted to InfluxDB outputs.
+
+In order to specify the data type, you should:
+- Use the environment variable `K6_INFLUXDB_TAGS_AS_FIELDS`, which is used to specify which k6 metric tag values should be sent as nonindexable fields (instead of tags) to an InfluxDB output. This is specified as a comma-separated string, and is now extended to optionally allow specifying a data type to each name.
+- Each pair of field name and its data type is represented in the format `(name):(data_type)`, for example, `event_processing_time:int`.
+- One of four data types (`int`, `float`, `bool` and `string`) can be specified to one field name.
+- When the colon and a `data_type` are omitted, for example `transaction_id`, it is interpreted as a string field.
+
+A complete example can look like this: `export K6_INFLUXDB_TAGS_AS_FIELDS="vu:int,iter:int,url:string,boolField:bool,floatField:float"`
+
+_Note: If you have existing InfluxDB databases that contain fields whose data types are different from the ones that you want to save in future k6 test executions, you may want to create a new database or change field names as the current InfluxDB offers limited support for changing fields' data type. See the [InfluxDB documentation](https://docs.influxdata.com/influxdb/v1.8/troubleshooting/frequently-asked-questions/#can-i-change-a-field-s-data-type) for more details._
+
+### Support for automatic gzip-ing of the CSV output result ([#1566](https://github.com/loadimpact/k6/pull/1566))
+
+@thejasbabu added support to gzip archiving the file emitted by the CSV output on the fly. To use it, simply append `.gz` at the end of the file name, like this: `k6 run --out csv=test.csv.gz test.js`
+
+## UX
+
+- Various spacing and progress bar rendering issues were improved ([#1580](https://github.com/loadimpact/k6/issues/1580)).
+- The k6 ASCII logo was made a bit more proportional ([#1615](https://github.com/loadimpact/k6/pull/1615/commits/54a3168f0945fa8243edb7540fe78ad7ac66a8dc)). Thanks, @rawtaz!
+- The docker-compose example setup from the k6 repo now contains a built-in simple dashboard ([#1610](https://github.com/loadimpact/k6/pull/1610)). Thanks, @jeevananthank!
+
+## Bugs fixed!
+
+- Network: IPv6 support was fixed as a part of the new `hosts` port mapping ([#1489](https://github.com/loadimpact/k6/pull/1489)). Thanks, @calavera!
+- Metrics: Fixed the wrong `name` metric tag for redirected requests ([#1474](https://github.com/loadimpact/k6/issues/1474)).
+- UI: Fixed a `divide by zero` panic caused by some unusual execution environments that present a TTY, but return `0` for the terminal size ([#1581](https://github.com/loadimpact/k6/pull/1581)).
+- Config: Fixed the parsing of `K6_DATADOG_TAG_BLACKLIST` ([#1602](https://github.com/loadimpact/k6/issues/1602)).
+- Config: Fixed marshaling of `tlsCipherSuites` and `tlsVersion` ([#1603](https://github.com/loadimpact/k6/pull/1603)). Thanks, @berndhartzer!
+- WebSockets: Fixed a `ws.SetTimeout()` and `ws.SetInterval()` panic when float values were passed ([#1608](https://github.com/loadimpact/k6/pull/1608)).
+
+## Internals
+
+- goja, the JavaScript runtime k6 uses, was updated to the latest version. This means that k6 with `--compatibility-mode=base` now supports some standard library features from ES6 ([goja's PR](https://github.com/dop251/goja/pull/180)), though no new syntax yet. In future versions we plan to drop some current core.js modules that are no longer needed, which should greadly reduce memory usage per VU ([#1588](https://github.com/loadimpact/k6/pull/1588)).
+- Go modules are now used to manage the k6 dependencies instead of `dep` ([#1584](https://github.com/loadimpact/k6/pull/1584)).
+
+## Breaking changes
+
+- As mentioned above, DNS resolution defaults were changed. If you want to use the old k6 behavior of always picking the first IP and caching DNS responses indefinitely, run k6 with `--dns="strategy=first,ttl=inf"`.
+
+- `k6 cloud` will now proxy execution logs back to the client machine. To disable this behavior, use `k6 cloud --show-logs=false`.
+
+- `--http-debug` request and response dumps are now emitted through the logging sub-system, to facilitate the cloud log proxying ([#1577](https://github.com/loadimpact/k6/pull/1577)).

--- a/release notes/v0.28.0.md
+++ b/release notes/v0.28.0.md
@@ -10,34 +10,6 @@ Logs from distributed k6 cloud test runs will now be shown in the terminal that 
 
 This feature is enabled by default, though you can disable it with `k6 cloud --show-logs=false script.js`.
 
-### New options for configuring k6 DNS resolution ([#1612](https://github.com/loadimpact/k6/pull/1612))
-
-You can now control some aspects of how k6 performs DNS resolution! Previously, k6 would have cached DNS responses indefinitely ([#726](https://github.com/loadimpact/k6/issues/726)) and always picked the first resolved IP ([#738](https://github.com/loadimpact/k6/issues/738)) for all connections. This caused issues, especially when load testing services that relied on DNS for load-balancing or auto-scaling.
-
-For technical reasons explored in ([#726](https://github.com/loadimpact/k6/issues/726)), k6 v0.28.0 still doesn't respect the actual TTL value of resolved IPs, that will be fixed in a future k6 version. For now, it simply allows users to specify a global DNS TTL value and resolution strategy manually. It also has better defaults! Now, by default, the global DNS TTL value is 5 minutes and, if the DNS resolution returned multiple IPs, k6 will pick a random one for each connection.
-
-You can also configure this behavior with the new `--dns` CLI flag, the `K6_DNS` environment variable, or the `dns` script/JSON option. Only 2 DNS resolution options are exposed in this k6 version, `ttl` and `strategy`.
-
-Possible `ttl` values are :
-- `0`, which means no caching at all - each request triggers a new DNS lookup
-- `inf`, which will cause k6 to cache any resolved IPs forever (the old k6 behavior)
-- any time duration like `60s`, `5m30s`, `10m`, `2h`, etc.; if no unit is specified (e.g. `ttl=3000`), k6 assumes milliseconds
-
-Possible `strategy` values are:
-- `first` - always pick the first resolved IP (the old k6 behavior)
-- `random` - pick a random IP for every new connection (the new default value)
-- `round-robin` - iterate sequentially over the resolved IPs
-
-Here are some configuration examples:
-
-```bash
-k6 run --dns "strategy=first,ttl=inf" script.js # this is the old k6 behavior
-K6_DNS="strategy=random,ttl=5m" k6 cloud script.js # new default behavior
-
-# syntax for the JSON config file or for the exported script `options`:
-echo '{"dns": {"strategy": "round-robin", "ttl": "1h33m7s"}}' > config.json
-k6 run --config "config.json" script.js
-```
 
 ### Pushing k6 logs to loki ([#1576](https://github.com/loadimpact/k6/pull/1576))
 
@@ -97,8 +69,6 @@ _Note: If you have existing InfluxDB databases that contain fields whose data ty
 - Go modules are now used to manage the k6 dependencies instead of `dep` ([#1584](https://github.com/loadimpact/k6/pull/1584)).
 
 ## Breaking changes
-
-- As mentioned above, DNS resolution defaults were changed. If you want to use the old k6 behavior of always picking the first IP and caching DNS responses indefinitely, run k6 with `--dns="strategy=first,ttl=inf"`.
 
 - `k6 cloud` will now proxy execution logs back to the client machine. To disable this behavior, use `k6 cloud --show-logs=false`.
 


### PR DESCRIPTION
Hopefully I haven't missed anything. And, of course, this is contingent on https://github.com/loadimpact/k6/pull/1612 getting merged... :sweat_smile: 

For easier reading of the release notes: https://github.com/loadimpact/k6/blob/release-v0.28.0/release%20notes/v0.28.0.md