### PR TITLE
Rename gRPC module to k6/net/grpc and track and bundle loaded protobuf files

### DIFF
--- a/js/common/context.go
+++ b/js/common/context.go
@@ -30,16 +30,33 @@ type ctxKey int
 
 const (
 	ctxKeyRuntime ctxKey = iota
+	ctxKeyInitEnv
 )
 
+// WithRuntime attaches the given goja runtime to the context.
 func WithRuntime(ctx context.Context, rt *goja.Runtime) context.Context {
 	return context.WithValue(ctx, ctxKeyRuntime, rt)
 }
 
+// GetRuntime retrieves the attached goja runtime from the given context.
 func GetRuntime(ctx context.Context) *goja.Runtime {
 	v := ctx.Value(ctxKeyRuntime)
 	if v == nil {
 		return nil
 	}
 	return v.(*goja.Runtime)
+}
+
+// WithInitEnv attaches the given init environment to the context.
+func WithInitEnv(ctx context.Context, initEnv *InitEnvironment) context.Context {
+	return context.WithValue(ctx, ctxKeyInitEnv, initEnv)
+}
+
+// GetInitEnv retrieves the attached init environment struct from the given context.
+func GetInitEnv(ctx context.Context) *InitEnvironment {
+	v := ctx.Value(ctxKeyInitEnv)
+	if v == nil {
+		return nil
+	}
+	return v.(*InitEnvironment)
 }

--- a/js/common/context_test.go
+++ b/js/common/context_test.go
@@ -36,3 +36,9 @@ func TestContextRuntime(t *testing.T) {
 func TestContextRuntimeNil(t *testing.T) {
 	assert.Nil(t, GetRuntime(context.Background()))
 }
+
+func TestContextInitEnv(t *testing.T) {
+	ie := &InitEnvironment{}
+	assert.Nil(t, GetInitEnv(context.Background()))
+	assert.Equal(t, ie, GetInitEnv(WithInitEnv(context.Background(), ie)))
+}

--- a/js/common/initenv.go
+++ b/js/common/initenv.go
@@ -1,0 +1,62 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2020 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package common
+
+import (
+	"net/url"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+)
+
+// InitEnvironment contains properties that can be accessed by Go code executed
+// in the k6 init context. It can be accessed by calling common.GetInitEnv().
+type InitEnvironment struct {
+	Logger      logrus.FieldLogger
+	FileSystems map[string]afero.Fs
+	CWD         *url.URL
+	// TODO: add RuntimeOptions and other properties, goja sources, etc.
+	// ideally, we should leave this as the only data structure necessary for
+	// executing the init context for all JS modules
+}
+
+// GetAbsFilePath should be used to access the FileSystems, since afero has a
+// bug when opening files with relative paths - it caches them from the FS root,
+// not the current working directory... So, if necessary, this method will
+// transform any relative paths into absolute ones, using the CWD.
+//
+// TODO: refactor? It was copied from
+// https://github.com/loadimpact/k6/blob/c51095ad7304bdd1e82cdb33c91abc331533b886/js/initcontext.go#L211-L222
+func (ie *InitEnvironment) GetAbsFilePath(filename string) string {
+	// Here IsAbs should be enough but unfortunately it doesn't handle absolute paths starting from
+	// the current drive on windows like `\users\noname\...`. Also it makes it more easy to test and
+	// will probably be need for archive execution under windows if always consider '/...' as an
+	// absolute path.
+	if filename[0] != '/' && filename[0] != '\\' && !filepath.IsAbs(filename) {
+		filename = filepath.Join(ie.CWD.Path, filename)
+	}
+	filename = filepath.Clean(filename)
+	if filename[0:1] != afero.FilePathSeparator {
+		filename = afero.FilePathSeparator + filename
+	}
+	return filename
+}

--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -49,6 +49,8 @@ const openCantBeUsedOutsideInitContextMsg = `The "open()" function is only avail
 	`(i.e. the global scope), see https://k6.io/docs/using-k6/test-life-cycle for more information`
 
 // InitContext provides APIs for use in the init context.
+//
+// TODO: refactor most/all of this state away, use common.InitEnvironment instead
 type InitContext struct {
 	// Bound runtime; used to instantiate objects.
 	runtime  *goja.Runtime

--- a/js/modules/k6/grpc/client.go
+++ b/js/modules/k6/grpc/client.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"strconv"
 	"strings"
@@ -116,17 +117,26 @@ func (c *Client) Load(ctxPtr *context.Context, importPaths []string, filenames .
 		return nil, errors.New("load must be called in the init context")
 	}
 
-	f, err := protoparse.ResolveFilenames(importPaths, filenames...)
-	if err != nil {
-		return nil, err
+	initEnv := common.GetInitEnv(*ctxPtr)
+	if initEnv == nil {
+		return nil, errors.New("missing init environment")
+	}
+
+	// If no import paths are specified, use the current working directory
+	if len(importPaths) == 0 {
+		importPaths = append(importPaths, initEnv.CWD.Path)
 	}
 
 	parser := protoparse.Parser{
 		ImportPaths:      importPaths,
-		InferImportPaths: len(importPaths) == 0,
+		InferImportPaths: false,
+		Accessor: protoparse.FileAccessor(func(filename string) (io.ReadCloser, error) {
+			absFilePath := initEnv.GetAbsFilePath(filename)
+			return initEnv.FileSystems["file"].Open(absFilePath)
+		}),
 	}
 
-	fds, err := parser.ParseFiles(f...)
+	fds, err := parser.ParseFiles(filenames...)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +154,11 @@ func (c *Client) Load(ctxPtr *context.Context, importPaths []string, filenames .
 	}
 
 	var rtn []MethodInfo
-	c.mds = make(map[string]protoreflect.MethodDescriptor)
+	if c.mds == nil {
+		// This allows us to call load() multiple times, without overwriting the
+		// previously loaded definitions.
+		c.mds = make(map[string]protoreflect.MethodDescriptor)
+	}
 
 	files.RangeFiles(func(fd protoreflect.FileDescriptor) bool {
 		sds := fd.Services()

--- a/js/modules/k6/grpc/grpc.go
+++ b/js/modules/k6/grpc/grpc.go
@@ -27,7 +27,7 @@ import (
 )
 
 func init() {
-	modules.Register("k6/protocols/grpc", New())
+	modules.Register("k6/net/grpc", New())
 }
 
 // GRPC represents the gRPC protocol module for k6

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -542,11 +542,11 @@ func TestRequestAndBatch(t *testing.T) {
 		}
 		t.Run("ocsp_stapled_good", func(t *testing.T) {
 			_, err := common.RunString(rt, `
-			var res = http.request("GET", "https://www.microsoft.com/");
+			var res = http.request("GET", "https://www.microsoft.com/en-us/");
 			if (res.ocsp.status != http.OCSP_STATUS_GOOD) { throw new Error("wrong ocsp stapled response status: " + res.ocsp.status); }
 			`)
 			assert.NoError(t, err)
-			assertRequestMetricsEmitted(t, stats.GetBufferedSamples(samples), "GET", "https://www.microsoft.com/", "", 200, "")
+			assertRequestMetricsEmitted(t, stats.GetBufferedSamples(samples), "GET", "https://www.microsoft.com/en-us/", "", 200, "")
 		})
 	})
 	t.Run("Invalid", func(t *testing.T) {

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -527,6 +527,7 @@ func TestVURunContext(t *testing.T) {
 				fnCalled = true
 
 				assert.Equal(t, vu.Runtime, common.GetRuntime(*vu.Context), "incorrect runtime in context")
+				assert.Nil(t, common.GetInitEnv(*vu.Context)) // shouldn't get this in the vu context
 
 				state := lib.GetState(*vu.Context)
 				if assert.NotNil(t, state) {

--- a/samples/grpc.js
+++ b/samples/grpc.js
@@ -1,4 +1,4 @@
-import grpc from 'k6/protocols/grpc';
+import grpc from 'k6/net/grpc';
 import { check } from "k6";
 
 let client = grpc.newClient();


### PR DESCRIPTION
This should fix https://github.com/loadimpact/k6/issues/1696 (it's WIP since I want to write a few more tests).

I think I've managed to get away with very little refactoring for v0.29.0, so hopefully not introducing any bugs... :crossed_fingers: 

I'm also hopeful that the new `InitEnvironment` concept is a viable way to refactor the `InitContext` and `BaseInitContext` and get rid of some of the complexity and code smells (`ctxPtr` :vomiting_face:) there in future k6 releases. In principle, we should be able to extend the `InitEnvironment` struct so that there is nothing special about the built-in k6 functions like `open()` and even `require()`, i.e. refactor them so they use `GetInitEnv()` as well.

@rogchap, can you please also review this PR and test it, to see if it works for your complex use case as well. I imagine that removing `protoparse.ResolveFilenames()` and always disabling `InferImportPaths` might break some complicated imports, even after automatically adding the CWD as the default import path, though I couldn't do it on my machine with my simple `.proto` files... In any case, `protoparse.ResolveFilenames()` is not viable since it directly uses the `os` package to look for files, so if it's absolutely needed, we'd have to re-implement it with afero (or a generic file system interface) in a future k6 version.

Edit: for testing it properly, if `k6 run script.js` works, then `k6 archive script.js && k6 run archive.tar` should also work.