### PR TITLE
GitHub container registry

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -136,7 +136,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get_version.outputs.version }}
-      version_ci: ${{ steps.get_version.outputs.version_ci }}
     steps:
       - name: Get version
         id: get_version
@@ -208,8 +207,6 @@ jobs:
   build-docker:
     runs-on: ubuntu-latest
     needs: [deps, lint, test, test-cov, configure]
-    env:
-      VERSION_CI: ${{ needs.configure.outputs.version_ci }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -135,7 +135,8 @@ jobs:
   configure:
     runs-on: ubuntu-latest
     outputs:
-        version: ${{ steps.get_version.outputs.version }}
+      version: ${{ steps.get_version.outputs.version }}
+      version_ci: ${{ steps.get_version.outputs.version_ci }}
     steps:
       - name: Get version
         id: get_version
@@ -143,6 +144,9 @@ jobs:
           VERSION="${GITHUB_REF##*/}"
           echo "VERSION=${VERSION}"
           echo "::set-output name=version::${VERSION}"
+          VERSION_CI="${VERSION#v}-${GITHUB_SHA::7}"
+          echo "VERSION_CI=${VERSION_CI}"
+          echo "::set-output name=version_ci::${VERSION_CI}"
 
   build:
     runs-on: ubuntu-latest
@@ -204,7 +208,74 @@ jobs:
           path: dist/
           retention-days: 7
 
+  build-docker:
+    runs-on: ubuntu-latest
+    needs: [deps, lint, test, test-cov, configure]
+    env:
+      VERSION_CI: ${{ needs.configure.outputs.version_ci }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build
+        run: docker build -t $DOCKER_IMAGE_ID .
+      - name: Check
+        run: |
+            docker run $DOCKER_IMAGE_ID version
+            docker run $DOCKER_IMAGE_ID --help
+            docker run $DOCKER_IMAGE_ID help
+            docker run $DOCKER_IMAGE_ID run --help
+            docker run $DOCKER_IMAGE_ID inspect --help
+            docker run $DOCKER_IMAGE_ID status --help
+            docker run $DOCKER_IMAGE_ID stats --help
+            docker run $DOCKER_IMAGE_ID scale --help
+            docker run $DOCKER_IMAGE_ID pause --help
+            docker run $DOCKER_IMAGE_ID resume --help
+      - name: Publish Docker CI
+        run: |
+          echo "DOCKER_IMAGE_ID=$DOCKER_IMAGE_ID"
+          # Log into GHCR
+          echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+          docker tag "$DOCKER_IMAGE_ID" "ghcr.io/$DOCKER_IMAGE_ID/ci:$VERSION_CI"
+          docker push "ghcr.io/$DOCKER_IMAGE_ID/ci:$VERSION_CI"
+
   publish-docker:
+    runs-on: ubuntu-latest
+    needs: [build-docker, configure]
+    if: github.event_name != 'pull_request'
+    env:
+      VERSION: ${{ needs.configure.outputs.version }}
+      VERSION_CI: ${{ needs.configure.outputs.version_ci }}
+    steps:
+      - name: Publish Container Registries
+        run: |
+          echo 'Publish Docker'
+          skopeo copy --src-creds ${{ github.actor }}:${{ secrets.CR_PAT }} \
+                      --dest-creds ${{ secrets.DOCKER_USER }}:${{ secrets.DOCKER_PASS }} \
+                      docker://ghcr.io/$DOCKER_IMAGE_ID/ci:$VERSION_CI \
+                      docker://$DOCKER_IMAGE_ID:$VERSION
+
+          echo 'Publish GHCR'
+          skopeo copy --src-creds ${{ github.actor }}:${{ secrets.CR_PAT }} \
+                      --dest-creds ${{ github.actor }}:${{ secrets.CR_PAT }} \
+                      docker://ghcr.io/$DOCKER_IMAGE_ID/ci:$VERSION_CI \
+                      docker://ghcr.io/$DOCKER_IMAGE_ID:$VERSION
+
+          # We also want to tag the latest stable version as latest
+          if [[ "$VERSION" != "master" ]] && [[ ! "$VERSION" =~ (RC|rc) ]]; then
+            echo 'Publish Docker (latest)'
+            skopeo copy --src-creds ${{ github.actor }}:${{ secrets.CR_PAT }} \
+                        --dest-creds ${{ secrets.DOCKER_USER }}:${{ secrets.DOCKER_PASS }} \
+                        docker://ghcr.io/$DOCKER_IMAGE_ID/ci:$VERSION_CI \
+                        docker://$DOCKER_IMAGE_ID:latest
+
+            echo 'Publish GHCR (latest)'
+            skopeo copy --src-creds ${{ github.actor }}:${{ secrets.CR_PAT }} \
+                        --dest-creds ${{ github.actor }}:${{ secrets.CR_PAT }} \
+                        docker://ghcr.io/$DOCKER_IMAGE_ID/ci:$VERSION_CI \
+                        docker://ghcr.io/$DOCKER_IMAGE_ID:latest
+          fi
+
+  publish-ghcr:
     runs-on: ubuntu-latest
     needs: [deps, lint, test, test-cov, configure]
     env:
@@ -232,16 +303,49 @@ jobs:
           echo "REF=${{ github.ref }}"
           echo "DOCKER_IMAGE_ID=$DOCKER_IMAGE_ID"
           # Log into registry
-          echo "${{ secrets.DOCKER_PASS }}" | docker login -u "${{ secrets.DOCKER_USER }}" --password-stdin
+          echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
           VERSION="${VERSION#v}"
           echo "VERSION=$VERSION"
-          docker tag "$DOCKER_IMAGE_ID" "$DOCKER_IMAGE_ID:$VERSION"
-          docker push "$DOCKER_IMAGE_ID:$VERSION"
+          docker tag "$DOCKER_IMAGE_ID" "ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE_ID:$VERSION"
+          docker push "ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE_ID:$VERSION"
           # We also want to tag the latest stable version as latest
           if [[ "$VERSION" != "master" ]] && [[ ! "$VERSION" =~ (RC|rc) ]]; then
-            docker tag "$DOCKER_IMAGE_ID" "$DOCKER_IMAGE_ID:latest"
-            docker push "$DOCKER_IMAGE_ID:latest"
+            docker tag "$DOCKER_IMAGE_ID" "ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE_ID:latest"
+            docker push "ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE_ID:latest"
           fi
+
+  publish-github:
+    runs-on: ubuntu-latest
+    needs: [deps, lint, test, test-cov, configure, build]
+    if: startsWith(github.ref, 'refs/tags/v')
+    env:
+      VERSION: ${{ needs.configure.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Download binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: binaries
+          path: dist
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -x
+          assets=()
+          for asset in ./dist/*; do
+            assets+=("-a" "$asset")
+          done
+          hub release create "${assets[@]}" -m "$VERSION" -m "$(cat ./release\ notes/${VERSION}.md)" "$VERSION"
+      - name: Upload packages to Bintray
+        run: |
+          # Publishing deb
+          curl --fail -H "X-GPG-PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}" -T "dist/k6-$VERSION-amd64.deb" \
+            "https://${{ secrets.BINTRAY_USER }}:${{ secrets.BINTRAY_KEY }}@api.bintray.com/content/loadimpact/deb/k6/${VERSION#v}/k6-${VERSION}-amd64.deb;deb_distribution=stable;deb_component=main;deb_architecture=amd64;publish=1;override=1"
+          # Publishing rpm
+          curl --fail -H "X-GPG-PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}" -T "dist/k6-$VERSION-amd64.rpm" \
+            "https://${{ secrets.BINTRAY_USER }}:${{ secrets.BINTRAY_KEY }}@api.bintray.com/content/loadimpact/rpm/k6/${VERSION#v}/k6-${VERSION}-amd64.rpm?publish=1&override=1"
 
   package-windows:
     runs-on: windows-latest

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -254,39 +254,6 @@ jobs:
             docker push "$DOCKER_IMAGE_ID:latest"
           fi
 
-  publish-github:
-    runs-on: ubuntu-latest
-    needs: [deps, lint, test, test-cov, configure, build]
-    if: startsWith(github.ref, 'refs/tags/v')
-    env:
-      VERSION: ${{ needs.configure.outputs.version }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Download binaries
-        uses: actions/download-artifact@v2
-        with:
-          name: binaries
-          path: dist
-      - name: Create release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -x
-          assets=()
-          for asset in ./dist/*; do
-            assets+=("-a" "$asset")
-          done
-          hub release create "${assets[@]}" -m "$VERSION" -m "$(cat ./release\ notes/${VERSION}.md)" "$VERSION"
-      - name: Upload packages to Bintray
-        run: |
-          # Publishing deb
-          curl --fail -H "X-GPG-PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}" -T "dist/k6-$VERSION-amd64.deb" \
-            "https://${{ secrets.BINTRAY_USER }}:${{ secrets.BINTRAY_KEY }}@api.bintray.com/content/loadimpact/deb/k6/${VERSION#v}/k6-${VERSION}-amd64.deb;deb_distribution=stable;deb_component=main;deb_architecture=amd64;publish=1;override=1"
-          # Publishing rpm
-          curl --fail -H "X-GPG-PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}" -T "dist/k6-$VERSION-amd64.rpm" \
-            "https://${{ secrets.BINTRAY_USER }}:${{ secrets.BINTRAY_KEY }}@api.bintray.com/content/loadimpact/rpm/k6/${VERSION#v}/k6-${VERSION}-amd64.rpm?publish=1&override=1"
-
   package-windows:
     runs-on: windows-latest
     defaults:

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -207,6 +207,8 @@ jobs:
   build-docker:
     runs-on: ubuntu-latest
     needs: [deps, lint, test, test-cov, configure]
+    env:
+      VERSION: ${{ needs.configure.outputs.version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -230,7 +232,7 @@ jobs:
           github.ref == 'refs/heads/master' ||
           startsWith(github.ref, 'refs/tags/v')
         run: |
-          echo "DOCKER_IMAGE_ID=$DOCKER_IMAGE_ID"
+          echo "Publish GHCR ($DOCKER_IMAGE_ID:$VERSION)"
 
           # Log into GitHub Container Registry
           echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
@@ -242,6 +244,8 @@ jobs:
             docker tag "$DOCKER_IMAGE_ID" "ghcr.io/$DOCKER_IMAGE_ID:latest"
             docker push "ghcr.io/$DOCKER_IMAGE_ID:latest"
           fi
+
+          echo "Publish Docker ($DOCKER_IMAGE_ID:$VERSION)"
 
           # Log into Docker Hub Registry
           echo "${{ secrets.DOCKER_PASS }}" | docker login -u "${{ secrets.DOCKER_USER }}" --password-stdin

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -144,9 +144,6 @@ jobs:
           VERSION="${GITHUB_REF##*/}"
           echo "VERSION=${VERSION}"
           echo "::set-output name=version::${VERSION}"
-          VERSION_CI="${VERSION#v}-${GITHUB_SHA::7}"
-          echo "VERSION_CI=${VERSION_CI}"
-          echo "::set-output name=version_ci::${VERSION_CI}"
 
   build:
     runs-on: ubuntu-latest
@@ -230,88 +227,34 @@ jobs:
             docker run $DOCKER_IMAGE_ID scale --help
             docker run $DOCKER_IMAGE_ID pause --help
             docker run $DOCKER_IMAGE_ID resume --help
-      - name: Publish Docker CI
+
+      - name: Publish
+        if: |
+          github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/tags/v')
         run: |
           echo "DOCKER_IMAGE_ID=$DOCKER_IMAGE_ID"
-          # Log into GHCR
+
+          # Log into GitHub Container Registry
           echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
-          docker tag "$DOCKER_IMAGE_ID" "ghcr.io/$DOCKER_IMAGE_ID/ci:$VERSION_CI"
-          docker push "ghcr.io/$DOCKER_IMAGE_ID/ci:$VERSION_CI"
+          docker tag "$DOCKER_IMAGE_ID" "ghcr.io/$DOCKER_IMAGE_ID:$VERSION"
+          docker push "ghcr.io/$DOCKER_IMAGE_ID:$VERSION"
+          # We also want to tag the latest stable version as latest
+          if [[ "$VERSION" != "master" ]] && [[ ! "$VERSION" =~ (RC|rc) ]]; then
+            echo 'Publish GHCR (latest)'
+            docker tag "$DOCKER_IMAGE_ID" "ghcr.io/$DOCKER_IMAGE_ID:latest"
+            docker push "ghcr.io/$DOCKER_IMAGE_ID:latest"
+          fi
 
-  publish-docker:
-    runs-on: ubuntu-latest
-    needs: [build-docker, configure]
-    if: github.event_name != 'pull_request'
-    env:
-      VERSION: ${{ needs.configure.outputs.version }}
-      VERSION_CI: ${{ needs.configure.outputs.version_ci }}
-    steps:
-      - name: Publish Container Registries
-        run: |
-          echo 'Publish Docker'
-          skopeo copy --src-creds ${{ github.actor }}:${{ secrets.CR_PAT }} \
-                      --dest-creds ${{ secrets.DOCKER_USER }}:${{ secrets.DOCKER_PASS }} \
-                      docker://ghcr.io/$DOCKER_IMAGE_ID/ci:$VERSION_CI \
-                      docker://$DOCKER_IMAGE_ID:$VERSION
-
-          echo 'Publish GHCR'
-          skopeo copy --src-creds ${{ github.actor }}:${{ secrets.CR_PAT }} \
-                      --dest-creds ${{ github.actor }}:${{ secrets.CR_PAT }} \
-                      docker://ghcr.io/$DOCKER_IMAGE_ID/ci:$VERSION_CI \
-                      docker://ghcr.io/$DOCKER_IMAGE_ID:$VERSION
-
+          # Log into Docker Hub Registry
+          echo "${{ secrets.DOCKER_PASS }}" | docker login -u "${{ secrets.DOCKER_USER }}" --password-stdin
+          docker tag "$DOCKER_IMAGE_ID" "$DOCKER_IMAGE_ID:$VERSION"
+          docker push "$DOCKER_IMAGE_ID:$VERSION"
           # We also want to tag the latest stable version as latest
           if [[ "$VERSION" != "master" ]] && [[ ! "$VERSION" =~ (RC|rc) ]]; then
             echo 'Publish Docker (latest)'
-            skopeo copy --src-creds ${{ github.actor }}:${{ secrets.CR_PAT }} \
-                        --dest-creds ${{ secrets.DOCKER_USER }}:${{ secrets.DOCKER_PASS }} \
-                        docker://ghcr.io/$DOCKER_IMAGE_ID/ci:$VERSION_CI \
-                        docker://$DOCKER_IMAGE_ID:latest
-
-            echo 'Publish GHCR (latest)'
-            skopeo copy --src-creds ${{ github.actor }}:${{ secrets.CR_PAT }} \
-                        --dest-creds ${{ github.actor }}:${{ secrets.CR_PAT }} \
-                        docker://ghcr.io/$DOCKER_IMAGE_ID/ci:$VERSION_CI \
-                        docker://ghcr.io/$DOCKER_IMAGE_ID:latest
-          fi
-
-  publish-ghcr:
-    runs-on: ubuntu-latest
-    needs: [deps, lint, test, test-cov, configure]
-    env:
-      VERSION: ${{ needs.configure.outputs.version }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Build
-        run: docker build -t $DOCKER_IMAGE_ID .
-      - name: Check
-        run: |
-            docker run $DOCKER_IMAGE_ID version
-            docker run $DOCKER_IMAGE_ID --help
-            docker run $DOCKER_IMAGE_ID help
-            docker run $DOCKER_IMAGE_ID run --help
-            docker run $DOCKER_IMAGE_ID inspect --help
-            docker run $DOCKER_IMAGE_ID status --help
-            docker run $DOCKER_IMAGE_ID stats --help
-            docker run $DOCKER_IMAGE_ID scale --help
-            docker run $DOCKER_IMAGE_ID pause --help
-            docker run $DOCKER_IMAGE_ID resume --help
-      - name: Publish
-        if: github.event_name != 'pull_request'
-        run: |
-          echo "REF=${{ github.ref }}"
-          echo "DOCKER_IMAGE_ID=$DOCKER_IMAGE_ID"
-          # Log into registry
-          echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
-          VERSION="${VERSION#v}"
-          echo "VERSION=$VERSION"
-          docker tag "$DOCKER_IMAGE_ID" "ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE_ID:$VERSION"
-          docker push "ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE_ID:$VERSION"
-          # We also want to tag the latest stable version as latest
-          if [[ "$VERSION" != "master" ]] && [[ ! "$VERSION" =~ (RC|rc) ]]; then
-            docker tag "$DOCKER_IMAGE_ID" "ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE_ID:latest"
-            docker push "ghcr.io/${{ github.repository_owner }}/$DOCKER_IMAGE_ID:latest"
+            docker tag "$DOCKER_IMAGE_ID" "$DOCKER_IMAGE_ID:latest"
+            docker push "$DOCKER_IMAGE_ID:latest"
           fi
 
   publish-github:

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -232,6 +232,7 @@ jobs:
           github.ref == 'refs/heads/master' ||
           startsWith(github.ref, 'refs/tags/v')
         run: |
+          VERSION="${VERSION#v}"
           echo "Publish GHCR ($DOCKER_IMAGE_ID:$VERSION)"
 
           # Log into GitHub Container Registry


### PR DESCRIPTION
This PR is linked to #1622 issue and implements Github package publishing in the new workflow.

As described in [Github Docs](https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images) Github Packages will be replaced with Github Container Registry, so I have used it.

In order to launch pipelines correctly CR_PAT secret must be created and it contains a Personal Access Token with `write;packages` scope.

More details can be found on this [link](https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images#authenticating-with-the-container-registry).

I have created tasks similar to Docker publishing, with the same dependencies, in order to execute them in parallel