### PR TITLE
Expand ArrayBuffer support

### DIFF
--- a/js/common/util.go
+++ b/js/common/util.go
@@ -56,3 +56,17 @@ func GetReader(data interface{}) (io.Reader, error) {
 		return nil, fmt.Errorf("invalid type %T, it needs to be a string, byte array or an ArrayBuffer", data)
 	}
 }
+
+// ToBytes tries to return a byte slice from compatible types.
+func ToBytes(data interface{}) ([]byte, error) {
+	switch dt := data.(type) {
+	case []byte:
+		return dt, nil
+	case string:
+		return []byte(dt), nil
+	case goja.ArrayBuffer:
+		return dt.Bytes(), nil
+	default:
+		return nil, fmt.Errorf("invalid type %T, expected string, []byte or ArrayBuffer", data)
+	}
+}

--- a/js/common/util_test.go
+++ b/js/common/util_test.go
@@ -22,6 +22,7 @@ package common
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/dop251/goja"
@@ -40,5 +41,32 @@ func TestThrow(t *testing.T) {
 			_, err := fn2(goja.Undefined())
 			assert.EqualError(t, err, "GoError: aaaa")
 		}
+	}
+}
+
+func TestToBytes(t *testing.T) {
+	rt := goja.New()
+	b := []byte("hello")
+	testCases := []struct {
+		in     interface{}
+		expOut []byte
+		expErr string
+	}{
+		{b, b, ""},
+		{"hello", b, ""},
+		{rt.NewArrayBuffer(b), b, ""},
+		{struct{}{}, nil, "invalid type struct {}, expected string, []byte or ArrayBuffer"},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(fmt.Sprintf("%T", tc.in), func(t *testing.T) {
+			out, err := ToBytes(tc.in)
+			if tc.expErr != "" {
+				assert.EqualError(t, err, tc.expErr)
+				return
+			}
+			assert.Equal(t, tc.expOut, out)
+		})
 	}
 }

--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -204,7 +204,8 @@ func (i *InitContext) compileImport(src, filename string) (*goja.Program, error)
 	return pgm, err
 }
 
-// Open implements open() in the init context and will read and return the contents of a file
+// Open implements open() in the init context and will read and return the contents of a file.
+// If the second argument is "b" it returns the data as a binary array, otherwise as a string.
 func (i *InitContext) Open(ctx context.Context, filename string, args ...string) (goja.Value, error) {
 	if lib.GetState(ctx) != nil {
 		return nil, errors.New(openCantBeUsedOutsideInitContextMsg)

--- a/js/modules/k6/crypto/crypto.go
+++ b/js/modules/k6/crypto/crypto.go
@@ -56,6 +56,7 @@ func New() *Crypto {
 	return &Crypto{}
 }
 
+// RandomBytes returns random data of the given size.
 func (*Crypto) RandomBytes(ctx context.Context, size int) []byte {
 	if size < 1 {
 		common.Throw(common.GetRuntime(ctx), errors.New("invalid size"))
@@ -68,60 +69,70 @@ func (*Crypto) RandomBytes(ctx context.Context, size int) []byte {
 	return bytes
 }
 
+// Md4 returns the MD4 hash of input in the given encoding.
 func (c *Crypto) Md4(ctx context.Context, input interface{}, outputEncoding string) interface{} {
 	hasher := c.CreateHash(ctx, "md4")
 	hasher.Update(input)
 	return hasher.Digest(outputEncoding)
 }
 
+// Md5 returns the MD5 hash of input in the given encoding.
 func (c *Crypto) Md5(ctx context.Context, input interface{}, outputEncoding string) interface{} {
 	hasher := c.CreateHash(ctx, "md5")
 	hasher.Update(input)
 	return hasher.Digest(outputEncoding)
 }
 
+// Sha1 returns the SHA1 hash of input in the given encoding.
 func (c *Crypto) Sha1(ctx context.Context, input interface{}, outputEncoding string) interface{} {
 	hasher := c.CreateHash(ctx, "sha1")
 	hasher.Update(input)
 	return hasher.Digest(outputEncoding)
 }
 
+// Sha256 returns the SHA256 hash of input in the given encoding.
 func (c *Crypto) Sha256(ctx context.Context, input interface{}, outputEncoding string) interface{} {
 	hasher := c.CreateHash(ctx, "sha256")
 	hasher.Update(input)
 	return hasher.Digest(outputEncoding)
 }
 
+// Sha384 returns the SHA384 hash of input in the given encoding.
 func (c *Crypto) Sha384(ctx context.Context, input interface{}, outputEncoding string) interface{} {
 	hasher := c.CreateHash(ctx, "sha384")
 	hasher.Update(input)
 	return hasher.Digest(outputEncoding)
 }
 
+// Sha512 returns the SHA512 hash of input in the given encoding.
 func (c *Crypto) Sha512(ctx context.Context, input interface{}, outputEncoding string) interface{} {
 	hasher := c.CreateHash(ctx, "sha512")
 	hasher.Update(input)
 	return hasher.Digest(outputEncoding)
 }
 
+// Sha512_224 returns the SHA512/224 hash of input in the given encoding.
 func (c *Crypto) Sha512_224(ctx context.Context, input interface{}, outputEncoding string) interface{} {
 	hasher := c.CreateHash(ctx, "sha512_224")
 	hasher.Update(input)
 	return hasher.Digest(outputEncoding)
 }
 
+// Sha512_256 returns the SHA512/256 hash of input in the given encoding.
 func (c *Crypto) Sha512_256(ctx context.Context, input interface{}, outputEncoding string) interface{} {
 	hasher := c.CreateHash(ctx, "sha512_256")
 	hasher.Update(input)
 	return hasher.Digest(outputEncoding)
 }
 
+// Ripemd160 returns the RIPEMD160 hash of input in the given encoding.
 func (c *Crypto) Ripemd160(ctx context.Context, input interface{}, outputEncoding string) interface{} {
 	hasher := c.CreateHash(ctx, "ripemd160")
 	hasher.Update(input)
 	return hasher.Digest(outputEncoding)
 }
 
+// CreateHash returns a Hasher instance that uses the given algorithm.
 func (*Crypto) CreateHash(ctx context.Context, algorithm string) *Hasher {
 	hasher := Hasher{}
 	hasher.ctx = ctx
@@ -162,6 +173,7 @@ func (hasher *Hasher) Update(input interface{}) {
 	}
 }
 
+// Digest returns the hash value in the given encoding.
 func (hasher *Hasher) Digest(outputEncoding string) interface{} {
 	sum := hasher.hash.Sum(nil)
 
@@ -235,6 +247,8 @@ func (c Crypto) CreateHMAC(ctx context.Context, algorithm string, key interface{
 	return &hasher
 }
 
+// Hmac returns a new HMAC hash of input using the given algorithm and key
+// in the given encoding.
 func (c *Crypto) Hmac(
 	ctx context.Context, algorithm string, key, input interface{}, outputEncoding string,
 ) interface{} {

--- a/js/modules/k6/crypto/crypto.go
+++ b/js/modules/k6/crypto/crypto.go
@@ -68,55 +68,55 @@ func (*Crypto) RandomBytes(ctx context.Context, size int) []byte {
 	return bytes
 }
 
-func (c *Crypto) Md4(ctx context.Context, input []byte, outputEncoding string) interface{} {
+func (c *Crypto) Md4(ctx context.Context, input interface{}, outputEncoding string) interface{} {
 	hasher := c.CreateHash(ctx, "md4")
 	hasher.Update(input)
 	return hasher.Digest(outputEncoding)
 }
 
-func (c *Crypto) Md5(ctx context.Context, input []byte, outputEncoding string) interface{} {
+func (c *Crypto) Md5(ctx context.Context, input interface{}, outputEncoding string) interface{} {
 	hasher := c.CreateHash(ctx, "md5")
 	hasher.Update(input)
 	return hasher.Digest(outputEncoding)
 }
 
-func (c *Crypto) Sha1(ctx context.Context, input []byte, outputEncoding string) interface{} {
+func (c *Crypto) Sha1(ctx context.Context, input interface{}, outputEncoding string) interface{} {
 	hasher := c.CreateHash(ctx, "sha1")
 	hasher.Update(input)
 	return hasher.Digest(outputEncoding)
 }
 
-func (c *Crypto) Sha256(ctx context.Context, input []byte, outputEncoding string) interface{} {
+func (c *Crypto) Sha256(ctx context.Context, input interface{}, outputEncoding string) interface{} {
 	hasher := c.CreateHash(ctx, "sha256")
 	hasher.Update(input)
 	return hasher.Digest(outputEncoding)
 }
 
-func (c *Crypto) Sha384(ctx context.Context, input []byte, outputEncoding string) interface{} {
+func (c *Crypto) Sha384(ctx context.Context, input interface{}, outputEncoding string) interface{} {
 	hasher := c.CreateHash(ctx, "sha384")
 	hasher.Update(input)
 	return hasher.Digest(outputEncoding)
 }
 
-func (c *Crypto) Sha512(ctx context.Context, input []byte, outputEncoding string) interface{} {
+func (c *Crypto) Sha512(ctx context.Context, input interface{}, outputEncoding string) interface{} {
 	hasher := c.CreateHash(ctx, "sha512")
 	hasher.Update(input)
 	return hasher.Digest(outputEncoding)
 }
 
-func (c *Crypto) Sha512_224(ctx context.Context, input []byte, outputEncoding string) interface{} {
+func (c *Crypto) Sha512_224(ctx context.Context, input interface{}, outputEncoding string) interface{} {
 	hasher := c.CreateHash(ctx, "sha512_224")
 	hasher.Update(input)
 	return hasher.Digest(outputEncoding)
 }
 
-func (c *Crypto) Sha512_256(ctx context.Context, input []byte, outputEncoding string) interface{} {
+func (c *Crypto) Sha512_256(ctx context.Context, input interface{}, outputEncoding string) interface{} {
 	hasher := c.CreateHash(ctx, "sha512_256")
 	hasher.Update(input)
 	return hasher.Digest(outputEncoding)
 }
 
-func (c *Crypto) Ripemd160(ctx context.Context, input []byte, outputEncoding string) interface{} {
+func (c *Crypto) Ripemd160(ctx context.Context, input interface{}, outputEncoding string) interface{} {
 	hasher := c.CreateHash(ctx, "ripemd160")
 	hasher.Update(input)
 	return hasher.Digest(outputEncoding)
@@ -150,8 +150,13 @@ func (*Crypto) CreateHash(ctx context.Context, algorithm string) *Hasher {
 	return &hasher
 }
 
-func (hasher *Hasher) Update(input []byte) {
-	_, err := hasher.hash.Write(input)
+// Update the hash with the input data.
+func (hasher *Hasher) Update(input interface{}) {
+	d, err := common.ToBytes(input)
+	if err != nil {
+		common.Throw(common.GetRuntime(hasher.ctx), err)
+	}
+	_, err = hasher.hash.Write(d)
 	if err != nil {
 		common.Throw(common.GetRuntime(hasher.ctx), err)
 	}
@@ -184,34 +189,44 @@ func (hasher *Hasher) Digest(outputEncoding string) interface{} {
 	return ""
 }
 
-// HexEncode returns a string with the hex representation of the provided byte array
-func (c Crypto) HexEncode(_ context.Context, data []byte) string {
-	return hex.EncodeToString(data)
+// HexEncode returns a string with the hex representation of the provided byte
+// array or ArrayBuffer.
+func (c Crypto) HexEncode(ctx context.Context, data interface{}) string {
+	d, err := common.ToBytes(data)
+	if err != nil {
+		common.Throw(common.GetRuntime(ctx), err)
+	}
+	return hex.EncodeToString(d)
 }
 
-func (c Crypto) CreateHMAC(ctx context.Context, algorithm string, key []byte) *Hasher {
+// CreateHMAC returns a new HMAC hash using the given algorithm and key.
+func (c Crypto) CreateHMAC(ctx context.Context, algorithm string, key interface{}) *Hasher {
 	hasher := Hasher{}
 	hasher.ctx = ctx
+	kb, err := common.ToBytes(key)
+	if err != nil {
+		common.Throw(common.GetRuntime(hasher.ctx), err)
+	}
 
 	switch algorithm {
 	case "md4":
-		hasher.hash = hmac.New(md4.New, key)
+		hasher.hash = hmac.New(md4.New, kb)
 	case "md5":
-		hasher.hash = hmac.New(md5.New, key)
+		hasher.hash = hmac.New(md5.New, kb)
 	case "sha1":
-		hasher.hash = hmac.New(sha1.New, key)
+		hasher.hash = hmac.New(sha1.New, kb)
 	case "sha256":
-		hasher.hash = hmac.New(sha256.New, key)
+		hasher.hash = hmac.New(sha256.New, kb)
 	case "sha384":
-		hasher.hash = hmac.New(sha512.New384, key)
+		hasher.hash = hmac.New(sha512.New384, kb)
 	case "sha512_224":
-		hasher.hash = hmac.New(sha512.New512_224, key)
+		hasher.hash = hmac.New(sha512.New512_224, kb)
 	case "sha512_256":
-		hasher.hash = hmac.New(sha512.New512_256, key)
+		hasher.hash = hmac.New(sha512.New512_256, kb)
 	case "sha512":
-		hasher.hash = hmac.New(sha512.New, key)
+		hasher.hash = hmac.New(sha512.New, kb)
 	case "ripemd160":
-		hasher.hash = hmac.New(ripemd160.New, key)
+		hasher.hash = hmac.New(ripemd160.New, kb)
 	default:
 		err := errors.New("Invalid algorithm: " + algorithm)
 		common.Throw(common.GetRuntime(hasher.ctx), err)
@@ -221,7 +236,7 @@ func (c Crypto) CreateHMAC(ctx context.Context, algorithm string, key []byte) *H
 }
 
 func (c *Crypto) Hmac(
-	ctx context.Context, algorithm string, key []byte, input []byte, outputEncoding string,
+	ctx context.Context, algorithm string, key, input interface{}, outputEncoding string,
 ) interface{} {
 	hasher := c.CreateHMAC(ctx, algorithm, key)
 	hasher.Update(input)

--- a/js/modules/k6/encoding/encoding.go
+++ b/js/modules/k6/encoding/encoding.go
@@ -38,18 +38,24 @@ func New() *Encoding {
 	return &Encoding{}
 }
 
-func (e *Encoding) B64encode(ctx context.Context, input []byte, encoding string) string {
+// B64encode returns the base64 encoding of input as a string.
+// The data type of input can be a string, []byte or ArrayBuffer.
+func (e *Encoding) B64encode(ctx context.Context, input interface{}, encoding string) string {
+	data, err := common.ToBytes(input)
+	if err != nil {
+		common.Throw(common.GetRuntime(ctx), err)
+	}
 	switch encoding {
 	case "rawstd":
-		return base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString(input)
+		return base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString(data)
 	case "std":
-		return base64.StdEncoding.EncodeToString(input)
+		return base64.StdEncoding.EncodeToString(data)
 	case "rawurl":
-		return base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(input)
+		return base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(data)
 	case "url":
-		return base64.URLEncoding.EncodeToString(input)
+		return base64.URLEncoding.EncodeToString(data)
 	default:
-		return base64.StdEncoding.EncodeToString(input)
+		return base64.StdEncoding.EncodeToString(data)
 	}
 }
 

--- a/js/modules/k6/encoding/encoding.go
+++ b/js/modules/k6/encoding/encoding.go
@@ -59,6 +59,8 @@ func (e *Encoding) B64encode(ctx context.Context, input interface{}, encoding st
 	}
 }
 
+// B64decode returns the decoded data of the base64 encoded input string using
+// the given encoding.
 func (e *Encoding) B64decode(ctx context.Context, input string, encoding string) string {
 	var output []byte
 	var err error

--- a/js/modules/k6/encoding/encoding_test.go
+++ b/js/modules/k6/encoding/encoding_test.go
@@ -60,6 +60,16 @@ func TestEncodingAlgorithms(t *testing.T) {
 			}`)
 			assert.NoError(t, err)
 		})
+		t.Run("DefaultArrayBufferEnc", func(t *testing.T) {
+			_, err := common.RunString(rt, `
+			var exp = "aGVsbG8=";
+			var input = new Uint8Array([104, 101, 108, 108, 111]); // "hello"
+			var encoded = encoding.b64encode(input.buffer);
+			if (encoded !== exp) {
+				throw new Error("Encoding mismatch: " + encoded);
+			}`)
+			assert.NoError(t, err)
+		})
 		t.Run("DefaultUnicodeEnc", func(t *testing.T) {
 			_, err := common.RunString(rt, `
 			var correct = "44GT44KT44Gr44Gh44Gv5LiW55WM";

--- a/js/modules/k6/http/file.go
+++ b/js/modules/k6/http/file.go
@@ -21,9 +21,12 @@
 package http
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/loadimpact/k6/js/common"
 )
 
 // FileData represents a binary file requiring multipart request encoding
@@ -40,7 +43,7 @@ func escapeQuotes(s string) string {
 }
 
 // File returns a FileData parameter
-func (h *HTTP) File(data []byte, args ...string) FileData {
+func (h *HTTP) File(ctx context.Context, data interface{}, args ...string) FileData {
 	// supply valid default if filename and content-type are not specified
 	fname, ct := fmt.Sprintf("%d", time.Now().UnixNano()), "application/octet-stream"
 
@@ -52,8 +55,13 @@ func (h *HTTP) File(data []byte, args ...string) FileData {
 		}
 	}
 
+	dt, err := common.ToBytes(data)
+	if err != nil {
+		common.Throw(common.GetRuntime(ctx), err)
+	}
+
 	return FileData{
-		Data:        data,
+		Data:        dt,
 		Filename:    fname,
 		ContentType: ct,
 	}

--- a/js/modules/k6/http/file_test.go
+++ b/js/modules/k6/http/file_test.go
@@ -1,0 +1,89 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2021 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package http
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/dop251/goja"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/loadimpact/k6/js/common"
+)
+
+func TestHTTPFile(t *testing.T) {
+	t.Parallel()
+	rt := goja.New()
+	input := []byte{104, 101, 108, 108, 111}
+
+	testCases := []struct {
+		input    interface{}
+		args     []string
+		expected FileData
+		expErr   string
+	}{
+		// We can't really test without specifying a filename argument,
+		// as File() calls time.Now(), so we'd need some time freezing/mocking
+		// or refactoring, or to exclude the field from the assertion.
+		{
+			input,
+			[]string{"test.bin"},
+			FileData{Data: input, Filename: "test.bin", ContentType: "application/octet-stream"},
+			"",
+		},
+		{
+			string(input),
+			[]string{"test.txt", "text/plain"},
+			FileData{Data: input, Filename: "test.txt", ContentType: "text/plain"},
+			"",
+		},
+		{
+			rt.NewArrayBuffer(input),
+			[]string{"test-ab.bin"},
+			FileData{Data: input, Filename: "test-ab.bin", ContentType: "application/octet-stream"},
+			"",
+		},
+		{struct{}{}, []string{}, FileData{}, "invalid type struct {}, expected string, []byte or ArrayBuffer"},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(fmt.Sprintf("%T", tc.input), func(t *testing.T) {
+			if tc.expErr != "" {
+				defer func() {
+					err := recover()
+					require.NotNil(t, err)
+					require.IsType(t, &goja.Object{}, err)
+					require.IsType(t, map[string]interface{}{}, err.(*goja.Object).Export())
+					val := err.(*goja.Object).Export().(map[string]interface{})
+					assert.Equal(t, tc.expErr, fmt.Sprintf("%s", val["value"]))
+				}()
+			}
+			h := New()
+			ctx := common.WithRuntime(context.Background(), rt)
+			out := h.File(ctx, tc.input, tc.args...)
+			assert.Equal(t, tc.expected, out)
+		})
+	}
+}


### PR DESCRIPTION
This addresses the backwards compatible changes of #1020, and showcases a workaround for better handling of multipart requests (ref. #747, #843, #1571).