### PR TITLE
Set Docker workdir to a writeable path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ RUN apk add --no-cache ca-certificates && \
 COPY --from=builder /go/bin/k6 /usr/bin/k6
 
 USER 12345
+WORKDIR /home/k6
 ENTRYPOINT ["k6"]


### PR DESCRIPTION
Inspired by [this question](https://stackoverflow.com/q/65678315/96213) and similar we've had on the forum.

This might break some use cases, but it's safer to have this set in the final image than not, and it can be easily overriden.