### PR TITLE
Marshal/Unmarshal DNS settings in a more consistan way

### DIFF
--- a/cmd/config_consolidation_test.go
+++ b/cmd/config_consolidation_test.go
@@ -414,12 +414,7 @@ func getConfigConsolidationTestCases() []configConsolidationTestCase {
 				Strategy: lib.NullDNSStrategy{DNSStrategy: lib.DNSRandom, Valid: false},
 			}, c.Options.DNS)
 		}},
-		{opts{cli: []string{"--dns", "ttl=5s,strategy="}}, exp{}, func(t *testing.T, c Config) {
-			assert.Equal(t, lib.DNSConfig{
-				TTL:      null.StringFrom("5s"),
-				Strategy: lib.NullDNSStrategy{DNSStrategy: lib.DNSRandom, Valid: false},
-			}, c.Options.DNS)
-		}},
+		{opts{cli: []string{"--dns", "ttl=5s,strategy="}}, exp{cliReadError: true}, nil},
 		{opts{fs: defaultConfig(`{"dns": {"ttl": "0", "strategy": "round-robin"}}`)}, exp{}, func(t *testing.T, c Config) {
 			assert.Equal(t, lib.DNSConfig{
 				TTL:      null.StringFrom("0"),

--- a/lib/options.go
+++ b/lib/options.go
@@ -73,7 +73,7 @@ const (
 	DNSRandom
 )
 
-// UnmarshalJSON converts JSON data to a valid DNSStratey
+// UnmarshalJSON converts JSON data to a valid DNSStrategy
 func (d *DNSStrategy) UnmarshalJSON(data []byte) error {
 	if bytes.Equal(data, []byte(`null`)) {
 		return nil


### PR DESCRIPTION
this also doesn't write down the default values in the metadata.json
unless they were set specifically.

