### PR TITLE
shareable array implementation

### DIFF
--- a/js/bundle.go
+++ b/js/bundle.go
@@ -302,9 +302,10 @@ func (b *Bundle) instantiate(logger logrus.FieldLogger, rt *goja.Runtime, init *
 	// TODO: get rid of the unused ctxPtr, use a real external context (so we
 	// can interrupt), build the common.InitEnvironment earlier and reuse it
 	initenv := &common.InitEnvironment{
-		Logger:      logger,
-		FileSystems: init.filesystems,
-		CWD:         init.pwd,
+		SharedObjects: init.sharedObjects,
+		Logger:        logger,
+		FileSystems:   init.filesystems,
+		CWD:           init.pwd,
 	}
 	ctx := common.WithInitEnv(context.Background(), initenv)
 	*init.ctxPtr = common.WithRuntime(ctx, rt)

--- a/js/common/initenv.go
+++ b/js/common/initenv.go
@@ -23,6 +23,7 @@ package common
 import (
 	"net/url"
 	"path/filepath"
+	"sync"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -37,6 +38,7 @@ type InitEnvironment struct {
 	// TODO: add RuntimeOptions and other properties, goja sources, etc.
 	// ideally, we should leave this as the only data structure necessary for
 	// executing the init context for all JS modules
+	SharedObjects *SharedObjects
 }
 
 // GetAbsFilePath should be used to access the FileSystems, since afero has a
@@ -59,4 +61,35 @@ func (ie *InitEnvironment) GetAbsFilePath(filename string) string {
 		filename = afero.FilePathSeparator + filename
 	}
 	return filename
+}
+
+// SharedObjects is a collection of general store for objects to be shared. It is mostly a wrapper
+// around map[string]interface with a lock and stuff.
+// The reason behind not just using sync.Map is that it still needs a lock when we want to only call
+// the function constructor if there is no such key at which point you already need a lock so ...
+type SharedObjects struct {
+	data map[string]interface{}
+	l    sync.Mutex
+}
+
+// NewSharedObjects returns a new SharedObjects ready to use
+func NewSharedObjects() *SharedObjects {
+	return &SharedObjects{
+		data: make(map[string]interface{}),
+	}
+}
+
+// GetOrCreateShare returns a shared value with the given name or sets it's value whatever
+// createCallback returns and returns it.
+func (so *SharedObjects) GetOrCreateShare(name string, createCallback func() interface{}) interface{} {
+	so.l.Lock()
+	defer so.l.Unlock()
+
+	value, ok := so.data[name]
+	if !ok {
+		value = createCallback()
+		so.data[name] = value
+	}
+
+	return value
 }

--- a/js/console_test.go
+++ b/js/console_test.go
@@ -76,6 +76,7 @@ func getSimpleRunner(tb testing.TB, filename, data string, opts ...interface{}) 
 	var (
 		fs     = afero.NewMemMapFs()
 		rtOpts = lib.RuntimeOptions{CompatibilityMode: null.NewString("base", true)}
+		logger = testutils.NewLogger(tb)
 	)
 	for _, o := range opts {
 		switch opt := o.(type) {
@@ -83,10 +84,12 @@ func getSimpleRunner(tb testing.TB, filename, data string, opts ...interface{}) 
 			fs = opt
 		case lib.RuntimeOptions:
 			rtOpts = opt
+		case *logrus.Logger:
+			logger = opt
 		}
 	}
 	return New(
-		testutils.NewLogger(tb),
+		logger,
 		&loader.SourceData{
 			URL:  &url.URL{Path: filename, Scheme: "file"},
 			Data: []byte(data),

--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -125,10 +125,10 @@ func newBoundInitContext(base *InitContext, ctxPtr *context.Context, rt *goja.Ru
 	}
 }
 
-// NewShare ...
-// TODO rename
-// TODO constructor?
-func (i *InitContext) NewShare(name string, call goja.Callable) goja.Value {
+// XShare is a constructor returning a shareable read-only array (general objects coming)
+// indentified by the name and having their contents be whatever the call returns - again only
+// arrays currently supported.
+func (i *InitContext) XShare(name string, call goja.Callable) goja.Value {
 	i.sharesLock.Lock()
 	defer i.sharesLock.Unlock()
 	value, ok := i.shares[name]

--- a/js/modules.go
+++ b/js/modules.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/loadimpact/k6/js/modules/k6"
 	_ "github.com/loadimpact/k6/js/modules/k6/crypto"
 	_ "github.com/loadimpact/k6/js/modules/k6/crypto/x509"
+	_ "github.com/loadimpact/k6/js/modules/k6/data"
 	_ "github.com/loadimpact/k6/js/modules/k6/encoding"
 	_ "github.com/loadimpact/k6/js/modules/k6/grpc"
 	_ "github.com/loadimpact/k6/js/modules/k6/http"

--- a/js/modules/k6/data/data.go
+++ b/js/modules/k6/data/data.go
@@ -1,0 +1,76 @@
+package data
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+
+	"github.com/dop251/goja"
+	"github.com/loadimpact/k6/js/common"
+	"github.com/loadimpact/k6/js/internal/modules"
+	"github.com/loadimpact/k6/lib"
+	"github.com/pkg/errors"
+)
+
+type data struct{}
+
+func init() {
+	modules.Register("k6/data", new())
+}
+
+func new() *data {
+	return &data{}
+}
+
+const sharedArrayNamePrefix = "k6/data/SharedArray."
+
+// XSharedArray is a constructor returning a shareable read-only array
+// indentified by the name and having their contents be whatever the call returns
+func (d *data) XSharedArray(ctx context.Context, name string, call goja.Callable) (goja.Value, error) {
+	if lib.GetState(ctx) != nil {
+		return nil, errors.New("new SharedArray must be called in the init context")
+	}
+
+	initEnv := common.GetInitEnv(ctx)
+	if initEnv == nil {
+		return nil, errors.New("missing init environment")
+	}
+
+	name = sharedArrayNamePrefix + name
+	value := initEnv.SharedObjects.GetOrCreateShare(name, func() interface{} {
+		return getShareArrayFromCall(common.GetRuntime(ctx), call)
+	})
+	array, ok := value.(sharedArray)
+	if !ok { // TODO more info in the error?
+		return nil, errors.New("wrong type of shared object")
+	}
+
+	return array.wrap(&ctx, common.GetRuntime(ctx)), nil
+}
+
+func getShareArrayFromCall(rt *goja.Runtime, call goja.Callable) sharedArray {
+	gojaValue, err := call(goja.Undefined())
+	if err != nil {
+		common.Throw(rt, err)
+	}
+	// TODO this can probably be better handled
+	if gojaValue.ExportType().Kind() != reflect.Slice {
+		common.Throw(rt, errors.New("only arrays can be made into SharedArray")) // TODO better error
+	}
+
+	// TODO this can probably be done better if we just iterate over the internal array, but ...
+	// that might be a bit harder given what currently goja provides
+	var tmpArr []interface{}
+	if err = rt.ExportTo(gojaValue, &tmpArr); err != nil {
+		common.Throw(rt, err)
+	}
+
+	arr := make([][]byte, len(tmpArr))
+	for index := range arr {
+		arr[index], err = json.Marshal(tmpArr[index])
+		if err != nil {
+			common.Throw(rt, err)
+		}
+	}
+	return sharedArray{arr: arr}
+}

--- a/js/modules/k6/data/data.go
+++ b/js/modules/k6/data/data.go
@@ -33,11 +33,7 @@ import (
 type data struct{}
 
 func init() {
-	modules.Register("k6/data", new())
-}
-
-func new() *data {
-	return &data{}
+	modules.Register("k6/data", new(data))
 }
 
 const sharedArrayNamePrefix = "k6/data/SharedArray."

--- a/js/modules/k6/data/data.go
+++ b/js/modules/k6/data/data.go
@@ -49,6 +49,9 @@ func (d *data) XSharedArray(ctx context.Context, name string, call goja.Callable
 	if initEnv == nil {
 		return nil, errors.New("missing init environment")
 	}
+	if len(name) == 0 {
+		return nil, errors.New("empty name provided to SharedArray's constructor")
+	}
 
 	name = sharedArrayNamePrefix + name
 	value := initEnv.SharedObjects.GetOrCreateShare(name, func() interface{} {

--- a/js/modules/k6/data/data.go
+++ b/js/modules/k6/data/data.go
@@ -76,6 +76,8 @@ func getShareArrayFromCall(rt *goja.Runtime, call goja.Callable) sharedArray {
 	}
 	arr := make([]string, obj.Get("length").ToInteger())
 
+	// We specifically use JSON.stringify here as we need to use JSON.parse on the way out
+	// it also has the benefit of needing only one loop and being more JS then using golang's json
 	cal, err := rt.RunString(`(function(input, output) {
 		for (var i = 0; i < input.length; i++) {
 			output[i] = JSON.stringify(input[i])

--- a/js/modules/k6/data/data.go
+++ b/js/modules/k6/data/data.go
@@ -1,3 +1,23 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2020 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 package data
 
 import (

--- a/js/modules/k6/data/share.go
+++ b/js/modules/k6/data/share.go
@@ -18,10 +18,7 @@
  *
  */
 
-package js
-
-// TODO move this to another package
-// it can possibly be even in a separate repo if the error handling is fixed
+package data
 
 import (
 	"context"
@@ -31,9 +28,8 @@ import (
 	"github.com/loadimpact/k6/js/common"
 )
 
-// TODO rename
-// TODO check how it works with setup data
-// TODO check how it works if logged
+// TODO fix it not working really well with setupData or just make it more broken
+// TODO fix it working with console.log
 type sharedArray struct {
 	arr [][]byte
 }

--- a/js/modules/k6/data/share.go
+++ b/js/modules/k6/data/share.go
@@ -52,6 +52,9 @@ func (s sharedArray) Get(index int) (interface{}, error) {
 		return goja.Undefined(), nil
 	}
 
+	// we specifically use JSON.parse to get the json to an object inside as otherwise we won't be
+	// able to freeze it as goja doesn't let us unless it is a pure goja object and this is the
+	// easiest way to get one.
 	return s.arr[index], nil
 }
 

--- a/js/share.go
+++ b/js/share.go
@@ -94,9 +94,11 @@ const arrayWrapperCode = `(function(val) {
 		get: function(target, property, receiver) {
 			switch (property){
 			case "length":
-				return target.length()
+				return target.length();
 			case Symbol.iterator:
-				return function() {return target.iterator()}
+				return function() {
+					return target.iterator();
+				};
 			}
 			var i = parseInt(property);
 			if (isNaN(i)) {
@@ -106,5 +108,5 @@ const arrayWrapperCode = `(function(val) {
 			return target.get(i);
 		}
 	};
-	return new Proxy(val, arrayHandler)
+	return new Proxy(val, arrayHandler);
 })`

--- a/js/share.go
+++ b/js/share.go
@@ -1,0 +1,99 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2020 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package js
+
+// TODO move this to another package
+// it can possibly be even in a separate repo if the error handling is fixed
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/dop251/goja"
+	"github.com/loadimpact/k6/js/common"
+)
+
+// TODO rename
+// TODO check how it works with setup data
+// TODO check how it works if logged
+// TODO maybe drop it and leave the sharedArray only for now
+type shared struct {
+	value *goja.Object
+}
+
+func (s shared) Get(ctx context.Context, index goja.Value) (interface{}, error) {
+	rt := common.GetRuntime(ctx)
+	// TODO other index
+	val := s.value.Get(index.String())
+	if val == nil {
+		return goja.Undefined(), nil
+	}
+	b, err := val.ToObject(rt).MarshalJSON()
+	if err != nil { // cache bytes, pre marshal
+		return goja.Undefined(), err
+	}
+	var tmp interface{}
+	if err = json.Unmarshal(b, &tmp); err != nil {
+		return goja.Undefined(), err
+	}
+	return tmp, nil
+}
+
+type sharedArray struct {
+	arr [][]byte
+}
+
+func (s sharedArray) Get(index int) (interface{}, error) {
+	if index < 0 || index >= len(s.arr) {
+		return goja.Undefined(), nil
+	}
+
+	var tmp interface{}
+	if err := json.Unmarshal(s.arr[index], &tmp); err != nil {
+		return goja.Undefined(), err
+	}
+	return tmp, nil
+}
+
+func (s sharedArray) Length() int {
+	return len(s.arr)
+}
+
+type sharedArrayIterator struct {
+	a     *sharedArray
+	index int
+}
+
+func (sai *sharedArrayIterator) Next() (interface{}, error) {
+	if sai.index == len(sai.a.arr)-1 {
+		return map[string]bool{"done": true}, nil
+	}
+	sai.index++
+	var tmp interface{}
+	if err := json.Unmarshal(sai.a.arr[sai.index], &tmp); err != nil {
+		return goja.Undefined(), err
+	}
+	return map[string]interface{}{"value": tmp}, nil
+}
+
+func (s sharedArray) Iterator() *sharedArrayIterator {
+	return &sharedArrayIterator{a: &s, index: -1}
+}

--- a/js/share.go
+++ b/js/share.go
@@ -92,30 +92,18 @@ func (s sharedArray) Iterator() *sharedArrayIterator {
 const arrayWrapperCode = `(function(val) {
 	var arrayHandler = {
 		get: function(target, property, receiver) {
-			// console.log("accessing ", property)
 			switch (property){
 			case "length":
 				return target.length()
 			case Symbol.iterator:
 				return function() {return target.iterator()}
-			/*
-			return function(){
+			}
+			var i = parseInt(property);
+			if (isNaN(i)) {
+				return undefined;
+			}
 
-				var index = 0;
-				return {
-					"next": function() {
-						if (index >= target.length()) {
-							return {done: true}
-						}
-						var result = {value:target.get(index)};
-						index++;
-						return result;
-					}
-				}
-			}
-			*/
-			}
-			return target.get(property);
+			return target.get(i);
 		}
 	};
 	return new Proxy(val, arrayHandler)

--- a/js/share_test.go
+++ b/js/share_test.go
@@ -33,8 +33,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestInitContextNewShareable(t *testing.T) {
+func TestInitContextNewSharedArray(t *testing.T) {
 	data := `'use strict';
+var SharedArray = require("k6/data").SharedArray;
 function generateArray() {
     console.log("once");
     var n = 50;
@@ -45,14 +46,14 @@ function generateArray() {
     return arr;
 }
 
-var s = new Share("something", generateArray);
+var s = new SharedArray("something", generateArray);
 
 var er = "";
 try {
-	var p = new Share("wat", function() {return "whatever"});
+	var p = new SharedArray("wat", function() {return "whatever"});
 	throw "the previous line should've errored";
 } catch (e) {
-	if (!e.toString().includes("only arrays can be made into shared objects")) {
+	if (!e.toString().includes("only arrays can be made into SharedArray")) {
 		er = "wrong error " + e.toString();
 	}
 }

--- a/js/share_test.go
+++ b/js/share_test.go
@@ -45,34 +45,34 @@ function generateArray() {
     return arr;
 }
 
-var s = newShare("something", generateArray);
+var s = new Share("something", generateArray);
 
 var er = "";
 try {
-	var p = newShare("wat", function() {return "whatever"});
+	var p = new Share("wat", function() {return "whatever"});
 	throw "the previous line should've errored";
 } catch (e) {
 	if (!e.toString().includes("only arrays can be made into shared objects")) {
-		er = "wrong error " + e.toString()
+		er = "wrong error " + e.toString();
 	}
 }
 
 if (er != "") {
-	throw er
+	throw er;
 }
 
 exports.default = function() {
 	if (s[2] !== "something2") {
-		throw new Error("bad s[2]="+s[2])
+		throw new Error("bad s[2]="+s[2]);
 	}
 	if (s.length != 50) {
-		throw new Error("bad length " +_s.length)
+		throw new Error("bad length " +_s.length);
 	}
 
 	var i = 0;
 	for (var v of s) {
 		if (v !== "something"+i) {
-			throw new Error("bad v="+v+" for i="+i)
+			throw new Error("bad v="+v+" for i="+i);
 		}
 		i++;
 	}
@@ -83,29 +83,29 @@ exports.default = function() {
 
 	try {
 		s.something = 21
-		throw "the previous line should've errored s.something = 21"
+		throw "the previous line should've errored s.something = 21";
 	} catch(e) {
 		if (!e.toString().includes("Host object field something cannot be made configurable")) {
-			er = "wrong error " + e.toString()
+			er = "wrong error " + e.toString();
 		}
 	}
 
 	if (er != "") {
-		throw er
+		throw er;
 	}
 
 	try {
-		s[1]= "21"
+		s[1]= "21";
 
-		throw "the previous line should've errored"
+		throw "the previous line should've errored";
 	} catch(e) {
 		if (!e.toString().includes("Host object field 1 cannot be made configurable")) {
-			er = "wrong error " + e.toString()
+			er = "wrong error " + e.toString();
 		}
 	}
 
 	if (er != "") {
-		throw er
+		throw er;
 	}
 }`
 

--- a/js/share_test.go
+++ b/js/share_test.go
@@ -1,0 +1,107 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2020 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package js
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/testutils"
+	"github.com/loadimpact/k6/stats"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitContextNewShareable(t *testing.T) {
+	data := `
+function generateArray() {
+    console.log("once");
+    var n = 50;
+    var arr = new Array(n);
+    for (var i = 0 ; i <n; i++) {
+        arr[i] = "something" +i;
+    }
+    return arr;
+}
+
+var s = newShare("something", generateArray);
+
+exports.default = function() {
+	if (s[2] !== "something2") {
+		throw new Error("bad s[2]="+s[2])
+	}
+	if (s.length != 50) {
+		throw new Error("bad length " +_s.length)
+	}
+
+	var i = 0;
+	for (var v of s) {
+		if (v !== "something"+i) {
+			throw new Error("bad v="+v+" for i="+i)
+		}
+		i++;
+	}
+}`
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.InfoLevel)
+	logger.Out = ioutil.Discard
+	hook := testutils.SimpleLogrusHook{
+		HookedLevels: []logrus.Level{logrus.InfoLevel, logrus.ErrorLevel, logrus.FatalLevel, logrus.PanicLevel},
+	}
+	logger.AddHook(&hook)
+
+	r1, err := getSimpleRunner(t, "/script.js", data, logger)
+	require.NoError(t, err)
+	entries := hook.Drain()
+	require.Len(t, entries, 1)
+	assert.Equal(t, logrus.InfoLevel, entries[0].Level)
+	assert.Equal(t, "once", entries[0].Message)
+
+	r2, err := NewFromArchive(logger, r1.MakeArchive(), lib.RuntimeOptions{})
+	require.NoError(t, err)
+	entries = hook.Drain()
+	require.Len(t, entries, 1)
+	assert.Equal(t, logrus.InfoLevel, entries[0].Level)
+	assert.Equal(t, "once", entries[0].Message)
+
+	testdata := map[string]*Runner{"Source": r1, "Archive": r2}
+	for name, r := range testdata {
+		r := r
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			samples := make(chan stats.SampleContainer, 100)
+			initVU, err := r.NewVU(1, samples)
+			if assert.NoError(t, err) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
+				err := vu.RunOnce()
+				assert.NoError(t, err)
+				entries := hook.Drain()
+				require.Len(t, entries, 0)
+			}
+		})
+	}
+}

--- a/js/share_test.go
+++ b/js/share_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestInitContextNewShareable(t *testing.T) {
-	data := `
+	data := `'use strict';
 function generateArray() {
     console.log("once");
     var n = 50;
@@ -46,6 +46,20 @@ function generateArray() {
 }
 
 var s = newShare("something", generateArray);
+
+var er = "";
+try {
+	var p = newShare("wat", function() {return "whatever"});
+	throw "the previous line should've errored";
+} catch (e) {
+	if (!e.toString().includes("only arrays can be made into shared objects")) {
+		er = "wrong error " + e.toString()
+	}
+}
+
+if (er != "") {
+	throw er
+}
 
 exports.default = function() {
 	if (s[2] !== "something2") {
@@ -61,6 +75,37 @@ exports.default = function() {
 			throw new Error("bad v="+v+" for i="+i)
 		}
 		i++;
+	}
+
+	if (s.something != undefined) {
+		throw "s.something should've been undefined but was " + s.something;
+	}
+
+	try {
+		s.something = 21
+		throw "the previous line should've errored s.something = 21"
+	} catch(e) {
+		if (!e.toString().includes("Host object field something cannot be made configurable")) {
+			er = "wrong error " + e.toString()
+		}
+	}
+
+	if (er != "") {
+		throw er
+	}
+
+	try {
+		s[1]= "21"
+
+		throw "the previous line should've errored"
+	} catch(e) {
+		if (!e.toString().includes("Host object field 1 cannot be made configurable")) {
+			er = "wrong error " + e.toString()
+		}
+	}
+
+	if (er != "") {
+		throw er
 	}
 }`
 

--- a/js/share_test.go
+++ b/js/share_test.go
@@ -58,6 +58,15 @@ try {
 }
 
 try {
+	var p = new SharedArray("", generateArray);
+	throw "the previous line should've errored as we provided an empty name";
+} catch (e){
+	if (!e.toString().includes("empty name provided to SharedArray's constructor")) {
+		throw "wrong error " + e.toString();
+	}
+}
+
+try {
 	var p = new SharedArray("wat2", function() {return [{s: function() {return "whatever"}}]});
 	// throw "the previous line should've errored as function was stringified";
 	// unfortunately JSON.stringify is defined that it will acctually just remove stuff (or make them null)

--- a/js/share_test.go
+++ b/js/share_test.go
@@ -41,30 +41,40 @@ function generateArray() {
     var n = 50;
     var arr = new Array(n);
     for (var i = 0 ; i <n; i++) {
-        arr[i] = "something" +i;
+        arr[i] = {value: "something" +i};
     }
     return arr;
 }
 
 var s = new SharedArray("something", generateArray);
 
-var er = "";
 try {
 	var p = new SharedArray("wat", function() {return "whatever"});
-	throw "the previous line should've errored";
+	throw "the previous line should've errored as we returned a string not array";
 } catch (e) {
 	if (!e.toString().includes("only arrays can be made into SharedArray")) {
-		er = "wrong error " + e.toString();
+		throw "wrong error " + e.toString();
 	}
 }
 
-if (er != "") {
-	throw er;
+try {
+	var p = new SharedArray("wat2", function() {return [{s: function() {return "whatever"}}]});
+	// throw "the previous line should've errored as function was stringified";
+	// unfortunately JSON.stringify is defined that it will acctually just remove stuff (or make them null)
+	// that can't be JSONified like functions
+	if (p[0].s != undefined) {
+		throw "only arrays can be made into SharedArray";
+	}
+} catch (e) {
+	if (!e.toString().includes("only arrays can be made into SharedArray")) {
+		throw "wrong error " + e.toString();
+	}
 }
 
+
 exports.default = function() {
-	if (s[2] !== "something2") {
-		throw new Error("bad s[2]="+s[2]);
+	if (s[2].value !== "something2") {
+		throw new Error("bad s[2]="+s[2].value);
 	}
 	if (s.length != 50) {
 		throw new Error("bad length " +_s.length);
@@ -72,10 +82,28 @@ exports.default = function() {
 
 	var i = 0;
 	for (var v of s) {
-		if (v !== "something"+i) {
-			throw new Error("bad v="+v+" for i="+i);
+		if (v.value !== "something"+i) {
+			throw new Error("bad v.value="+v.value+" for i="+i);
 		}
 		i++;
+
+		try {
+			v.data = "help";
+			throw "the previous line should've errored v.data = 'help'";
+		} catch(e) {
+			if (!e.toString().includes("TypeError: Cannot add property data, object is not extensible")) {
+				throw "wrong error " + e.toString();
+			}
+		}
+	}
+
+	try {
+		s[2].data = "help";
+		throw "the previous line should've errored s[2].data = 'help'";
+	} catch(e) {
+		if (!e.toString().includes("TypeError: Cannot add property data, object is not extensible")) {
+			throw "wrong error " + e.toString();
+		}
 	}
 
 	if (s.something != undefined) {
@@ -87,12 +115,8 @@ exports.default = function() {
 		throw "the previous line should've errored s.something = 21";
 	} catch(e) {
 		if (!e.toString().includes("Host object field something cannot be made configurable")) {
-			er = "wrong error " + e.toString();
+			throw "wrong error " + e.toString();
 		}
-	}
-
-	if (er != "") {
-		throw er;
 	}
 
 	try {
@@ -101,12 +125,8 @@ exports.default = function() {
 		throw "the previous line should've errored";
 	} catch(e) {
 		if (!e.toString().includes("Host object field 1 cannot be made configurable")) {
-			er = "wrong error " + e.toString();
+			throw "wrong error " + e.toString();
 		}
-	}
-
-	if (er != "") {
-		throw er;
 	}
 }`
 


### PR DESCRIPTION
This is part of #532

The reason behind this not redefing ... how to open a file or load data
from one is that, as in the majority of the cases after that there is
some amount of ... transformation of the data, so that won't help much.

The original idea was to have a shareable JSON ... but the more concrete
array implementation is faster (in some cases by a lot) and also seems
like a better fix for the first iteration of this, as that will be the
majority of the data type. So it is very likely that the non array parts
will be dropped in favor of doing them later and this getting merged
faster.

There are still more things to be done and depending on whether or not
we want to support iterating (with for-of) it can probably be done
without some of the js code.