### PR TITLE
Fix hostname blocking

### DIFF
--- a/lib/types/hostnametrie.go
+++ b/lib/types/hostnametrie.go
@@ -163,14 +163,16 @@ func (t *HostnameTrie) childInsert(s string) error {
 func (t *HostnameTrie) Contains(s string) (matchedPattern string, matchFound bool) {
 	s = strings.ToLower(s)
 	if len(s) == 0 {
-		return s, len(t.children) == 0
-	}
-
-	rStr := []rune(s)
-	last := len(rStr) - 1
-	if c, ok := t.children[rStr[last]]; ok {
-		if match, matched := c.Contains(string(rStr[:last])); matched {
-			return match + string(rStr[last]), true
+		if len(t.children) == 0 {
+			return "", true
+		}
+	} else {
+		rStr := []rune(s)
+		last := len(rStr) - 1
+		if c, ok := t.children[rStr[last]]; ok {
+			if match, matched := c.Contains(string(rStr[:last])); matched {
+				return match + string(rStr[last]), true
+			}
 		}
 	}
 

--- a/lib/types/hostnametrie_test.go
+++ b/lib/types/hostnametrie_test.go
@@ -42,6 +42,7 @@ func TestHostnameTrieContains(t *testing.T) {
 		"tEsT.k6.Io":            "test.k6.io",
 		"TESt.K6.IO":            "test.k6.io",
 		"blocked.valId.paTtern": "*valid.pattern",
+		"valId.paTtern":         "*valid.pattern",
 		"example.test.k6.io":    "",
 	}
 	for key, value := range cases {

--- a/lib/types/hostnametrie_test.go
+++ b/lib/types/hostnametrie_test.go
@@ -28,21 +28,26 @@ import (
 )
 
 func TestHostnameTrieInsert(t *testing.T) {
-	hostnames := HostnameTrie{}
+	hostnames, err := NewHostnameTrie([]string{"foo.bar"})
+	assert.NoError(t, err)
 	assert.NoError(t, hostnames.insert("test.k6.io"))
 	assert.Error(t, hostnames.insert("inval*d.pattern"))
 	assert.NoError(t, hostnames.insert("*valid.pattern"))
 }
 
 func TestHostnameTrieContains(t *testing.T) {
-	trie, err := NewHostnameTrie([]string{"test.k6.io", "*valid.pattern"})
+	trie, err := NewHostnameTrie([]string{"sub.test.k6.io", "test.k6.io", "*valid.pattern", "sub.valid.pattern"})
 	require.NoError(t, err)
 	cases := map[string]string{
 		"K6.Io":                 "",
 		"tEsT.k6.Io":            "test.k6.io",
 		"TESt.K6.IO":            "test.k6.io",
+		"sub.test.k6.io":        "sub.test.k6.io",
+		"sub.sub.test.k6.io":    "",
 		"blocked.valId.paTtern": "*valid.pattern",
 		"valId.paTtern":         "*valid.pattern",
+		"sub.valid.pattern":     "sub.valid.pattern", // use the most specific blocker
+		"www.sub.valid.pattern": "*valid.pattern",
 		"example.test.k6.io":    "",
 	}
 	for key, value := range cases {


### PR DESCRIPTION
This should close https://github.com/loadimpact/k6/issues/1721 (cc @curvedriver). There were 2 separate bugs... :disappointed: Wildcards didn't catch 0-length matches, and when you blocked both a `domain` and a `sub.domain`, the `HostnameTrie` stopped blocking the `domain` because the `len(t.children) == 0` check was no longer true (wrong assumption that you can't block both a top-level and a sub-domain). This script more succinctly demonstrates the issue, running it with k6 0.29.0 will fail all checks, whereas with this PR they all pass:
```js
import http from 'k6/http';
import { check, group } from "k6";

export const options = {
    blockHostnames: ['*httpbin.org', 'test.k6.io', 'k6.io']
}

export default function getFromBlockedHostname() {
    [
        'https://httpbin.org/get?my_param=my_value',
        'https://k6.io/',
    ].forEach(url =>
        group(url, () => {
            check(http.get(url, { redirects: 0 }), {
                "status is 0": (r) => r.status === 0,
                "error_code is 1111": (r) => r.error_code === 1111,
            });
        }));
}
```