### PR TITLE
enable k6 to use IP range or CIDR as client source ip addresses

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -91,6 +91,7 @@ func optionFlagSet() *pflag.FlagSet {
 	flags.StringSlice("tag", nil, "add a `tag` to be applied to all samples, as `[name]=[value]`")
 	flags.String("console-output", "", "redirects the console logging to the provided output file")
 	flags.Bool("discard-response-bodies", false, "Read but don't process or save HTTP response bodies")
+	flags.StringP("ip", "", "", "Client IP Range or CIDR, randomly selected by VU id")
 	return flags
 }
 
@@ -114,6 +115,7 @@ func getOptions(flags *pflag.FlagSet) (lib.Options, error) {
 		MinIterationDuration:  getNullDuration(flags, "min-iteration-duration"),
 		Throw:                 getNullBool(flags, "throw"),
 		DiscardResponseBodies: getNullBool(flags, "discard-response-bodies"),
+		ClientIpRange:         getNullString(flags, "ip"),
 		// Default values for options without CLI flags:
 		// TODO: find a saner and more dev-friendly and error-proof way to handle options
 		SetupTimeout:    types.NullDuration{Duration: types.Duration(60 * time.Second), Valid: false},

--- a/lib/options.go
+++ b/lib/options.go
@@ -382,6 +382,9 @@ type Options struct {
 
 	// Redirect console logging to a file
 	ConsoleOutput null.String `json:"-" envconfig:"K6_CONSOLE_OUTPUT"`
+
+	// Specify client IP range from which k6 select by VU_ID % IP_NUM
+	ClientIpRange null.String `json:"clientIpRange,omitemty" envconf:"K6_CLIENT_IP_RANGE"`
 }
 
 // Returns the result of overwriting any fields with any that are set on the argument.
@@ -532,6 +535,9 @@ func (o Options) Apply(opts Options) Options {
 	}
 	if opts.ConsoleOutput.Valid {
 		o.ConsoleOutput = opts.ConsoleOutput
+	}
+	if opts.ClientIpRange.Valid {
+		o.ClientIpRange = opts.ClientIpRange
 	}
 
 	return o

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -400,6 +400,14 @@ func TestOptions(t *testing.T) {
 		assert.True(t, opts.DiscardResponseBodies.Valid)
 		assert.True(t, opts.DiscardResponseBodies.Bool)
 	})
+	t.Run("ClientIpRange", func(t *testing.T) {
+		opts := Options{}.Apply(Options{ClientIpRange: null.StringFrom("10.10.0.0/16")})
+		assert.True(t, opts.ClientIpRange.Valid)
+		assert.Equal(t, "10.10.0.0/16", opts.ClientIpRange.String)
+		opts := Options{}.Apply(Options{ClientIpRange: null.StringFrom("10.10.0.1-10.10.255.254")})
+		assert.True(t, opts.ClientIpRange.Valid)
+		assert.Equal(t, "10.10.0.1-10.10.255.254", opts.ClientIpRange.String)
+	})
 }
 
 func TestOptionsEnv(t *testing.T) {
@@ -474,6 +482,11 @@ func TestOptionsEnv(t *testing.T) {
 		},
 		// Thresholds
 		// External
+		{"ClientIpRange", "K6_CLIENT_IP_RANGE"}: {
+			"": null.String{},
+			"10.10.0.1-10.10.255.254": null.StringFrom("10.10.0.1-10.10.255.254"),
+			"10.10.0.0/16": null.StringFrom("10.10.0.0/16"),
+		},
 	}
 	for field, data := range testdata {
 		field, data := field, data


### PR DESCRIPTION
An alternative PR for #1293 , no Network Interface required.
Example of run script:
```bash
#!/bin/bash
s=${1:-"ax.js:1000:10m:rps_http"}
read jsfile vus duration casename <<<${s//:/ }
shift
echo -e "testfile[$jsfile] testcase[$casename] vus[$vus] duration[$duration]\noptions[$*]"

set_k6_local_route(){ #$1:net $2:ifname
  net="$1" ifname=${2-"lo"}
  ip r s t local |grep -q "^local $net" || \
  ip -6 r s t local |grep -q "^local $net" || \
  ip route add local "$net" dev $ifname
  ip r s t local |grep "^local $net" || ip -6 r s t local |grep "^local $net"
}

# k6 client ip -- use local type route instead
set_k6_local_route "10.50.0.0/16" "eth0"
set_k6_local_route "fd00:0:1::0/120" "eth0"

# Linux: echo "ulimit -n 1000000" >> ~/.bashrc
# MacOS: sudo launchctl limit maxfiles 65536 1000000
ulimit -n 1000000

# run k6 for ipv4 targets
TESTCASE=$casename VUS=$vus DURATION=$duration k6 run --ip="10.50.0.62-10.50.2.100" --verbose --no-thresholds $* $jsfile
# run k6 for ipv6 targets
sysctl -w net.ipv6.ip_nonlocal_bind=1
TESTCASE=$casename VUS=$vus DURATION=$duration k6 run --ip="fd00:0:188::/120" --verbose --no-thresholds $* $jsfile
sysctl -w net.ipv6.ip_nonlocal_bind=0
```
<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/loadimpact/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/loadimpact/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
