### PR TITLE
Add git-lfs to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.15-alpine as builder
 WORKDIR $GOPATH/src/github.com/loadimpact/k6
 ADD . .
-RUN apk --no-cache add git
+RUN apk --no-cache add git git-lfs
 RUN CGO_ENABLED=0 go install -a -trimpath -ldflags "-s -w -X github.com/loadimpact/k6/lib/consts.VersionDetails=$(date -u +"%FT%T%z")/$(git describe --always --long --dirty)"
 
 FROM alpine:3.11


### PR DESCRIPTION
It's fairly common to store load testing images in more efficient storage like git lfs. This wouldn't increase the size of the intermediate container by much, as well.