### PR TITLE
Print errors stopping the execution to the stderr

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -119,7 +119,13 @@ var RootCmd = &cobra.Command{
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
 		code := -1
-		var logger logrus.FieldLogger = logrus.StandardLogger()
+
+		var logger logrus.FieldLogger = &logrus.Logger{
+			Out:       os.Stderr,
+			Formatter: new(logrus.TextFormatter),
+			Hooks:     make(logrus.LevelHooks),
+			Level:     logrus.InfoLevel,
+		}
 		if e, ok := err.(ExitCode); ok {
 			code = e.Code
 			if e.Hint != "" {


### PR DESCRIPTION
This was broken after the adding of the loki logger output and should be
better fixed, but a better fix will required either rewrite of the cmd
package or more global variables, so this is preferable for now.
