### PR TITLE
Recover from panics caused by goja

### DIFF
--- a/lib/executor/constant_vus.go
+++ b/lib/executor/constant_vus.go
@@ -26,13 +26,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sirupsen/logrus"
-	"gopkg.in/guregu/null.v3"
-
 	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/stats"
 	"github.com/loadimpact/k6/ui/pb"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/guregu/null.v3"
 )
 
 const constantVUsType = "constant-vus"
@@ -182,6 +181,11 @@ func (clv ConstantVUs) Run(parentCtx context.Context, out chan<- stats.SampleCon
 			activeVUs.Done()
 		})
 	handleVU := func(initVU lib.InitializedVU) {
+		defer func() {
+			if r := recover(); r != nil {
+				clv.logger.Errorln(r)
+			}
+		}()
 		ctx, cancel := context.WithCancel(maxDurationCtx)
 		defer cancel()
 

--- a/lib/executor/shared_iterations.go
+++ b/lib/executor/shared_iterations.go
@@ -27,14 +27,13 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/sirupsen/logrus"
-	"gopkg.in/guregu/null.v3"
-
 	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/lib/metrics"
 	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/stats"
 	"github.com/loadimpact/k6/ui/pb"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/guregu/null.v3"
 )
 
 const sharedIterationsType = "shared-iterations"
@@ -238,6 +237,11 @@ func (si SharedIterations) Run(parentCtx context.Context, out chan<- stats.Sampl
 			activeVUs.Done()
 		})
 	handleVU := func(initVU lib.InitializedVU) {
+		defer func() {
+			if r := recover(); r != nil {
+				si.logger.Errorln(r)
+			}
+		}()
 		ctx, cancel := context.WithCancel(maxDurationCtx)
 		defer cancel()
 


### PR DESCRIPTION
Making sure k6 never panics (#1601 and #1487) by adding `defer..recover` blocks. I'm not sure about the performance penalty though.
