### PR TITLE
Enable some tests on Windows

### DIFF
--- a/core/local/local_test.go
+++ b/core/local/local_test.go
@@ -1077,9 +1077,6 @@ func TestDNSResolver(t *testing.T) {
 }
 
 func TestRealTimeAndSetupTeardownMetrics(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip()
-	}
 	t.Parallel()
 	script := []byte(`
 	import { Counter } from "k6/metrics";

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -551,11 +551,6 @@ func TestVURunContext(t *testing.T) {
 }
 
 func TestVURunInterrupt(t *testing.T) {
-	// TODO: figure out why interrupt sometimes fails... data race in goja?
-	if isWindows {
-		t.Skip()
-	}
-
 	r1, err := getSimpleRunner(t, "/script.js", `
 		exports.default = function() { while(true) {} }
 		`)
@@ -589,11 +584,6 @@ func TestVURunInterrupt(t *testing.T) {
 }
 
 func TestVURunInterruptDoesntPanic(t *testing.T) {
-	// TODO: figure out why interrupt sometimes fails... data race in goja?
-	if isWindows {
-		t.Skip()
-	}
-
 	r1, err := getSimpleRunner(t, "/script.js", `
 		exports.default = function() { while(true) {} }
 		`)

--- a/lib/netext/httpext/tracer_test.go
+++ b/lib/netext/httpext/tracer_test.go
@@ -148,9 +148,6 @@ func (c failingConn) Write(b []byte) (int, error) {
 }
 
 func TestTracerNegativeHttpSendingValues(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip()
-	}
 	t.Parallel()
 	srv := httptest.NewTLSServer(httpbin.New().Handler())
 	defer srv.Close()


### PR DESCRIPTION
These were flaky on AppVeyor, but seem to pass on GHA. I ran the full suite a few times in https://github.com/imiric/k6/actions/runs/359816051 without any failures, so it seems safe to leave them on, unless they embarass me and fail now... :)

There are still two that failed consistently and weren't enabled: `TestRequestAndBatch` and `TestTracer`. I'll look into refactoring them before closing #902, though that can also wait for another PR.