### PR TITLE
Cleanup and handleSummaryResult() tests

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -299,7 +299,7 @@ a commandline interface for interacting with it.`,
 					TestRunDuration: executionState.GetCurrentTestRunDuration(),
 				})
 				if err == nil {
-					err = handleSummaryResult(afero.NewOsFs(), os.Stdout, os.Stderr, summaryResult)
+					err = handleSummaryResult(afero.NewOsFs(), stdout, stderr, summaryResult)
 				}
 				if err != nil {
 					logger.WithError(err).Error("failed to handle the end-of-test summary")

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,0 +1,124 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2020 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/loadimpact/k6/lib/fsext"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockWriter struct {
+	err      error
+	errAfter int
+}
+
+func (fw mockWriter) Write(p []byte) (n int, err error) {
+	if fw.err != nil {
+		return fw.errAfter, fw.err
+	}
+	return len(p), nil
+}
+
+var _ io.Writer = mockWriter{}
+
+func getFiles(t *testing.T, fs afero.Fs) map[string]*bytes.Buffer {
+	result := map[string]*bytes.Buffer{}
+	walkFn := func(filePath string, info os.FileInfo, err error) error {
+		if filePath == "/" {
+			return nil
+		}
+		require.NoError(t, err)
+		contents, err := afero.ReadFile(fs, filePath)
+		require.NoError(t, err)
+		result[filePath] = bytes.NewBuffer(contents)
+		return nil
+	}
+
+	err := fsext.Walk(fs, afero.FilePathSeparator, filepath.WalkFunc(walkFn))
+	require.NoError(t, err)
+
+	return result
+}
+
+func assertEqual(t *testing.T, exp string, actual io.Reader) {
+	act, err := ioutil.ReadAll(actual)
+	require.NoError(t, err)
+	assert.Equal(t, []byte(exp), act)
+}
+
+func initVars() (
+	content map[string]io.Reader, stdout *bytes.Buffer, stderr *bytes.Buffer, fs afero.Fs,
+) {
+	fs = afero.NewMemMapFs()
+	if runtime.GOOS == "windows" {
+		fs = fsext.NewTrimFilePathSeparatorFs(fs)
+	}
+
+	return map[string]io.Reader{}, bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), fs
+}
+
+func TestHandleSummaryResultSimple(t *testing.T) {
+	t.Parallel()
+	content, stdout, stderr, fs := initVars()
+
+	// Test noop
+	assert.NoError(t, handleSummaryResult(fs, stdout, stderr, content))
+	require.Empty(t, getFiles(t, fs))
+	require.Empty(t, stdout.Bytes())
+	require.Empty(t, stderr.Bytes())
+
+	// Test stdout only
+	content["stdout"] = bytes.NewBufferString("some stdout summary")
+	assert.NoError(t, handleSummaryResult(fs, stdout, stderr, content))
+	require.Empty(t, getFiles(t, fs))
+	assertEqual(t, "some stdout summary", stdout)
+	require.Empty(t, stderr.Bytes())
+}
+
+func TestHandleSummaryResultError(t *testing.T) {
+	t.Parallel()
+	content, _, stderr, fs := initVars()
+
+	expErr := errors.New("test error")
+	stdout := mockWriter{err: expErr, errAfter: 10}
+
+	content["stdout"] = bytes.NewBufferString("some stdout summary")
+	content["stderr"] = bytes.NewBufferString("some stderr summary")
+	content["/path/file1"] = bytes.NewBufferString("file summary 1")
+	content["/path/file2"] = bytes.NewBufferString("file summary 2")
+	err := handleSummaryResult(fs, stdout, stderr, content)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), expErr.Error())
+	files := getFiles(t, fs)
+	assertEqual(t, "file summary 1", files["/path/file1"])
+	assertEqual(t, "file summary 2", files["/path/file2"])
+}

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -53,7 +53,7 @@ var _ io.Writer = mockWriter{}
 func getFiles(t *testing.T, fs afero.Fs) map[string]*bytes.Buffer {
 	result := map[string]*bytes.Buffer{}
 	walkFn := func(filePath string, info os.FileInfo, err error) error {
-		if filePath == "/" {
+		if filePath == "/" || filePath == "\\" {
 			return nil
 		}
 		require.NoError(t, err)
@@ -78,9 +78,7 @@ func assertEqual(t *testing.T, exp string, actual io.Reader) {
 func initVars() (
 	content map[string]io.Reader, stdout *bytes.Buffer, stderr *bytes.Buffer, fs afero.Fs,
 ) {
-	fs = afero.NewMemMapFs()
-
-	return map[string]io.Reader{}, bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), fs
+	return map[string]io.Reader{}, bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), afero.NewMemMapFs()
 }
 
 func TestHandleSummaryResultSimple(t *testing.T) {

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -111,8 +111,8 @@ func TestHandleSummaryResultError(t *testing.T) {
 	filePath1 := "/path/file1"
 	filePath2 := "/path/file2"
 	if runtime.GOOS == "windows" {
-		filePath1 = "c:\\path\\file1"
-		filePath2 = "c:\\path\\file2"
+		filePath1 = "\\path\\file1"
+		filePath2 = "\\path\\file2"
 	}
 
 	content["stdout"] = bytes.NewBufferString("some stdout summary")

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -27,7 +27,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/loadimpact/k6/lib/fsext"
@@ -79,9 +78,6 @@ func initVars() (
 	content map[string]io.Reader, stdout *bytes.Buffer, stderr *bytes.Buffer, fs afero.Fs,
 ) {
 	fs = afero.NewMemMapFs()
-	if runtime.GOOS == "windows" {
-		fs = fsext.NewTrimFilePathSeparatorFs(fs)
-	}
 
 	return map[string]io.Reader{}, bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{}), fs
 }
@@ -113,12 +109,12 @@ func TestHandleSummaryResultError(t *testing.T) {
 
 	content["stdout"] = bytes.NewBufferString("some stdout summary")
 	content["stderr"] = bytes.NewBufferString("some stderr summary")
-	content["/path/file1"] = bytes.NewBufferString("file summary 1")
-	content["/path/file2"] = bytes.NewBufferString("file summary 2")
+	content["path/file1"] = bytes.NewBufferString("file summary 1")
+	content["path/file2"] = bytes.NewBufferString("file summary 2")
 	err := handleSummaryResult(fs, stdout, stderr, content)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), expErr.Error())
 	files := getFiles(t, fs)
-	assertEqual(t, "file summary 1", files["/path/file1"])
-	assertEqual(t, "file summary 2", files["/path/file2"])
+	assertEqual(t, "file summary 1", files["path/file1"])
+	assertEqual(t, "file summary 2", files["path/file2"])
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -27,6 +27,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/loadimpact/k6/lib/fsext"
@@ -107,14 +108,21 @@ func TestHandleSummaryResultError(t *testing.T) {
 	expErr := errors.New("test error")
 	stdout := mockWriter{err: expErr, errAfter: 10}
 
+	filePath1 := "/path/file1"
+	filePath2 := "/path/file2"
+	if runtime.GOOS == "windows" {
+		filePath1 = "c:\\path\\file1"
+		filePath2 = "c:\\path\\file2"
+	}
+
 	content["stdout"] = bytes.NewBufferString("some stdout summary")
 	content["stderr"] = bytes.NewBufferString("some stderr summary")
-	content["path/file1"] = bytes.NewBufferString("file summary 1")
-	content["path/file2"] = bytes.NewBufferString("file summary 2")
+	content[filePath1] = bytes.NewBufferString("file summary 1")
+	content[filePath2] = bytes.NewBufferString("file summary 2")
 	err := handleSummaryResult(fs, stdout, stderr, content)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), expErr.Error())
 	files := getFiles(t, fs)
-	assertEqual(t, "file summary 1", files["path/file1"])
-	assertEqual(t, "file summary 2", files["path/file2"])
+	assertEqual(t, "file summary 1", files[filePath1])
+	assertEqual(t, "file summary 2", files[filePath2])
 }

--- a/js/summary.go
+++ b/js/summary.go
@@ -36,10 +36,12 @@ import (
 // TODO: move this to a separate JS file and use go.rice to embed it
 const summaryWrapperLambdaCode = `
 (function() {
-	var forEach = function(obj, callback) {
+	var forEach = function (obj, callback) {
 		for (var key in obj) {
 			if (obj.hasOwnProperty(key)) {
-				callback(key, obj[key]);
+				if (callback(key, obj[key])) {
+					break;
+				}
 			}
 		}
 	}
@@ -88,9 +90,7 @@ const summaryWrapperLambdaCode = `
 		return JSON.stringify(results, null, 4);
 	};
 
-	var oldTextSummary = function(data) {
-		// TODO: implement something like the current end of test summary
-	};
+	// TODO: bundle the text summary generation from jslib and get rid of oldCallback
 
 	return function(exportedSummaryCallback, jsonSummaryPath, data, oldCallback) {
 		var result = {};
@@ -99,12 +99,10 @@ const summaryWrapperLambdaCode = `
 				result = exportedSummaryCallback(data, oldCallback);
 			} catch (e) {
 				console.error('handleSummary() failed with error "' + e + '", falling back to the default summary');
-				//result["stdout"] = oldTextSummary(data);
-				result["stdout"] = oldCallback(); // TODO: delete
+				result["stdout"] = oldCallback(); // TODO: replace with JS function
 			}
 		} else {
-			// result["stdout"] = oldTextSummary(data);
-			result["stdout"] = oldCallback(); // TODO: delete
+			result["stdout"] = oldCallback(); // TODO: replace with JS function
 		}
 
 		// TODO: ensure we're returning a map of strings or null/undefined...

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -474,6 +474,8 @@ var unitMap = map[string][]interface{}{
 	"us": {"µs", time.Microsecond},
 }
 
+// HumanizeValue makes the value human-readable
+// TODO: get rid of this after we remove the Go-based summary
 func (m *Metric) HumanizeValue(v float64, timeUnit string) string {
 	switch m.Type {
 	case Rate:


### PR DESCRIPTION
There were a few other things I wondered if I should fix in the current Go summary code, but at this point in time I'll probably just fix them in the upcoming JS replacement... For example, this code: https://github.com/loadimpact/k6/blob/c00a85bfea21d748f0f9d11fdbc326087f34c411/ui/summary.go#L91 

Should be
```go
if !inEscSeq && !inLongEscSeq {
	n++
}
```
i.e. that `StrWidth()` function is completely broken... :man_facepalming: But this turns not to matter one bit, since almost all of the errors are by the same margin and mostly cancel out... :rofl: Not to mention that the Unicode normalization it tries to do might actually be worse than not doing anything at all: https://github.com/loadimpact/k6/blob/c00a85bfea21d748f0f9d11fdbc326087f34c411/ui/summary.go#L64-L65

See [this MDN article](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize) for a good explanation of the various normalization modes, and why `NFC` or `NFKC` (or even doing nothing) might be better for our use case than `NFKD`. On the other hand, not even they are sufficient, so maybe it doesn't really matter and everything in life is pointless: https://hsivonen.fi/string-length/ :sob: :sweat_smile: :rofl: 

Anyway, I think this is the final summary-related PR before v0.30.0.