### PR TITLE
Fix sending empty metric tags for failed requests

### DIFF
--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -931,6 +931,35 @@ func TestRequestAndBatch(t *testing.T) {
 				})
 			}
 
+			t.Run("name/none", func(t *testing.T) {
+				_, err := common.RunString(rt, sr(`
+					var res = http.request("GET", "HTTPBIN_URL/headers");
+					if (res.status != 200) { throw new Error("wrong status: " + res.status); }
+				`))
+				assert.NoError(t, err)
+				assertRequestMetricsEmitted(t, stats.GetBufferedSamples(samples), "GET",
+					sr("HTTPBIN_URL/headers"), sr("HTTPBIN_URL/headers"), 200, "")
+			})
+
+			t.Run("name/request", func(t *testing.T) {
+				_, err := common.RunString(rt, sr(`
+					var res = http.request("GET", "HTTPBIN_URL/headers", null, { tags: { name: "myReq" }});
+					if (res.status != 200) { throw new Error("wrong status: " + res.status); }
+				`))
+				assert.NoError(t, err)
+				assertRequestMetricsEmitted(t, stats.GetBufferedSamples(samples), "GET",
+					sr("HTTPBIN_URL/headers"), "myReq", 200, "")
+			})
+
+			t.Run("name/template", func(t *testing.T) {
+				_, err := runES6String(t, rt, "http.get(http.url`"+sr(`HTTPBIN_URL/anything/${1+1}`)+"`);")
+				assert.NoError(t, err)
+				// There's no /anything endpoint in the go-httpbin library we're using, hence the 404,
+				// but it doesn't matter for this test.
+				assertRequestMetricsEmitted(t, stats.GetBufferedSamples(samples), "GET",
+					sr("HTTPBIN_URL/anything/2"), sr("HTTPBIN_URL/anything/${}"), 404, "")
+			})
+
 			t.Run("object", func(t *testing.T) {
 				_, err := common.RunString(rt, sr(`
 				var res = http.request("GET", "HTTPBIN_URL/headers", null, { tags: { tag: "value" } });

--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -235,10 +235,17 @@ func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error
 		tags[k] = v
 	}
 
+	if state.Options.SystemTags.Has(stats.TagMethod) {
+		tags["method"] = preq.Req.Method
+	}
+	if state.Options.SystemTags.Has(stats.TagURL) {
+		tags["url"] = preq.URL.Clean()
+	}
+
 	// Only set the name system tag if the user didn't explicitly set it beforehand,
 	// and the Name was generated from a tagged template string (via http.url).
 	if _, ok := tags["name"]; !ok && state.Options.SystemTags.Has(stats.TagName) &&
-		preq.URL.Name != preq.URL.CleanURL {
+		preq.URL.Name != preq.URL.Clean() {
 		tags["name"] = preq.URL.Name
 	}
 

--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -235,17 +235,10 @@ func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error
 		tags[k] = v
 	}
 
-	if state.Options.SystemTags.Has(stats.TagMethod) {
-		tags["method"] = preq.Req.Method
-	}
-	if state.Options.SystemTags.Has(stats.TagURL) {
-		tags["url"] = preq.URL.Clean()
-	}
-
 	// Only set the name system tag if the user didn't explicitly set it beforehand,
 	// and the Name was generated from a tagged template string (via http.url).
 	if _, ok := tags["name"]; !ok && state.Options.SystemTags.Has(stats.TagName) &&
-		preq.URL.Name != preq.URL.Clean() {
+		preq.URL.Name != "" && preq.URL.Name != preq.URL.Clean() {
 		tags["name"] = preq.URL.Name
 	}
 

--- a/lib/netext/httpext/request_test.go
+++ b/lib/netext/httpext/request_test.go
@@ -211,7 +211,7 @@ func TestMakeRequestTimeout(t *testing.T) {
 		"status":     "0",
 		"method":     "GET",
 		"url":        srv.URL,
-		"name":       "",
+		"name":       srv.URL,
 	}
 	for _, s := range allSamples {
 		assert.Equal(t, expTags, s.Tags.CloneTags())

--- a/lib/netext/httpext/transport.go
+++ b/lib/netext/httpext/transport.go
@@ -101,6 +101,26 @@ func (t *transport) measureAndEmitMetrics(unfReq *unfinishedRequest) *finishedRe
 	}
 
 	enabledTags := t.state.Options.SystemTags
+
+	urlEnabled := enabledTags.Has(stats.TagURL)
+	var setName bool
+	if _, ok := tags["name"]; !ok && enabledTags.Has(stats.TagName) {
+		setName = true
+	}
+	if urlEnabled || setName {
+		cleanURL := URL{u: unfReq.request.URL, URL: unfReq.request.URL.String()}.Clean()
+		if urlEnabled {
+			tags["url"] = cleanURL
+		}
+		if setName {
+			tags["name"] = cleanURL
+		}
+	}
+
+	if enabledTags.Has(stats.TagMethod) {
+		tags["method"] = unfReq.request.Method
+	}
+
 	if unfReq.err != nil {
 		result.errorCode, result.errorMsg = errorCodeForError(unfReq.err)
 		if enabledTags.Has(stats.TagError) {
@@ -115,24 +135,6 @@ func (t *transport) measureAndEmitMetrics(unfReq *unfinishedRequest) *finishedRe
 			tags["status"] = "0"
 		}
 	} else {
-		urlEnabled := enabledTags.Has(stats.TagURL)
-		var setName bool
-		if _, ok := tags["name"]; !ok && enabledTags.Has(stats.TagName) {
-			setName = true
-		}
-		if urlEnabled || setName {
-			cleanURL := URL{u: unfReq.request.URL, URL: unfReq.request.URL.String()}.Clean()
-			if urlEnabled {
-				tags["url"] = cleanURL
-			}
-			if setName {
-				tags["name"] = cleanURL
-			}
-		}
-
-		if enabledTags.Has(stats.TagMethod) {
-			tags["method"] = unfReq.request.Method
-		}
 		if enabledTags.Has(stats.TagStatus) {
 			tags["status"] = strconv.Itoa(unfReq.response.StatusCode)
 		}


### PR DESCRIPTION
This fixes an issue introduced in #1570 where metrics for failed requests were being sent with missing `url`, `method` and `name` tags, causing requests to show up with "0" tags in the cloud.