### PR TITLE
Sign Windows release binary and installer

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -311,7 +311,7 @@ jobs:
         run: echo "${env:ProgramFiles(x86)}\Windows Kits\10\bin\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Convert base64 certificate to PFX
         run: |
-          $bytes = [Convert]::FromBase64String("${{ secrets.CERTIFICATE }}")
+          $bytes = [Convert]::FromBase64String("${{ secrets.WIN_SIGN_CERT }}")
           [IO.File]::WriteAllBytes("k6.pfx", $bytes)
       - name: Sign Windows binary
         run: signtool sign /f k6.pfx /p "${{ secrets.WIN_SIGN_PASS }}" /tr "http://timestamp.digicert.com" /td sha256 /fd sha256 "packaging\k6.exe"

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -308,7 +308,7 @@ jobs:
           move .\packaging\k6-$env:VERSION-win64\k6.exe .\packaging\
           rmdir .\packaging\k6-$env:VERSION-win64\
       - name: Add signtool to PATH
-        run: echo "C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        run: echo "${env:ProgramFiles(x86)}\Windows Kits\10\bin\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Convert base64 certificate to PFX
         run: |
           $bytes = [Convert]::FromBase64String("${{ secrets.CERTIFICATE }}")

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -324,6 +324,8 @@ jobs:
           light.exe -ext WixUIExtension k6.wixobj
       - name: Sign MSI package
         run: signtool sign /f k6.pfx /p "${{ secrets.WIN_SIGN_PASS }}" /tr "http://timestamp.digicert.com" /td sha256 /fd sha256 "packaging\k6.msi"
+      - name: Cleanup signing artifacts
+        run: del k6.pfx
       - name: Prepare Chocolatey package
         run: |
           $env:VERSION = $env:VERSION.TrimStart("v", " ")

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -307,6 +307,14 @@ jobs:
           Expand-Archive -Path ".\dist\k6-$env:VERSION-win64.zip" -DestinationPath .\packaging\
           move .\packaging\k6-$env:VERSION-win64\k6.exe .\packaging\
           rmdir .\packaging\k6-$env:VERSION-win64\
+      - name: Add signtool to PATH
+        run: echo "C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Convert base64 certificate to PFX
+        run: |
+          $bytes = [Convert]::FromBase64String("${{ secrets.CERTIFICATE }}")
+          [IO.File]::WriteAllBytes("k6.pfx", $bytes)
+      - name: Sign Windows binary
+        run: signtool sign /f k6.pfx /p "${{ secrets.WIN_SIGN_PASS }}" /tr "http://timestamp.digicert.com" /td sha256 /fd sha256 "packaging\k6.exe"
       - name: Create MSI package
         run: |
           $env:VERSION = $env:VERSION -replace 'v(\d+\.\d+\.\d+).*','$1'
@@ -314,6 +322,8 @@ jobs:
           cd .\packaging
           candle.exe -arch x64 "-dVERSION=$env:VERSION" k6.wxs
           light.exe -ext WixUIExtension k6.wixobj
+      - name: Sign MSI package
+        run: signtool sign /f k6.pfx /p "${{ secrets.WIN_SIGN_PASS }}" /tr "http://timestamp.digicert.com" /td sha256 /fd sha256 "packaging\k6.msi"
       - name: Prepare Chocolatey package
         run: |
           $env:VERSION = $env:VERSION.TrimStart("v", " ")


### PR DESCRIPTION
Closes #1034

I tested this in my fork and you can download the signed MSI from [here](https://github.com/imiric/k6/actions/runs/385130865). As explained in [this comment](https://github.com/loadimpact/k6/issues/1034#issuecomment-734268724), I chose to not use any 3rd-party extensions to avoid any security issues. As noted there, this won't remove the "Windows protected your PC" warning, but should eventually if we reach a certain "trust" level with Microsoft, which is gained by a lot of people choosing to run the app anyway.

Two secrets were added to the GitHub repo for this: `WIN_SIGN_CERT` and `WIN_SIGN_PASS`. Information about both can be found in the password manager.

Note that currently this only signs the binary in the MSI package and the MSI itself that are uploaded to Bintray. The binary that is uploaded to GitHub and available as release assets is not signed, as that would be more convoluted to setup, since `signtool.exe` is Windows-only and the build stage happens on Linux. I suppose we could overwrite the assets from Windows, but I didn't test this.