### PR TITLE
Add support for ArrayBuffer request bodies

### DIFF
--- a/js/modules/k6/http/request.go
+++ b/js/modules/k6/http/request.go
@@ -222,6 +222,8 @@ func (h *HTTP) parseRequest(
 			if err := handleObjectBody(newData); err != nil {
 				return nil, err
 			}
+		case goja.ArrayBuffer:
+			result.Body = bytes.NewBuffer(data.Bytes())
 		case map[string]interface{}:
 			if err := handleObjectBody(data); err != nil {
 				return nil, err


### PR DESCRIPTION
This is part of #1020, just for supporting `ArrayBuffer` request bodies. It works fine for submitting binary data from `open()`, e.g.:

```
var img = open('image.png', 'b');

exports.default = function() {
  var arr = new Uint8Array(img);
  http.post('http://127.0.0.1:9000/postbin', arr.buffer,
            { headers: { 'Content-Type': 'image/png' }});
}
```

It should probably have much more tests, but let me know what other scenarios we should cover. All the other typed arrays?

I wasn't able to get it to work with submitting the typed array itself instead of the `ArrayBuffer`, i.e. submitting `arr` instead of `arr.buffer` above (as mentioned [here](https://github.com/loadimpact/k6/issues/1020#issuecomment-727911302)). Goja's `Export()` on it returns an empty `map[string]interface{}{}`, so I couldn't get the `ArrayBuffer` from it. We should probably raise a warning in that case, unless we can work around it.