### PR TITLE
fix: flooring of progress when rate is low

### DIFF
--- a/ui/pb/helpers.go
+++ b/ui/pb/helpers.go
@@ -49,8 +49,20 @@ func GetFixedLengthIntFormat(maxValue int64) (formatStr string) {
 // precision + how many zeros it will be padded on the left with) in the
 // returned string corresponds to the number of digits in the supplied maxValue
 // and the desired precision.
+// if the precision is 0 and the maxValue is between 0 and 1, the number of decimal
+// places required to show the first non-zero digit is calculated and that is set 
+// to the precision.
 func GetFixedLengthFloatFormat(maxValue float64, precision uint) (formatStr string) {
 	resLen := 1
+	var decimalPlacesCount uint = 0
+	if precision == 0 && maxValue < 1 && maxValue > 0 {
+		value := maxValue
+		for value < 1 {
+			value *= 10
+			decimalPlacesCount += 1
+		}
+		precision = decimalPlacesCount
+	}
 	if maxValue < 0 {
 		maxValue = -maxValue
 		resLen++


### PR DESCRIPTION
Fixes flooring of the rate when precision is 0 and the rate is low (between 0 and 1).

Closes #1753 

Any feedback and suggestions are welcome!
<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/loadimpact/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/loadimpact/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
