### PR TITLE
Immediately  shutdown `k6 cloud`  on second sig-c signal

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -258,7 +258,7 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 				logger.WithError(err).Error("Stop cloud test error")
 			}
 			shouldExitLoop = true // Exit after the next GetTestProgress call
-		
+
 			sig = <-sigC
 			logger.WithField("sig", sig).Error("Aborting k6 in response to signal")
 			globalCancel()

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -329,7 +329,6 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 			case <-globalCtx.Done():
 				break runningLoop
 			}
-
 		}
 
 		if testProgress == nil {

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -199,6 +199,9 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 			name = filepath.Base(filename)
 		}
 
+		globalCtx, globalCancel := context.WithCancel(context.Background())
+		defer globalCancel()
+
 		// Start cloud test run
 		modifyAndPrintBar(progressBar, pb.WithConstProgress(0, "Validating script options"))
 		client := cloud.NewClient(logger, cloudConfig.Token.String, cloudConfig.Host.String, consts.Version)
@@ -226,7 +229,7 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 			pb.WithConstProgress(0, "Initializing the cloud test"),
 		)
 
-		progressCtx, progressCancel := context.WithCancel(context.Background())
+		progressCtx, progressCancel := context.WithCancel(globalCtx)
 		progressBarWG := &sync.WaitGroup{}
 		progressBarWG.Add(1)
 		defer progressBarWG.Wait()
@@ -241,10 +244,26 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 			return nil
 		}
 
+		shouldExitLoop := false
+
 		// Trap Interrupts, SIGINTs and SIGTERMs.
 		sigC := make(chan os.Signal, 1)
 		signal.Notify(sigC, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 		defer signal.Stop(sigC)
+		go func() {
+			sig := <-sigC
+			logger.WithField("sig", sig).Print("Stopping k6 in response to signal...")
+			err := client.StopCloudTestRun(refID)
+			if err != nil {
+				logger.WithError(err).Error("Stop cloud test error")
+			}
+			shouldExitLoop = true // Exit after the next GetTestProgress call
+		
+			sig = <-sigC
+			logger.WithField("sig", sig).Error("Aborting k6 in response to signal")
+			globalCancel()
+			os.Exit(externalAbortErrorCode)
+		}()
 
 		var (
 			startTime   time.Time
@@ -284,12 +303,11 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 		)
 
 		ticker := time.NewTicker(time.Millisecond * 2000)
-		shouldExitLoop := false
 		if showCloudLogs {
 			go func() {
 				logger.Debug("Connecting to cloud logs server...")
 				// TODO replace with another context
-				if err := cloudConfig.StreamLogsToLogger(context.Background(), logger, refID, 0); err != nil {
+				if err := cloudConfig.StreamLogsToLogger(globalCtx, logger, refID, 0); err != nil {
 					logger.WithError(err).Error("error while tailing cloud logs")
 				}
 			}()
@@ -314,13 +332,6 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 				if shouldExitLoop {
 					break runningLoop
 				}
-			case sig := <-sigC:
-				logger.WithField("sig", sig).Print("Exiting in response to signal...")
-				err := client.StopCloudTestRun(refID)
-				if err != nil {
-					logger.WithError(err).Error("Stop cloud test error")
-				}
-				shouldExitLoop = true // Exit after the next GetTestProgress call
 			}
 		}
 

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -318,7 +318,7 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 				if progressErr == nil {
 					if (newTestProgress.RunStatus > lib.RunStatusRunning) ||
 						(exitOnRunning && newTestProgress.RunStatus == lib.RunStatusRunning) {
-						globalCtx.Done()
+						globalCancel()
 					}
 					testProgressLock.Lock()
 					testProgress = newTestProgress

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -319,6 +319,7 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 					if (newTestProgress.RunStatus > lib.RunStatusRunning) ||
 						(exitOnRunning && newTestProgress.RunStatus == lib.RunStatusRunning) {
 						globalCancel()
+						break runningLoop
 					}
 					testProgressLock.Lock()
 					testProgress = newTestProgress


### PR DESCRIPTION
Trap signal and handle second sig-c to shutdown `k6 cloud` immediately

Closes #1530