### PR TITLE
Drop js.common.RunString as it is just goja.Runtime.RunString

### DIFF
--- a/js/common/bridge_test.go
+++ b/js/common/bridge_test.go
@@ -297,25 +297,25 @@ func TestBind(t *testing.T) {
 	}{
 		{"Fields", bridgeTestFieldsType{"a", "b", "c", "d", "e"}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
 			t.Run("Exported", func(t *testing.T) {
-				v, err := RunString(rt, `obj.exported`)
+				v, err := rt.RunString(`obj.exported`)
 				if assert.NoError(t, err) {
 					assert.Equal(t, "a", v.Export())
 				}
 			})
 			t.Run("ExportedTag", func(t *testing.T) {
-				v, err := RunString(rt, `obj.renamed`)
+				v, err := rt.RunString(`obj.renamed`)
 				if assert.NoError(t, err) {
 					assert.Equal(t, "b", v.Export())
 				}
 			})
 			t.Run("unexported", func(t *testing.T) {
-				v, err := RunString(rt, `obj.unexported`)
+				v, err := rt.RunString(`obj.unexported`)
 				if assert.NoError(t, err) {
 					assert.Equal(t, nil, v.Export())
 				}
 			})
 			t.Run("unexportedTag", func(t *testing.T) {
-				v, err := RunString(rt, `obj.unexportedTag`)
+				v, err := rt.RunString(`obj.unexportedTag`)
 				if assert.NoError(t, err) {
 					assert.Equal(t, nil, v.Export())
 				}
@@ -323,19 +323,19 @@ func TestBind(t *testing.T) {
 		}},
 		{"Methods", bridgeTestMethodsType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
 			t.Run("unexportedFn", func(t *testing.T) {
-				_, err := RunString(rt, `obj.unexportedFn()`)
+				_, err := rt.RunString(`obj.unexportedFn()`)
 				assert.EqualError(t, err, "TypeError: Object has no member 'unexportedFn' at <eval>:1:17(3)")
 			})
 			t.Run("ExportedFn", func(t *testing.T) {
-				_, err := RunString(rt, `obj.exportedFn()`)
+				_, err := rt.RunString(`obj.exportedFn()`)
 				assert.NoError(t, err)
 			})
 			t.Run("unexportedPtrFn", func(t *testing.T) {
-				_, err := RunString(rt, `obj.unexportedPtrFn()`)
+				_, err := rt.RunString(`obj.unexportedPtrFn()`)
 				assert.EqualError(t, err, "TypeError: Object has no member 'unexportedPtrFn' at <eval>:1:20(3)")
 			})
 			t.Run("ExportedPtrFn", func(t *testing.T) {
-				_, err := RunString(rt, `obj.exportedPtrFn()`)
+				_, err := rt.RunString(`obj.exportedPtrFn()`)
 				switch obj.(type) {
 				case *bridgeTestMethodsType:
 					assert.NoError(t, err)
@@ -347,53 +347,53 @@ func TestBind(t *testing.T) {
 			})
 		}},
 		{"Error", bridgeTestErrorType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
-			_, err := RunString(rt, `obj.error()`)
+			_, err := rt.RunString(`obj.error()`)
 			assert.Contains(t, err.Error(), "GoError: error")
 		}},
 		{"JSValue", bridgeTestJSValueType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
-			v, err := RunString(rt, `obj.func(1234)`)
+			v, err := rt.RunString(`obj.func(1234)`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(1234), v.Export())
 			}
 		}},
 		{"JSValueError", bridgeTestJSValueErrorType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
-			_, err := RunString(rt, `obj.func()`)
+			_, err := rt.RunString(`obj.func()`)
 			assert.Contains(t, err.Error(), "GoError: missing argument")
 
 			t.Run("Valid", func(t *testing.T) {
-				v, err := RunString(rt, `obj.func(1234)`)
+				v, err := rt.RunString(`obj.func(1234)`)
 				if assert.NoError(t, err) {
 					assert.Equal(t, int64(1234), v.Export())
 				}
 			})
 		}},
 		{"JSValueContext", bridgeTestJSValueContextType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
-			_, err := RunString(rt, `obj.func()`)
+			_, err := rt.RunString(`obj.func()`)
 			assert.Contains(t, err.Error(), "GoError: func() can only be called from within default()")
 
 			t.Run("Context", func(t *testing.T) {
 				*ctxPtr = context.Background()
 				defer func() { *ctxPtr = nil }()
 
-				v, err := RunString(rt, `obj.func(1234)`)
+				v, err := rt.RunString(`obj.func(1234)`)
 				if assert.NoError(t, err) {
 					assert.Equal(t, int64(1234), v.Export())
 				}
 			})
 		}},
 		{"JSValueContextError", bridgeTestJSValueContextErrorType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
-			_, err := RunString(rt, `obj.func()`)
+			_, err := rt.RunString(`obj.func()`)
 			assert.Contains(t, err.Error(), "GoError: func() can only be called from within default()")
 
 			t.Run("Context", func(t *testing.T) {
 				*ctxPtr = context.Background()
 				defer func() { *ctxPtr = nil }()
 
-				_, err := RunString(rt, `obj.func()`)
+				_, err := rt.RunString(`obj.func()`)
 				assert.Contains(t, err.Error(), "GoError: missing argument")
 
 				t.Run("Valid", func(t *testing.T) {
-					v, err := RunString(rt, `obj.func(1234)`)
+					v, err := rt.RunString(`obj.func(1234)`)
 					if assert.NoError(t, err) {
 						assert.Equal(t, int64(1234), v.Export())
 					}
@@ -401,49 +401,49 @@ func TestBind(t *testing.T) {
 			})
 		}},
 		{"NativeFunction", bridgeTestNativeFunctionType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
-			v, err := RunString(rt, `obj.func(1234)`)
+			v, err := rt.RunString(`obj.func(1234)`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(1234), v.Export())
 			}
 		}},
 		{"NativeFunctionError", bridgeTestNativeFunctionErrorType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
-			_, err := RunString(rt, `obj.func()`)
+			_, err := rt.RunString(`obj.func()`)
 			assert.Contains(t, err.Error(), "GoError: missing argument")
 
 			t.Run("Valid", func(t *testing.T) {
-				v, err := RunString(rt, `obj.func(1234)`)
+				v, err := rt.RunString(`obj.func(1234)`)
 				if assert.NoError(t, err) {
 					assert.Equal(t, int64(1234), v.Export())
 				}
 			})
 		}},
 		{"NativeFunctionContext", bridgeTestNativeFunctionContextType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
-			_, err := RunString(rt, `obj.func()`)
+			_, err := rt.RunString(`obj.func()`)
 			assert.Contains(t, err.Error(), "GoError: func() can only be called from within default()")
 
 			t.Run("Context", func(t *testing.T) {
 				*ctxPtr = context.Background()
 				defer func() { *ctxPtr = nil }()
 
-				v, err := RunString(rt, `obj.func(1234)`)
+				v, err := rt.RunString(`obj.func(1234)`)
 				if assert.NoError(t, err) {
 					assert.Equal(t, int64(1234), v.Export())
 				}
 			})
 		}},
 		{"NativeFunctionContextError", bridgeTestNativeFunctionContextErrorType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
-			_, err := RunString(rt, `obj.func()`)
+			_, err := rt.RunString(`obj.func()`)
 			assert.Contains(t, err.Error(), "GoError: func() can only be called from within default()")
 
 			t.Run("Context", func(t *testing.T) {
 				*ctxPtr = context.Background()
 				defer func() { *ctxPtr = nil }()
 
-				_, err := RunString(rt, `obj.func()`)
+				_, err := rt.RunString(`obj.func()`)
 				assert.Contains(t, err.Error(), "GoError: missing argument")
 
 				t.Run("Valid", func(t *testing.T) {
-					v, err := RunString(rt, `obj.func(1234)`)
+					v, err := rt.RunString(`obj.func(1234)`)
 					if assert.NoError(t, err) {
 						assert.Equal(t, int64(1234), v.Export())
 					}
@@ -451,80 +451,80 @@ func TestBind(t *testing.T) {
 			})
 		}},
 		{"Add", bridgeTestAddType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
-			v, err := RunString(rt, `obj.add(1, 2)`)
+			v, err := rt.RunString(`obj.add(1, 2)`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(3), v.Export())
 			}
 		}},
 		{"AddWithError", bridgeTestAddWithErrorType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
-			v, err := RunString(rt, `obj.addWithError(1, 2)`)
+			v, err := rt.RunString(`obj.addWithError(1, 2)`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(3), v.Export())
 			}
 
 			t.Run("Negative", func(t *testing.T) {
-				_, err := RunString(rt, `obj.addWithError(0, -1)`)
+				_, err := rt.RunString(`obj.addWithError(0, -1)`)
 				assert.Contains(t, err.Error(), "GoError: answer is negative")
 			})
 		}},
 		{"AddWithError", bridgeTestAddWithErrorType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
-			v, err := RunString(rt, `obj.addWithError(1, 2)`)
+			v, err := rt.RunString(`obj.addWithError(1, 2)`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(3), v.Export())
 			}
 
 			t.Run("Negative", func(t *testing.T) {
-				_, err := RunString(rt, `obj.addWithError(0, -1)`)
+				_, err := rt.RunString(`obj.addWithError(0, -1)`)
 				assert.Contains(t, err.Error(), "GoError: answer is negative")
 			})
 		}},
 		{"Context", bridgeTestContextType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
-			_, err := RunString(rt, `obj.context()`)
+			_, err := rt.RunString(`obj.context()`)
 			assert.Contains(t, err.Error(), "GoError: context() can only be called from within default()")
 
 			t.Run("Valid", func(t *testing.T) {
 				*ctxPtr = context.Background()
 				defer func() { *ctxPtr = nil }()
 
-				_, err := RunString(rt, `obj.context()`)
+				_, err := rt.RunString(`obj.context()`)
 				assert.NoError(t, err)
 			})
 		}},
 		{"ContextAdd", bridgeTestContextAddType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
-			_, err := RunString(rt, `obj.contextAdd(1, 2)`)
+			_, err := rt.RunString(`obj.contextAdd(1, 2)`)
 			assert.Contains(t, err.Error(), "GoError: contextAdd() can only be called from within default()")
 
 			t.Run("Valid", func(t *testing.T) {
 				*ctxPtr = context.Background()
 				defer func() { *ctxPtr = nil }()
 
-				v, err := RunString(rt, `obj.contextAdd(1, 2)`)
+				v, err := rt.RunString(`obj.contextAdd(1, 2)`)
 				if assert.NoError(t, err) {
 					assert.Equal(t, int64(3), v.Export())
 				}
 			})
 		}},
 		{"ContextAddWithError", bridgeTestContextAddWithErrorType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
-			_, err := RunString(rt, `obj.contextAddWithError(1, 2)`)
+			_, err := rt.RunString(`obj.contextAddWithError(1, 2)`)
 			assert.Contains(t, err.Error(), "GoError: contextAddWithError() can only be called from within default()")
 
 			t.Run("Valid", func(t *testing.T) {
 				*ctxPtr = context.Background()
 				defer func() { *ctxPtr = nil }()
 
-				v, err := RunString(rt, `obj.contextAddWithError(1, 2)`)
+				v, err := rt.RunString(`obj.contextAddWithError(1, 2)`)
 				if assert.NoError(t, err) {
 					assert.Equal(t, int64(3), v.Export())
 				}
 
 				t.Run("Negative", func(t *testing.T) {
-					_, err := RunString(rt, `obj.contextAddWithError(0, -1)`)
+					_, err := rt.RunString(`obj.contextAddWithError(0, -1)`)
 					assert.Contains(t, err.Error(), "GoError: answer is negative")
 				})
 			})
 		}},
 		{"ContextInject", bridgeTestContextInjectType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
-			_, err := RunString(rt, `obj.contextInject()`)
+			_, err := rt.RunString(`obj.contextInject()`)
 			switch impl := obj.(type) {
 			case bridgeTestContextInjectType:
 				assert.EqualError(t, err, "TypeError: Object has no member 'contextInject' at <eval>:1:18(3)")
@@ -536,14 +536,14 @@ func TestBind(t *testing.T) {
 					*ctxPtr = context.Background()
 					defer func() { *ctxPtr = nil }()
 
-					_, err := RunString(rt, `obj.contextInject()`)
+					_, err := rt.RunString(`obj.contextInject()`)
 					assert.NoError(t, err)
 					assert.Equal(t, *ctxPtr, impl.ctx)
 				})
 			}
 		}},
 		{"ContextInjectPtr", bridgeTestContextInjectPtrType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
-			_, err := RunString(rt, `obj.contextInjectPtr()`)
+			_, err := rt.RunString(`obj.contextInjectPtr()`)
 			switch impl := obj.(type) {
 			case bridgeTestContextInjectPtrType:
 				assert.EqualError(t, err, "TypeError: Object has no member 'contextInjectPtr' at <eval>:1:21(3)")
@@ -557,7 +557,7 @@ func TestBind(t *testing.T) {
 			case *bridgeTestCounterType:
 				for i := 0; i < 10; i++ {
 					t.Run(strconv.Itoa(i), func(t *testing.T) {
-						v, err := RunString(rt, `obj.count()`)
+						v, err := rt.RunString(`obj.count()`)
 						if assert.NoError(t, err) {
 							assert.Equal(t, int64(i+1), v.Export())
 							assert.Equal(t, i+1, impl.Counter)
@@ -565,7 +565,7 @@ func TestBind(t *testing.T) {
 					})
 				}
 			case bridgeTestCounterType:
-				_, err := RunString(rt, `obj.count()`)
+				_, err := rt.RunString(`obj.count()`)
 				assert.EqualError(t, err, "TypeError: Object has no member 'count' at <eval>:1:10(3)")
 			default:
 				assert.Fail(t, "UNKNOWN TYPE")
@@ -579,7 +579,7 @@ func TestBind(t *testing.T) {
 				sum += i
 				t.Run(strconv.Itoa(i), func(t *testing.T) {
 					code := fmt.Sprintf(`obj.sum(%s)`, strings.Join(args, ", "))
-					v, err := RunString(rt, code)
+					v, err := rt.RunString(code)
 					if assert.NoError(t, err) {
 						assert.Equal(t, int64(sum), v.Export())
 					}
@@ -587,7 +587,7 @@ func TestBind(t *testing.T) {
 			}
 		}},
 		{"SumWithContext", bridgeTestSumWithContextType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
-			_, err := RunString(rt, `obj.sumWithContext(1, 2)`)
+			_, err := rt.RunString(`obj.sumWithContext(1, 2)`)
 			assert.Contains(t, err.Error(), "GoError: sumWithContext() can only be called from within default()")
 
 			t.Run("Valid", func(t *testing.T) {
@@ -601,7 +601,7 @@ func TestBind(t *testing.T) {
 					sum += i
 					t.Run(strconv.Itoa(i), func(t *testing.T) {
 						code := fmt.Sprintf(`obj.sumWithContext(%s)`, strings.Join(args, ", "))
-						v, err := RunString(rt, code)
+						v, err := rt.RunString(code)
 						if assert.NoError(t, err) {
 							assert.Equal(t, int64(sum), v.Export())
 						}
@@ -617,7 +617,7 @@ func TestBind(t *testing.T) {
 				sum += i
 				t.Run(strconv.Itoa(i), func(t *testing.T) {
 					code := fmt.Sprintf(`obj.sumWithError(%s)`, strings.Join(args, ", "))
-					v, err := RunString(rt, code)
+					v, err := rt.RunString(code)
 					if assert.NoError(t, err) {
 						assert.Equal(t, int64(sum), v.Export())
 					}
@@ -625,7 +625,7 @@ func TestBind(t *testing.T) {
 			}
 		}},
 		{"SumWithContextAndError", bridgeTestSumWithContextAndErrorType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
-			_, err := RunString(rt, `obj.sumWithContextAndError(1, 2)`)
+			_, err := rt.RunString(`obj.sumWithContextAndError(1, 2)`)
 			assert.Contains(t, err.Error(), "GoError: sumWithContextAndError() can only be called from within default()")
 
 			t.Run("Valid", func(t *testing.T) {
@@ -639,7 +639,7 @@ func TestBind(t *testing.T) {
 					sum += i
 					t.Run(strconv.Itoa(i), func(t *testing.T) {
 						code := fmt.Sprintf(`obj.sumWithContextAndError(%s)`, strings.Join(args, ", "))
-						v, err := RunString(rt, code)
+						v, err := rt.RunString(code)
 						if assert.NoError(t, err) {
 							assert.Equal(t, int64(sum), v.Export())
 						}
@@ -648,7 +648,7 @@ func TestBind(t *testing.T) {
 			})
 		}},
 		{"Constructor", bridgeTestConstructorType{}, func(t *testing.T, obj interface{}, rt *goja.Runtime) {
-			v, err := RunString(rt, `new obj.Constructor()`)
+			v, err := rt.RunString(`new obj.Constructor()`)
 			assert.NoError(t, err)
 			assert.IsType(t, bridgeTestConstructorSpawnedType{}, v.Export())
 		}},

--- a/js/common/util.go
+++ b/js/common/util.go
@@ -28,11 +28,6 @@ import (
 	"github.com/dop251/goja"
 )
 
-// RunString Runs an string in the given runtime. Use this if writing ES5 in tests isn't a problem.
-func RunString(rt *goja.Runtime, src string) (goja.Value, error) {
-	return rt.RunString(src)
-}
-
 // Throw a JS error; avoids re-wrapping GoErrors.
 func Throw(rt *goja.Runtime, err error) {
 	if e, ok := err.(*goja.Exception); ok {

--- a/js/console_test.go
+++ b/js/console_test.go
@@ -50,7 +50,7 @@ func TestConsoleContext(t *testing.T) {
 	logger, hook := logtest.NewNullLogger()
 	rt.Set("console", common.Bind(rt, &console{logger}, ctxPtr))
 
-	_, err := common.RunString(rt, `console.log("a")`)
+	_, err := rt.RunString(`console.log("a")`)
 	assert.NoError(t, err)
 	if entry := hook.LastEntry(); assert.NotNil(t, entry) {
 		assert.Equal(t, "a", entry.Message)
@@ -58,14 +58,14 @@ func TestConsoleContext(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	*ctxPtr = ctx
-	_, err = common.RunString(rt, `console.log("b")`)
+	_, err = rt.RunString(`console.log("b")`)
 	assert.NoError(t, err)
 	if entry := hook.LastEntry(); assert.NotNil(t, entry) {
 		assert.Equal(t, "b", entry.Message)
 	}
 
 	cancel()
-	_, err = common.RunString(rt, `console.log("c")`)
+	_, err = rt.RunString(`console.log("c")`)
 	assert.NoError(t, err)
 	if entry := hook.LastEntry(); assert.NotNil(t, entry) {
 		assert.Equal(t, "b", entry.Message)

--- a/js/modules/k6/crypto/crypto_test.go
+++ b/js/modules/k6/crypto/crypto_test.go
@@ -53,7 +53,7 @@ func TestCryptoAlgorithms(t *testing.T) {
 	rt.Set("crypto", common.Bind(rt, New(), &ctx))
 
 	t.Run("RandomBytesSuccess", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		var bytes = crypto.randomBytes(5);
 		if (bytes.length !== 5) {
 			throw new Error("Incorrect size: " + bytes.length);
@@ -63,7 +63,7 @@ func TestCryptoAlgorithms(t *testing.T) {
 	})
 
 	t.Run("RandomBytesInvalidSize", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		crypto.randomBytes(-1);`)
 
 		assert.Error(t, err)
@@ -72,7 +72,7 @@ func TestCryptoAlgorithms(t *testing.T) {
 	t.Run("RandomBytesFailure", func(t *testing.T) {
 		SavedReader := rand.Reader
 		rand.Reader = MockReader{}
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		crypto.randomBytes(5);`)
 		rand.Reader = SavedReader
 
@@ -80,7 +80,7 @@ func TestCryptoAlgorithms(t *testing.T) {
 	})
 
 	t.Run("MD4", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		var correct = "aa010fbc1d14c795d86ef98c95479d17";
 		var hash = crypto.md4("hello world", "hex");
 		if (hash !== correct) {
@@ -90,7 +90,7 @@ func TestCryptoAlgorithms(t *testing.T) {
 	})
 
 	t.Run("MD5", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		var correct = "5eb63bbbe01eeed093cb22bb8f5acdc3";
 		var hash = crypto.md5("hello world", "hex");
 		if (hash !== correct) {
@@ -101,7 +101,7 @@ func TestCryptoAlgorithms(t *testing.T) {
 	})
 
 	t.Run("SHA1", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		var correct = "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed";
 		var hash = crypto.sha1("hello world", "hex");
 		if (hash !== correct) {
@@ -112,7 +112,7 @@ func TestCryptoAlgorithms(t *testing.T) {
 	})
 
 	t.Run("SHA256", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		var correct = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
 		var hash = crypto.sha256("hello world", "hex");
 		if (hash !== correct) {
@@ -123,7 +123,7 @@ func TestCryptoAlgorithms(t *testing.T) {
 	})
 
 	t.Run("SHA384", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		var correct = "fdbd8e75a67f29f701a4e040385e2e23986303ea10239211af907fcbb83578b3e417cb71ce646efd0819dd8c088de1bd";
 		var hash = crypto.sha384("hello world", "hex");
 		if (hash !== correct) {
@@ -134,7 +134,7 @@ func TestCryptoAlgorithms(t *testing.T) {
 	})
 
 	t.Run("SHA512", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		var correct = "309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f";
 		var hash = crypto.sha512("hello world", "hex");
 		if (hash !== correct) {
@@ -145,7 +145,7 @@ func TestCryptoAlgorithms(t *testing.T) {
 	})
 
 	t.Run("SHA512_224", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		var hash = crypto.sha512_224("hello world", "hex");
 		var correct = "22e0d52336f64a998085078b05a6e37b26f8120f43bf4db4c43a64ee";
 		if (hash !== correct) {
@@ -156,7 +156,7 @@ func TestCryptoAlgorithms(t *testing.T) {
 	})
 
 	t.Run("SHA512_256", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		var hash = crypto.sha512_256("hello world", "hex");
 		var correct = "0ac561fac838104e3f2e4ad107b4bee3e938bf15f2b15f009ccccd61a913f017";
 		if (hash !== correct) {
@@ -167,7 +167,7 @@ func TestCryptoAlgorithms(t *testing.T) {
 	})
 
 	t.Run("RIPEMD160", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		var hash = crypto.ripemd160("hello world", "hex");
 		var correct = "98c615784ccb5fe5936fbc0cbe9dfdb408d92f0f";
 		if (hash !== correct) {
@@ -197,7 +197,7 @@ func TestStreamingApi(t *testing.T) {
 
 	// Empty strings are still hashable
 	t.Run("Empty", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		var correctHex = "d41d8cd98f00b204e9800998ecf8427e";
 
 		var hasher = crypto.createHash("md5");
@@ -211,7 +211,7 @@ func TestStreamingApi(t *testing.T) {
 	})
 
 	t.Run("UpdateOnce", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		var correctHex = "5eb63bbbe01eeed093cb22bb8f5acdc3";
 
 		var hasher = crypto.createHash("md5");
@@ -226,7 +226,7 @@ func TestStreamingApi(t *testing.T) {
 	})
 
 	t.Run("UpdateMultiple", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		var correctHex = "5eb63bbbe01eeed093cb22bb8f5acdc3";
 
 		var hasher = crypto.createHash("md5");
@@ -261,7 +261,7 @@ func TestOutputEncoding(t *testing.T) {
 	rt.Set("crypto", common.Bind(rt, New(), &ctx))
 
 	t.Run("Valid", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		var correctHex = "5eb63bbbe01eeed093cb22bb8f5acdc3";
 		var correctBase64 = "XrY7u+Ae7tCTyyK7j1rNww==";
 		var correctBase64URL = "XrY7u-Ae7tCTyyK7j1rNww=="
@@ -313,7 +313,7 @@ func TestOutputEncoding(t *testing.T) {
 	})
 
 	t.Run("Invalid", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		var hasher = crypto.createHash("md5");
 		hasher.update("hello world");
 		hasher.digest("someInvalidEncoding");
@@ -354,7 +354,7 @@ func TestHMac(t *testing.T) {
 		rt.Set("correctHex", rt.ToValue(value))
 		rt.Set("algorithm", rt.ToValue(algorithm))
 		t.Run(algorithm+" hasher: valid", func(t *testing.T) {
-			_, err := common.RunString(rt, `
+			_, err := rt.RunString(`
 			var hasher = crypto.createHMAC(algorithm, "a secret");
 			hasher.update("some data to hash");
 
@@ -367,7 +367,7 @@ func TestHMac(t *testing.T) {
 		})
 
 		t.Run(algorithm+" wrapper: valid", func(t *testing.T) {
-			_, err := common.RunString(rt, `
+			_, err := rt.RunString(`
 			var resultHex = crypto.hmac(algorithm, "a secret", "some data to hash", "hex");
 			if (resultHex !== correctHex) {
 				throw new Error("Hex encoding mismatch: " + resultHex);
@@ -377,7 +377,7 @@ func TestHMac(t *testing.T) {
 		})
 
 		t.Run(algorithm+" ArrayBuffer: valid", func(t *testing.T) {
-			_, err := common.RunString(rt, `
+			_, err := rt.RunString(`
 			var data = new Uint8Array([115,111,109,101,32,100,97,116,97,32,116,
 										111,32,104,97,115,104]).buffer;
 			var resultHex = crypto.hmac(algorithm, "a secret", data, "hex");
@@ -400,7 +400,7 @@ func TestHMac(t *testing.T) {
 		rt.Set("correctHex", rt.ToValue(value))
 		rt.Set("algorithm", rt.ToValue(algorithm))
 		t.Run(algorithm+" hasher: invalid", func(t *testing.T) {
-			_, err := common.RunString(rt, `
+			_, err := rt.RunString(`
 			var hasher = crypto.createHMAC(algorithm, "a secret");
 			hasher.update("some data to hash");
 
@@ -413,7 +413,7 @@ func TestHMac(t *testing.T) {
 		})
 
 		t.Run(algorithm+" wrapper: invalid", func(t *testing.T) {
-			_, err := common.RunString(rt, `
+			_, err := rt.RunString(`
 			var resultHex = crypto.hmac(algorithm, "a secret", "some data to hash", "hex");
 			if (resultHex !== correctHex) {
 				throw new Error("Hex encoding mismatch: " + resultHex);
@@ -468,7 +468,7 @@ func TestAWSv4(t *testing.T) {
 	ctx = common.WithRuntime(ctx, rt)
 	rt.Set("crypto", common.Bind(rt, New(), &ctx))
 
-	_, err := common.RunString(rt, `
+	_, err := rt.RunString(`
 		var HexEncode = crypto.hexEncode;
 		var HmacSHA256 = function(data, key) {
 			return crypto.hmac("sha256", key, data, "binary");

--- a/js/modules/k6/crypto/x509/x509_test.go
+++ b/js/modules/k6/crypto/x509/x509_test.go
@@ -147,14 +147,14 @@ func TestParse(t *testing.T) {
 	rt := makeRuntime()
 
 	t.Run("DecodeFailure", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		x509.parse("bad-certificate");`)
 		assert.Contains(
 			t, err.Error(), "GoError: failed to decode certificate PEM file")
 	})
 
 	t.Run("ParseFailure", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		x509.parse(pem);`, material.publicKey))
 		if assert.Error(t, err) {
@@ -166,7 +166,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("SignatureAlgorithm", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var value = cert.signatureAlgorithm;
@@ -177,7 +177,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("Subject", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		if (typeof cert.subject !== "object") {
@@ -187,7 +187,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("SubjectCommonName", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var value = cert.subject ? cert.subject.commonName : null;
@@ -198,7 +198,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("SubjectCountry", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var value = cert.subject ? cert.subject.country : null;
@@ -209,7 +209,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("SubjectPostalCode", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var value = cert.subject ? cert.subject.postalCode : null;
@@ -220,7 +220,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("SubjectProvince", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var value = cert.subject ? cert.subject.stateOrProvinceName : null;
@@ -231,7 +231,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("SubjectLocality", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var value = cert.subject ? cert.subject.localityName : null;
@@ -242,7 +242,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("SubjectStreetAddress", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var value = cert.subject ? cert.subject.streetAddress : null;
@@ -253,7 +253,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("SubjectOrganization", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var value = cert.subject ? cert.subject.organizationName : null;
@@ -264,7 +264,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("SubjectOrganizationalUnit", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var values =
@@ -282,7 +282,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("SubjectNames", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var values = cert.subject ? cert.subject.names : null;
@@ -311,7 +311,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("Issuer", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		if (typeof cert.issuer !== "object") {
@@ -321,7 +321,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("IssuerCommonName", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var value = cert.issuer ? cert.issuer.commonName : null;
@@ -332,7 +332,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("IssuerCountry", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var value = cert.issuer ? cert.issuer.country : null;
@@ -343,7 +343,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("IssuerProvince", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var value = cert.issuer ? cert.issuer.stateOrProvinceName : null;
@@ -354,7 +354,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("IssuerLocality", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var value = cert.issuer ? cert.issuer.localityName : null;
@@ -365,7 +365,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("IssuerOrganization", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var value = cert.issuer ? cert.issuer.organizationName : null;
@@ -376,7 +376,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("IssuerNames", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var values = cert.issuer ? cert.issuer.names : null;
@@ -405,7 +405,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("NotBefore", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var value = cert.notBefore;
@@ -416,7 +416,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("NotAfter", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var value = cert.notAfter;
@@ -427,7 +427,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("AltNames", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var values = cert.altNames;
@@ -448,7 +448,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("FingerPrint", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var value = cert.fingerPrint;
@@ -463,7 +463,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("PublicKey", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		if (typeof cert.publicKey !== "object") {
@@ -473,7 +473,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("RSAPublicKey", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var value = cert.publicKey;
@@ -491,7 +491,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("RSAPublicKeyExponent", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var value = cert.publicKey ? cert.publicKey.key.e : null;
@@ -502,7 +502,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("RSAPublicKeyModulus", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var value = cert.publicKey ? cert.publicKey.key.n.bytes() : null;
@@ -533,7 +533,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("DSAPublicKey", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var value = cert.publicKey;
@@ -550,7 +550,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("ECDSAPublicKey", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var cert = x509.parse(pem);
 		var value = cert.publicKey;
@@ -575,13 +575,13 @@ func TestGetAltNames(t *testing.T) {
 	rt := makeRuntime()
 
 	t.Run("Failure", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		x509.getAltNames("bad-certificate");`)
 		assert.Error(t, err)
 	})
 
 	t.Run("Success", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var altNames = x509.getAltNames(pem);
 		if (!(
@@ -609,13 +609,13 @@ func TestGetIssuer(t *testing.T) {
 	rt := makeRuntime()
 
 	t.Run("Failure", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		x509.getIssuer("bad-certificate");`)
 		assert.Error(t, err)
 	})
 
 	t.Run("Success", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var issuer = x509.getIssuer(pem);
 		if (!(
@@ -641,13 +641,13 @@ func TestGetSubject(t *testing.T) {
 	rt := makeRuntime()
 
 	t.Run("Failure", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		x509.getSubject("bad-certificate");`)
 		assert.Error(t, err)
 	})
 
 	t.Run("Success", func(t *testing.T) {
-		_, err := common.RunString(rt, fmt.Sprintf(`
+		_, err := rt.RunString(fmt.Sprintf(`
 		var pem = %q;
 		var subject = x509.getSubject(pem);
 		if (!(

--- a/js/modules/k6/data/share_test.go
+++ b/js/modules/k6/data/share_test.go
@@ -84,7 +84,7 @@ func TestSharedArrayConstructorExceptions(t *testing.T) {
 	for name, testCase := range cases {
 		name, testCase := name, testCase
 		t.Run(name, func(t *testing.T) {
-			_, err := common.RunString(rt, testCase.code)
+			_, err := rt.RunString(testCase.code)
 			if testCase.err == "" {
 				require.NoError(t, err)
 				return // the t.Run

--- a/js/modules/k6/encoding/encoding_test.go
+++ b/js/modules/k6/encoding/encoding_test.go
@@ -43,7 +43,7 @@ func TestEncodingAlgorithms(t *testing.T) {
 
 	t.Run("Base64", func(t *testing.T) {
 		t.Run("DefaultEnc", func(t *testing.T) {
-			_, err := common.RunString(rt, `
+			_, err := rt.RunString(`
 			var correct = "aGVsbG8gd29ybGQ=";
 			var encoded = encoding.b64encode("hello world");
 			if (encoded !== correct) {
@@ -52,7 +52,7 @@ func TestEncodingAlgorithms(t *testing.T) {
 			assert.NoError(t, err)
 		})
 		t.Run("DefaultDec", func(t *testing.T) {
-			_, err := common.RunString(rt, `
+			_, err := rt.RunString(`
 			var correct = "hello world";
 			var decoded = encoding.b64decode("aGVsbG8gd29ybGQ=");
 			if (decoded !== correct) {
@@ -61,7 +61,7 @@ func TestEncodingAlgorithms(t *testing.T) {
 			assert.NoError(t, err)
 		})
 		t.Run("DefaultArrayBufferEnc", func(t *testing.T) {
-			_, err := common.RunString(rt, `
+			_, err := rt.RunString(`
 			var exp = "aGVsbG8=";
 			var input = new Uint8Array([104, 101, 108, 108, 111]); // "hello"
 			var encoded = encoding.b64encode(input.buffer);
@@ -71,7 +71,7 @@ func TestEncodingAlgorithms(t *testing.T) {
 			assert.NoError(t, err)
 		})
 		t.Run("DefaultUnicodeEnc", func(t *testing.T) {
-			_, err := common.RunString(rt, `
+			_, err := rt.RunString(`
 			var correct = "44GT44KT44Gr44Gh44Gv5LiW55WM";
 			var encoded = encoding.b64encode("こんにちは世界", "std");
 			if (encoded !== correct) {
@@ -80,7 +80,7 @@ func TestEncodingAlgorithms(t *testing.T) {
 			assert.NoError(t, err)
 		})
 		t.Run("DefaultUnicodeDec", func(t *testing.T) {
-			_, err := common.RunString(rt, `
+			_, err := rt.RunString(`
 			var correct = "こんにちは世界";
 			var decoded = encoding.b64decode("44GT44KT44Gr44Gh44Gv5LiW55WM");
 			if (decoded !== correct) {
@@ -89,7 +89,7 @@ func TestEncodingAlgorithms(t *testing.T) {
 			assert.NoError(t, err)
 		})
 		t.Run("StdEnc", func(t *testing.T) {
-			_, err := common.RunString(rt, `
+			_, err := rt.RunString(`
 			var correct = "aGVsbG8gd29ybGQ=";
 			var encoded = encoding.b64encode("hello world", "std");
 			if (encoded !== correct) {
@@ -98,7 +98,7 @@ func TestEncodingAlgorithms(t *testing.T) {
 			assert.NoError(t, err)
 		})
 		t.Run("StdDec", func(t *testing.T) {
-			_, err := common.RunString(rt, `
+			_, err := rt.RunString(`
 			var correct = "hello world";
 			var decoded = encoding.b64decode("aGVsbG8gd29ybGQ=", "std");
 			if (decoded !== correct) {
@@ -107,7 +107,7 @@ func TestEncodingAlgorithms(t *testing.T) {
 			assert.NoError(t, err)
 		})
 		t.Run("RawStdEnc", func(t *testing.T) {
-			_, err := common.RunString(rt, `
+			_, err := rt.RunString(`
 			var correct = "aGVsbG8gd29ybGQ";
 			var encoded = encoding.b64encode("hello world", "rawstd");
 			if (encoded !== correct) {
@@ -116,7 +116,7 @@ func TestEncodingAlgorithms(t *testing.T) {
 			assert.NoError(t, err)
 		})
 		t.Run("RawStdDec", func(t *testing.T) {
-			_, err := common.RunString(rt, `
+			_, err := rt.RunString(`
 			var correct = "hello world";
 			var decoded = encoding.b64decode("aGVsbG8gd29ybGQ", "rawstd");
 			if (decoded !== correct) {
@@ -125,7 +125,7 @@ func TestEncodingAlgorithms(t *testing.T) {
 			assert.NoError(t, err)
 		})
 		t.Run("URLEnc", func(t *testing.T) {
-			_, err := common.RunString(rt, `
+			_, err := rt.RunString(`
 			var correct = "5bCP6aO85by-Li4=";
 			var encoded = encoding.b64encode("小飼弾..", "url");
 			if (encoded !== correct) {
@@ -134,7 +134,7 @@ func TestEncodingAlgorithms(t *testing.T) {
 			assert.NoError(t, err)
 		})
 		t.Run("URLDec", func(t *testing.T) {
-			_, err := common.RunString(rt, `
+			_, err := rt.RunString(`
 			var correct = "小飼弾..";
 			var decoded = encoding.b64decode("5bCP6aO85by-Li4=", "url");
 			if (decoded !== correct) {
@@ -143,7 +143,7 @@ func TestEncodingAlgorithms(t *testing.T) {
 			assert.NoError(t, err)
 		})
 		t.Run("RawURLEnc", func(t *testing.T) {
-			_, err := common.RunString(rt, `
+			_, err := rt.RunString(`
 			var correct = "5bCP6aO85by-Li4";
 			var encoded = encoding.b64encode("小飼弾..", "rawurl");
 			if (encoded !== correct) {
@@ -152,7 +152,7 @@ func TestEncodingAlgorithms(t *testing.T) {
 			assert.NoError(t, err)
 		})
 		t.Run("RawURLDec", func(t *testing.T) {
-			_, err := common.RunString(rt, `
+			_, err := rt.RunString(`
 			var correct = "小飼弾..";
 			var decoded = encoding.b64decode("5bCP6aO85by-Li4", "rawurl");
 			if (decoded !== correct) {

--- a/js/modules/k6/grpc/client_test.go
+++ b/js/modules/k6/grpc/client_test.go
@@ -117,7 +117,7 @@ func TestClient(t *testing.T) {
 	rt.Set("grpc", common.Bind(rt, New(), &ctx))
 
 	t.Run("New", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 			var client = new grpc.Client();
 			if (!client) throw new Error("no client created")
 		`)
@@ -125,7 +125,7 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("LoadNotFound", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 			client.load([], "./does_not_exist.proto");
 		`)
 		if !assert.Error(t, err) {
@@ -139,7 +139,7 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("Load", func(t *testing.T) {
-		respV, err := common.RunString(rt, `
+		respV, err := rt.RunString(`
 			client.load([], "../../../../vendor/google.golang.org/grpc/test/grpc_testing/test.proto");
 		`)
 		if !assert.NoError(t, err) {
@@ -151,7 +151,7 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("ConnectInit", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 			client.connect();
 		`)
 		if !assert.Error(t, err) {
@@ -161,7 +161,7 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("invokeInit", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 			var err = client.invoke();
 			throw new Error(err)
 		`)
@@ -174,7 +174,7 @@ func TestClient(t *testing.T) {
 	ctx = lib.WithState(ctx, state)
 
 	t.Run("NoConnect", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 			client.invoke("grpc.testing.TestService/EmptyCall", {})
 		`)
 		if !assert.Error(t, err) {
@@ -184,7 +184,7 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("UnknownConnectParam", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 			client.connect("GRPCBIN_ADDR", { name: "k6" });
 		`))
 		if !assert.Error(t, err) {
@@ -194,7 +194,7 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("ConnectInvalidTimeout", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 			client.connect("GRPCBIN_ADDR", { timeout: "k6" });
 		`))
 		if !assert.Error(t, err) {
@@ -204,35 +204,35 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("ConnectStringTimeout", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 			client.connect("GRPCBIN_ADDR", { timeout: "1h3s" });
 		`))
 		assert.NoError(t, err)
 	})
 
 	t.Run("ConnectFloatTimeout", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 			client.connect("GRPCBIN_ADDR", { timeout: 3456.3 });
 		`))
 		assert.NoError(t, err)
 	})
 
 	t.Run("ConnectIntegerTimeout", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 			client.connect("GRPCBIN_ADDR", { timeout: 3000 });
 		`))
 		assert.NoError(t, err)
 	})
 
 	t.Run("Connect", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 			client.connect("GRPCBIN_ADDR");
 		`))
 		assert.NoError(t, err)
 	})
 
 	t.Run("InvokeNotFound", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 			client.invoke("foo/bar", {})
 		`)
 		if !assert.Error(t, err) {
@@ -242,7 +242,7 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("InvokeInvalidParam", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 			client.invoke("grpc.testing.TestService/EmptyCall", {}, { void: true })
 		`)
 		if !assert.Error(t, err) {
@@ -252,7 +252,7 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("InvokeInvalidTimeoutType", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 			client.invoke("grpc.testing.TestService/EmptyCall", {}, { timeout: true })
 		`)
 		if !assert.Error(t, err) {
@@ -262,7 +262,7 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("InvokeInvalidTimeout", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 			client.invoke("grpc.testing.TestService/EmptyCall", {}, { timeout: "please" })
 		`)
 		if !assert.Error(t, err) {
@@ -272,21 +272,21 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("InvokeStringTimeout", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 			client.invoke("grpc.testing.TestService/EmptyCall", {}, { timeout: "1h42m" })
 		`)
 		assert.NoError(t, err)
 	})
 
 	t.Run("InvokeFloatTimeout", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 			client.invoke("grpc.testing.TestService/EmptyCall", {}, { timeout: 400.50 })
 		`)
 		assert.NoError(t, err)
 	})
 
 	t.Run("InvokeIntegerTimeout", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 			client.invoke("grpc.testing.TestService/EmptyCall", {}, { timeout: 2000 })
 		`)
 		assert.NoError(t, err)
@@ -296,7 +296,7 @@ func TestClient(t *testing.T) {
 		tb.GRPCStub.EmptyCallFunc = func(context.Context, *grpc_testing.Empty) (*grpc_testing.Empty, error) {
 			return &grpc_testing.Empty{}, nil
 		}
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 			var resp = client.invoke("grpc.testing.TestService/EmptyCall", {})
 			if (resp.status !== grpc.StatusOK) {
 				throw new Error("unexpected error status: " + resp.status)
@@ -315,7 +315,7 @@ func TestClient(t *testing.T) {
 
 			return &grpc_testing.SimpleResponse{}, nil
 		}
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 			var resp = client.invoke("grpc.testing.TestService/UnaryCall", { payload: { body: "6LSf6L295rWL6K+V"} })
 			if (resp.status !== grpc.StatusOK) {
 				throw new Error("server did not receive the correct request message")
@@ -333,7 +333,7 @@ func TestClient(t *testing.T) {
 
 			return &grpc_testing.Empty{}, nil
 		}
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 			var resp = client.invoke("grpc.testing.TestService/EmptyCall", {}, { headers: { "X-Load-Tester": "k6" } })
 			if (resp.status !== grpc.StatusOK) {
 				throw new Error("failed to send correct headers in the request")
@@ -348,7 +348,7 @@ func TestClient(t *testing.T) {
 				OauthScope: "水",
 			}, nil
 		}
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 			var resp = client.invoke("grpc.testing.TestService/UnaryCall", {})
 			if (!resp.message || resp.message.username !== "" || resp.message.oauthScope !== "水") {
 				throw new Error("unexpected response message: " + JSON.stringify(resp.message))
@@ -363,7 +363,7 @@ func TestClient(t *testing.T) {
 		tb.GRPCStub.EmptyCallFunc = func(context.Context, *grpc_testing.Empty) (*grpc_testing.Empty, error) {
 			return nil, status.Error(codes.DataLoss, "foobar")
 		}
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 			var resp = client.invoke("grpc.testing.TestService/EmptyCall", {})
 			if (resp.status !== grpc.StatusDataLoss) {
 				throw new Error("unexpected error status: " + resp.status)
@@ -384,7 +384,7 @@ func TestClient(t *testing.T) {
 
 			return &grpc_testing.Empty{}, nil
 		}
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 			var resp = client.invoke("grpc.testing.TestService/EmptyCall", {})
 			if (resp.status !== grpc.StatusOK) {
 				throw new Error("unexpected error status: " + resp.status)
@@ -403,7 +403,7 @@ func TestClient(t *testing.T) {
 
 			return &grpc_testing.Empty{}, nil
 		}
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 			var resp = client.invoke("grpc.testing.TestService/EmptyCall", {})
 			if (resp.status !== grpc.StatusOK) {
 				throw new Error("unexpected error status: " + resp.status)
@@ -416,7 +416,7 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("LoadNotInit", func(t *testing.T) {
-		_, err := common.RunString(rt, "client.load()")
+		_, err := rt.RunString("client.load()")
 		if !assert.Error(t, err) {
 			return
 		}
@@ -424,7 +424,7 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("Close", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 			client.close();
 			client.invoke();
 		`)

--- a/js/modules/k6/html/element_test.go
+++ b/js/modules/k6/html/element_test.go
@@ -63,124 +63,124 @@ func TestElement(t *testing.T) {
 	rt.Set("html", common.Bind(rt, &HTML{}, &ctx))
 	// compileProtoElem()
 
-	_, err := common.RunString(rt, `var doc = html.parseHTML(src)`)
+	_, err := rt.RunString(`var doc = html.parseHTML(src)`)
 
 	assert.NoError(t, err)
 	assert.IsType(t, Selection{}, rt.Get("doc").Export())
 
 	t.Run("NodeName", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("#top").get(0).nodeName()`)
+		v, err := rt.RunString(`doc.find("#top").get(0).nodeName()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "h1", v.Export())
 		}
 	})
 	t.Run("NodeType", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("#top").get(0).nodeType()`)
+		v, err := rt.RunString(`doc.find("#top").get(0).nodeType()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "1", v.String())
 		}
 	})
 	t.Run("NodeValue", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("#top").get(0).firstChild().nodeValue()`)
+		v, err := rt.RunString(`doc.find("#top").get(0).firstChild().nodeValue()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "Lorem ipsum", v.String())
 		}
 	})
 	t.Run("InnerHtml", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("span").get(0).innerHTML()`)
+		v, err := rt.RunString(`doc.find("span").get(0).innerHTML()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "<b>test content</b>", v.String())
 		}
 	})
 	t.Run("TextContent", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("b").get(0).textContent()`)
+		v, err := rt.RunString(`doc.find("b").get(0).textContent()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "test content", v.String())
 		}
 	})
 	t.Run("OwnerDocument", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("body").get(0).ownerDocument().nodeName()`)
+		v, err := rt.RunString(`doc.find("body").get(0).ownerDocument().nodeName()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "#document", v.String())
 		}
 	})
 	t.Run("Attributes", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("div").get(0).attributes()`)
+		v, err := rt.RunString(`doc.find("div").get(0).attributes()`)
 		if assert.NoError(t, err) {
 			attrs := v.Export().(map[string]Attribute)
 			assert.Equal(t, "div_elem", attrs["id"].Value)
 		}
 	})
 	t.Run("FirstChild", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("div").get(0).firstChild().nodeValue()`)
+		v, err := rt.RunString(`doc.find("div").get(0).firstChild().nodeValue()`)
 		if assert.NoError(t, err) {
 			assert.Contains(t, v.Export(), "innerfirst")
 		}
 	})
 	t.Run("LastChild", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("div").get(0).lastChild().nodeValue()`)
+		v, err := rt.RunString(`doc.find("div").get(0).lastChild().nodeValue()`)
 		if assert.NoError(t, err) {
 			assert.Contains(t, v.Export(), "innerlast")
 		}
 	})
 	t.Run("ChildElementCount", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("body").get(0).childElementCount()`)
+		v, err := rt.RunString(`doc.find("body").get(0).childElementCount()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, int64(6), v.Export())
 		}
 	})
 	t.Run("FirstElementChild", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("div").get(0).firstElementChild().textContent()`)
+		v, err := rt.RunString(`doc.find("div").get(0).firstElementChild().textContent()`)
 		if assert.NoError(t, err) {
 			assert.Contains(t, v.Export(), "Nullam id nisi ")
 		}
 	})
 	t.Run("LastElementChild", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("div").get(0).lastElementChild().textContent()`)
+		v, err := rt.RunString(`doc.find("div").get(0).lastElementChild().textContent()`)
 		if assert.NoError(t, err) {
 			assert.Contains(t, v.Export(), "Maecenas augue ligula")
 		}
 	})
 	t.Run("PreviousSibling", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("div").get(0).previousSibling().textContent()`)
+		v, err := rt.RunString(`doc.find("div").get(0).previousSibling().textContent()`)
 		if assert.NoError(t, err) {
 			assert.Contains(t, v.Export(), "pretext")
 		}
 	})
 	t.Run("NextSibling", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("div").get(0).nextSibling().textContent()`)
+		v, err := rt.RunString(`doc.find("div").get(0).nextSibling().textContent()`)
 		if assert.NoError(t, err) {
 			assert.Contains(t, v.Export(), "aftertext")
 		}
 	})
 	t.Run("PreviousElementSibling", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("div").get(0).previousElementSibling().textContent()`)
+		v, err := rt.RunString(`doc.find("div").get(0).previousElementSibling().textContent()`)
 		if assert.NoError(t, err) {
 			assert.Contains(t, v.Export(), "consectetur adipiscing elit")
 		}
 	})
 	t.Run("NextElementSibling", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("div").get(0).nextElementSibling().textContent()`)
+		v, err := rt.RunString(`doc.find("div").get(0).nextElementSibling().textContent()`)
 		if assert.NoError(t, err) {
 			assert.Contains(t, v.Export(), "This is the footer.")
 		}
 	})
 	t.Run("ParentElement", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("div").get(0).parentElement().nodeName()`)
+		v, err := rt.RunString(`doc.find("div").get(0).parentElement().nodeName()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "body", v.String())
 		}
 	})
 	t.Run("ParentNode", func(t *testing.T) {
-		nodeVal, err1 := common.RunString(rt, `doc.find("html").get(0).parentNode().nodeName()`)
-		nilVal, err2 := common.RunString(rt, `doc.find("html").get(0).parentElement()`)
+		nodeVal, err1 := rt.RunString(`doc.find("html").get(0).parentNode().nodeName()`)
+		nilVal, err2 := rt.RunString(`doc.find("html").get(0).parentElement()`)
 		if assert.NoError(t, err1) && assert.NoError(t, err2) {
 			assert.Equal(t, "#document", nodeVal.String())
 			assert.Equal(t, nil, nilVal.Export())
 		}
 	})
 	t.Run("ChildNodes", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("div").get(0).childNodes()`)
+		v, err := rt.RunString(`doc.find("div").get(0).childNodes()`)
 		if assert.NoError(t, err) {
 			nodes := v.Export().([]goja.Value)
 			assert.Equal(t, 9, len(nodes))
@@ -189,7 +189,7 @@ func TestElement(t *testing.T) {
 		}
 	})
 	t.Run("Children", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("div").get(0).children()`)
+		v, err := rt.RunString(`doc.find("div").get(0).children()`)
 		if assert.NoError(t, err) {
 			nodes := v.Export().([]goja.Value)
 			assert.Equal(t, 4, len(nodes))
@@ -198,7 +198,7 @@ func TestElement(t *testing.T) {
 		}
 	})
 	t.Run("ClassList", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("div").get(0).classList()`)
+		v, err := rt.RunString(`doc.find("div").get(0).classList()`)
 		if assert.NoError(t, err) {
 			clsNames := v.Export().([]string)
 			assert.Equal(t, 2, len(clsNames))
@@ -206,79 +206,79 @@ func TestElement(t *testing.T) {
 		}
 	})
 	t.Run("ClassName", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("div").get(0).className()`)
+		v, err := rt.RunString(`doc.find("div").get(0).className()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "class1 class2", v.String())
 		}
 	})
 	t.Run("Lang", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("div").get(0).lang()`)
+		v, err := rt.RunString(`doc.find("div").get(0).lang()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "en", v.String())
 		}
 	})
 	t.Run("ToString", func(t *testing.T) {
-		v1, err1 := common.RunString(rt, `doc.find("div").get(0).toString()`)
-		v2, err2 := common.RunString(rt, `doc.find("div").get(0).previousSibling().toString()`)
+		v1, err1 := rt.RunString(`doc.find("div").get(0).toString()`)
+		v2, err2 := rt.RunString(`doc.find("div").get(0).previousSibling().toString()`)
 		if assert.NoError(t, err1) && assert.NoError(t, err2) {
 			assert.Equal(t, "[object html.Node]", v1.String())
 			assert.Equal(t, "[object #text]", v2.String())
 		}
 	})
 	t.Run("HasAttribute", func(t *testing.T) {
-		v1, err1 := common.RunString(rt, `doc.find("div").get(0).hasAttribute("id")`)
-		v2, err2 := common.RunString(rt, `doc.find("div").get(0).hasAttribute("noattr")`)
+		v1, err1 := rt.RunString(`doc.find("div").get(0).hasAttribute("id")`)
+		v2, err2 := rt.RunString(`doc.find("div").get(0).hasAttribute("noattr")`)
 		if assert.NoError(t, err1) && assert.NoError(t, err2) {
 			assert.Equal(t, true, v1.Export())
 			assert.Equal(t, false, v2.Export())
 		}
 	})
 	t.Run("GetAttribute", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("div").get(0).getAttribute("id")`)
+		v, err := rt.RunString(`doc.find("div").get(0).getAttribute("id")`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "div_elem", v.Export())
 		}
 	})
 	t.Run("GetAttributeNode", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("div").get(0).getAttributeNode("id")`)
+		v, err := rt.RunString(`doc.find("div").get(0).getAttributeNode("id")`)
 		if assert.NoError(t, err) && assert.IsType(t, Attribute{}, v.Export()) {
 			assert.Equal(t, "div_elem", v.Export().(Attribute).Value)
 		}
 	})
 	t.Run("HasAttributes", func(t *testing.T) {
-		v1, err1 := common.RunString(rt, `doc.find("h1").get(0).hasAttributes()`)
-		v2, err2 := common.RunString(rt, `doc.find("footer").get(0).hasAttributes()`)
+		v1, err1 := rt.RunString(`doc.find("h1").get(0).hasAttributes()`)
+		v2, err2 := rt.RunString(`doc.find("footer").get(0).hasAttributes()`)
 		if assert.NoError(t, err1) && assert.NoError(t, err2) {
 			assert.Equal(t, true, v1.Export())
 			assert.Equal(t, false, v2.Export())
 		}
 	})
 	t.Run("HasChildNodes", func(t *testing.T) {
-		v1, err1 := common.RunString(rt, `doc.find("p").get(0).hasChildNodes()`)
-		v2, err2 := common.RunString(rt, `doc.find("empty").get(0).hasChildNodes()`)
+		v1, err1 := rt.RunString(`doc.find("p").get(0).hasChildNodes()`)
+		v2, err2 := rt.RunString(`doc.find("empty").get(0).hasChildNodes()`)
 		if assert.NoError(t, err1) && assert.NoError(t, err2) {
 			assert.Equal(t, true, v1.Export())
 			assert.Equal(t, false, v2.Export())
 		}
 	})
 	t.Run("IsSameNode", func(t *testing.T) {
-		v1, err1 := common.RunString(rt, `doc.find("p").get(0).isSameNode(doc.find("p").get(1))`)
-		v2, err2 := common.RunString(rt, `doc.find("p").get(0).isSameNode(doc.find("p").get(0))`)
+		v1, err1 := rt.RunString(`doc.find("p").get(0).isSameNode(doc.find("p").get(1))`)
+		v2, err2 := rt.RunString(`doc.find("p").get(0).isSameNode(doc.find("p").get(0))`)
 		if assert.NoError(t, err1) && assert.NoError(t, err2) {
 			assert.Equal(t, false, v1.Export())
 			assert.Equal(t, true, v2.Export())
 		}
 	})
 	t.Run("IsEqualNode", func(t *testing.T) {
-		v1, err1 := common.RunString(rt, `doc.find("p").get(0).isEqualNode(doc.find("p").get(1))`)
-		v2, err2 := common.RunString(rt, `doc.find("p").get(0).isEqualNode(doc.find("p").get(0))`)
+		v1, err1 := rt.RunString(`doc.find("p").get(0).isEqualNode(doc.find("p").get(1))`)
+		v2, err2 := rt.RunString(`doc.find("p").get(0).isEqualNode(doc.find("p").get(0))`)
 		if assert.NoError(t, err1) && assert.NoError(t, err2) {
 			assert.Equal(t, true, v1.Export())
 			assert.Equal(t, true, v2.Export())
 		}
 	})
 	t.Run("GetElementsByClassName", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("body").get(0).getElementsByClassName("class2")`)
+		v, err := rt.RunString(`doc.find("body").get(0).getElementsByClassName("class2")`)
 		if assert.NoError(t, err) {
 			elems := v.Export().([]goja.Value)
 			assert.Equal(t, "div_elem", elems[0].Export().(Element).Id())
@@ -286,20 +286,20 @@ func TestElement(t *testing.T) {
 		}
 	})
 	t.Run("GetElementsByTagName", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("body").get(0).getElementsByTagName("span")`)
+		v, err := rt.RunString(`doc.find("body").get(0).getElementsByTagName("span")`)
 		if assert.NoError(t, err) {
 			elems := v.Export().([]goja.Value)
 			assert.Equal(t, 2, len(elems))
 		}
 	})
 	t.Run("QuerySelector", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("body").get(0).querySelector("#div_elem").id()`)
+		v, err := rt.RunString(`doc.find("body").get(0).querySelector("#div_elem").id()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "div_elem", v.Export())
 		}
 	})
 	t.Run("QuerySelectorAll", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("body").get(0).querySelectorAll("span")`)
+		v, err := rt.RunString(`doc.find("body").get(0).querySelectorAll("span")`)
 		if assert.NoError(t, err) {
 			elems := v.Export().([]goja.Value)
 			assert.Equal(t, "span1", elems[0].Export().(Element).Id())
@@ -307,28 +307,28 @@ func TestElement(t *testing.T) {
 		}
 	})
 	t.Run("Contains", func(t *testing.T) {
-		v1, err1 := common.RunString(rt, `doc.find("html").get(0).contains(doc.find("body").get(0))`)
-		v2, err2 := common.RunString(rt, `doc.find("body").get(0).contains(doc.find("body").get(0))`)
+		v1, err1 := rt.RunString(`doc.find("html").get(0).contains(doc.find("body").get(0))`)
+		v2, err2 := rt.RunString(`doc.find("body").get(0).contains(doc.find("body").get(0))`)
 		if assert.NoError(t, err1) && assert.NoError(t, err2) {
 			assert.Equal(t, true, v1.Export())
 			assert.Equal(t, false, v2.Export())
 		}
 	})
 	t.Run("Matches", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("div").get(0).matches("#div_elem")`)
+		v, err := rt.RunString(`doc.find("div").get(0).matches("#div_elem")`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, true, v.Export())
 		}
 	})
 	t.Run("NamespaceURI", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("#svg_elem").get(0).namespaceURI()`)
+		v, err := rt.RunString(`doc.find("#svg_elem").get(0).namespaceURI()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "http://www.w3.org/2000/svg", v.Export())
 		}
 	})
 	t.Run("IsDefaultNamespace", func(t *testing.T) {
-		v1, err1 := common.RunString(rt, `doc.find("#svg_elem").get(0).isDefaultNamespace()`)
-		v2, err2 := common.RunString(rt, `doc.find("#div_elem").get(0).isDefaultNamespace()`)
+		v1, err1 := rt.RunString(`doc.find("#svg_elem").get(0).isDefaultNamespace()`)
+		v2, err2 := rt.RunString(`doc.find("#div_elem").get(0).isDefaultNamespace()`)
 		if assert.NoError(t, err1) && assert.NoError(t, err2) {
 			assert.Equal(t, false, v1.ToBoolean())
 			assert.Equal(t, true, v2.ToBoolean())

--- a/js/modules/k6/html/elements_gen_test.go
+++ b/js/modules/k6/html/elements_gen_test.go
@@ -411,14 +411,14 @@ func TestGenElements(t *testing.T) {
 	rt.Set("src", testGenElems)
 	rt.Set("html", common.Bind(rt, &HTML{}, &ctx))
 
-	_, err := common.RunString(rt, "var doc = html.parseHTML(src)")
+	_, err := rt.RunString("var doc = html.parseHTML(src)")
 
 	assert.NoError(t, err)
 	assert.IsType(t, Selection{}, rt.Get("doc").Export())
 
 	t.Run("Test text properties", func(t *testing.T) {
 		for _, test := range textTests {
-			v, err := common.RunString(rt, `doc.find("#`+test.id+`").get(0).`+test.property+`()`)
+			v, err := rt.RunString(`doc.find("#` + test.id + `").get(0).` + test.property + `()`)
 			if err != nil {
 				t.Errorf("Error for property name '%s' on element id '#%s':\n%+v ", test.id, test.property, err)
 			} else if v.Export() != test.data {
@@ -429,14 +429,14 @@ func TestGenElements(t *testing.T) {
 
 	t.Run("Test bool properties", func(t *testing.T) {
 		for _, test := range boolTests {
-			vT, errT := common.RunString(rt, `doc.find("#`+test.idTrue+`").get(0).`+test.property+`()`)
+			vT, errT := rt.RunString(`doc.find("#` + test.idTrue + `").get(0).` + test.property + `()`)
 			if errT != nil {
 				t.Errorf("Error for property name '%s' on element id '#%s':\n%+v", test.property, test.idTrue, errT)
 			} else if vT.Export() != true { // nolint: gosimple
 				t.Errorf("Expected true for property name '%s' on element id '#%s'", test.property, test.idTrue)
 			}
 
-			vF, errF := common.RunString(rt, `doc.find("#`+test.idFalse+`").get(0).`+test.property+`()`)
+			vF, errF := rt.RunString(`doc.find("#` + test.idFalse + `").get(0).` + test.property + `()`)
 			if errF != nil {
 				t.Errorf("Error for property name '%s' on element id '#%s':\n%+v", test.property, test.idFalse, errF)
 			} else if vF.Export() != false { // nolint: gosimple
@@ -447,7 +447,7 @@ func TestGenElements(t *testing.T) {
 
 	t.Run("Test int64 properties", func(t *testing.T) {
 		for _, test := range intTests {
-			v, err := common.RunString(rt, `doc.find("#`+test.id+`").get(0).`+test.property+`()`)
+			v, err := rt.RunString(`doc.find("#` + test.id + `").get(0).` + test.property + `()`)
 			if err != nil {
 				t.Errorf("Error for property name '%s' on element id '#%s':\n%+v", test.property, test.id, err)
 			} else if v.Export() != int64(test.data) {
@@ -458,7 +458,7 @@ func TestGenElements(t *testing.T) {
 
 	t.Run("Test nullable properties", func(t *testing.T) {
 		for _, test := range nullTests {
-			v, err := common.RunString(rt, `doc.find("#`+test.id+`").get(0).`+test.property+`()`)
+			v, err := rt.RunString(`doc.find("#` + test.id + `").get(0).` + test.property + `()`)
 			if err != nil {
 				t.Errorf("Error for property name '%s' on element id '#%s':\n%+v", test.property, test.id, err)
 			} else if v.Export() != nil {
@@ -478,7 +478,7 @@ func TestGenElements(t *testing.T) {
 			sel.URL = test.baseUrl
 			rt.Set("urldoc", sel)
 
-			v, err := common.RunString(rt, `urldoc.find("#`+test.id+`").get(0).`+test.property+`()`)
+			v, err := rt.RunString(`urldoc.find("#` + test.id + `").get(0).` + test.property + `()`)
 			if err != nil {
 				t.Errorf("Error for url property '%s' on element id '#%s':\n%+v", test.property, test.id, err)
 			} else if v.Export() != test.data {

--- a/js/modules/k6/html/elements_test.go
+++ b/js/modules/k6/html/elements_test.go
@@ -93,208 +93,208 @@ func TestElements(t *testing.T) {
 	rt.Set("src", testHTMLElems)
 	rt.Set("html", common.Bind(rt, &HTML{}, &ctx))
 
-	_, err := common.RunString(rt, `var doc = html.parseHTML(src)`)
+	_, err := rt.RunString(`var doc = html.parseHTML(src)`)
 
 	assert.NoError(t, err)
 	assert.IsType(t, Selection{}, rt.Get("doc").Export())
 
 	t.Run("AnchorElement", func(t *testing.T) {
 		t.Run("Hash", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("a").get(0).hash()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("a").get(0).hash()`); assert.NoError(t, err) {
 				assert.Equal(t, "#hashtext", v.Export())
 			}
-			if v, err := common.RunString(rt, `doc.find("#blank_anchor").get(0).hash()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#blank_anchor").get(0).hash()`); assert.NoError(t, err) {
 				assert.Equal(t, "", v.Export())
 			}
 		})
 		t.Run("Host", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("a").get(1).host()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("a").get(1).host()`); assert.NoError(t, err) {
 				assert.Equal(t, "example.com", v.Export())
 			}
-			if v, err := common.RunString(rt, `doc.find("a").get(2).host()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("a").get(2).host()`); assert.NoError(t, err) {
 				assert.Equal(t, "example.com:81", v.Export())
 			}
-			if v, err := common.RunString(rt, `doc.find("a").get(3).host()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("a").get(3).host()`); assert.NoError(t, err) {
 				assert.Equal(t, "ssl.example.com", v.Export())
 			}
-			if v, err := common.RunString(rt, `doc.find("a").get(4).host()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("a").get(4).host()`); assert.NoError(t, err) {
 				assert.Equal(t, "ssl.example.com:444", v.Export())
 			}
-			if v, err := common.RunString(rt, `doc.find("#blank_anchor").get(0).host()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#blank_anchor").get(0).host()`); assert.NoError(t, err) {
 				assert.Equal(t, "", v.Export())
 			}
 		})
 		t.Run("Hostname", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("a").get(1).hostname()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("a").get(1).hostname()`); assert.NoError(t, err) {
 				assert.Equal(t, "example.com", v.Export())
 			}
-			if v, err := common.RunString(rt, `doc.find("#blank_anchor").get(0).hostname()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#blank_anchor").get(0).hostname()`); assert.NoError(t, err) {
 				assert.Equal(t, "", v.Export())
 			}
 		})
 		t.Run("Port", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("a").get(5).port()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("a").get(5).port()`); assert.NoError(t, err) {
 				assert.Equal(t, "80", v.Export())
 			}
-			if v, err := common.RunString(rt, `doc.find("#blank_anchor").get(0).port()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#blank_anchor").get(0).port()`); assert.NoError(t, err) {
 				assert.Equal(t, "", v.Export())
 			}
 		})
 		t.Run("Username", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("a").get(5).username()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("a").get(5).username()`); assert.NoError(t, err) {
 				assert.Equal(t, "username", v.Export())
 			}
-			if v, err := common.RunString(rt, `doc.find("#blank_anchor").get(0).username()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#blank_anchor").get(0).username()`); assert.NoError(t, err) {
 				assert.Equal(t, "", v.Export())
 			}
 		})
 		t.Run("Password", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("a").get(5).password()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("a").get(5).password()`); assert.NoError(t, err) {
 				assert.Equal(t, "password", v.Export())
 			}
-			if v, err := common.RunString(rt, `doc.find("#blank_anchor").get(0).password()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#blank_anchor").get(0).password()`); assert.NoError(t, err) {
 				assert.Equal(t, "", v.Export())
 			}
 		})
 		t.Run("Origin", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("a").get(5).origin()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("a").get(5).origin()`); assert.NoError(t, err) {
 				assert.Equal(t, "http://example.com:80", v.Export())
 			}
-			if v, err := common.RunString(rt, `doc.find("#blank_anchor").get(0).origin()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#blank_anchor").get(0).origin()`); assert.NoError(t, err) {
 				assert.Equal(t, "", v.Export())
 			}
 		})
 		t.Run("Pathname", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("a").get(1).pathname()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("a").get(1).pathname()`); assert.NoError(t, err) {
 				assert.Equal(t, "", v.Export())
 			}
-			if v, err := common.RunString(rt, `doc.find("a").get(2).pathname()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("a").get(2).pathname()`); assert.NoError(t, err) {
 				assert.Equal(t, "/path/file", v.Export())
 			}
-			if v, err := common.RunString(rt, `doc.find("#blank_anchor").get(0).pathname()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#blank_anchor").get(0).pathname()`); assert.NoError(t, err) {
 				assert.Equal(t, "", v.Export())
 			}
 		})
 		t.Run("Protocol", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("a").get(4).protocol()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("a").get(4).protocol()`); assert.NoError(t, err) {
 				assert.Equal(t, "https", v.Export())
 			}
-			if v, err := common.RunString(rt, `doc.find("#blank_anchor").get(0).protocol()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#blank_anchor").get(0).protocol()`); assert.NoError(t, err) {
 				assert.Equal(t, ":", v.Export())
 			}
 		})
 		t.Run("RelList", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("a").get(6).relList()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("a").get(6).relList()`); assert.NoError(t, err) {
 				assert.Equal(t, []string{"prev", "next"}, v.Export())
 			}
-			if v, err := common.RunString(rt, `doc.find("a").get(5).relList()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("a").get(5).relList()`); assert.NoError(t, err) {
 				assert.Equal(t, []string{}, v.Export())
 			}
 		})
 		t.Run("Search", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("a").get(0).search()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("a").get(0).search()`); assert.NoError(t, err) {
 				assert.Equal(t, "?querytxt", v.Export())
 			}
 		})
 		t.Run("Text", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("a").get(6).text()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("a").get(6).text()`); assert.NoError(t, err) {
 				assert.Equal(t, "6", v.Export())
 			}
 		})
 	})
 	t.Run("AreaElement", func(t *testing.T) {
-		if v, err := common.RunString(rt, `doc.find("area").get(0).toString()`); assert.NoError(t, err) {
+		if v, err := rt.RunString(`doc.find("area").get(0).toString()`); assert.NoError(t, err) {
 			assert.Equal(t, "web.address.com", v.Export())
 		}
 	})
 	t.Run("ButtonElement", func(t *testing.T) {
 		t.Run("form", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#form_btn").get(0).form().id()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#form_btn").get(0).form().id()`); assert.NoError(t, err) {
 				assert.Equal(t, "form1", v.Export())
 			}
-			if v, err := common.RunString(rt, `doc.find("#named_form_btn").get(0).form().id()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#named_form_btn").get(0).form().id()`); assert.NoError(t, err) {
 				assert.Equal(t, "form2", v.Export())
 			}
-			if v, err := common.RunString(rt, `doc.find("#no_form_btn").get(0).form()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#no_form_btn").get(0).form()`); assert.NoError(t, err) {
 				assert.Equal(t, nil, v.Export())
 			}
 		})
 		t.Run("formaction", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#form_btn").get(0).formAction()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#form_btn").get(0).formAction()`); assert.NoError(t, err) {
 				assert.Equal(t, "action_url", v.Export())
 			}
-			if v, err := common.RunString(rt, `doc.find("#form_btn_2").get(0).formAction()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#form_btn_2").get(0).formAction()`); assert.NoError(t, err) {
 				assert.Equal(t, "override_action_url", v.Export())
 			}
 		})
 		t.Run("formenctype", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#form_btn").get(0).formEnctype()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#form_btn").get(0).formEnctype()`); assert.NoError(t, err) {
 				assert.Equal(t, "text/plain", v.Export())
 			}
-			if v, err := common.RunString(rt, `doc.find("#form_btn_2").get(0).formEnctype()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#form_btn_2").get(0).formEnctype()`); assert.NoError(t, err) {
 				assert.Equal(t, "multipart/form-data", v.Export())
 			}
 		})
 		t.Run("formmethod", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#form_btn").get(0).formMethod()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#form_btn").get(0).formMethod()`); assert.NoError(t, err) {
 				assert.Equal(t, "get", v.Export())
 			}
-			if v, err := common.RunString(rt, `doc.find("#form_btn_2").get(0).formMethod()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#form_btn_2").get(0).formMethod()`); assert.NoError(t, err) {
 				assert.Equal(t, "post", v.Export())
 			}
 		})
 		t.Run("formnovalidate", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#form_btn").get(0).formNoValidate()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#form_btn").get(0).formNoValidate()`); assert.NoError(t, err) {
 				assert.Equal(t, false, v.Export())
 			}
-			if v, err := common.RunString(rt, `doc.find("#form_btn_2").get(0).formNoValidate()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#form_btn_2").get(0).formNoValidate()`); assert.NoError(t, err) {
 				assert.Equal(t, true, v.Export())
 			}
 		})
 		t.Run("formtarget", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#form_btn").get(0).formTarget()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#form_btn").get(0).formTarget()`); assert.NoError(t, err) {
 				assert.Equal(t, "_self", v.Export())
 			}
-			if v, err := common.RunString(rt, `doc.find("#form_btn_2").get(0).formTarget()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#form_btn_2").get(0).formTarget()`); assert.NoError(t, err) {
 				assert.Equal(t, "_top", v.Export())
 			}
 		})
 		t.Run("labels", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#form_btn").get(0).labels()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#form_btn").get(0).labels()`); assert.NoError(t, err) {
 				assert.Equal(t, 1, len(v.Export().([]goja.Value)))
 				assert.Equal(t, "form_btn_label", v.Export().([]goja.Value)[0].Export().(LabelElement).Id())
 			}
-			if v, err := common.RunString(rt, `doc.find("#form_btn_2").get(0).labels()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#form_btn_2").get(0).labels()`); assert.NoError(t, err) {
 				assert.Equal(t, 2, len(v.Export().([]goja.Value)))
 				assert.Equal(t, "wrapper_label", v.Export().([]goja.Value)[0].Export().(LabelElement).Id())
 				assert.Equal(t, "form_btn_2_label", v.Export().([]goja.Value)[1].Export().(LabelElement).Id())
 			}
 		})
 		t.Run("name", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#form_btn").get(0).name()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#form_btn").get(0).name()`); assert.NoError(t, err) {
 				assert.Equal(t, "form_btn", v.Export())
 			}
 		})
 		t.Run("value", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#form_btn_2").get(0).value()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#form_btn_2").get(0).value()`); assert.NoError(t, err) {
 				assert.Equal(t, "form_btn_2_initval", v.Export())
 			}
 		})
 	})
 	t.Run("CanvasElement", func(t *testing.T) {
 		t.Run("width", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("canvas").get(0).width()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("canvas").get(0).width()`); assert.NoError(t, err) {
 				assert.Equal(t, int64(200), v.Export())
 			}
 		})
 		t.Run("height", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("canvas").get(0).height()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("canvas").get(0).height()`); assert.NoError(t, err) {
 				assert.Equal(t, int64(150), v.Export())
 			}
 		})
 	})
 	t.Run("DataListElement options", func(t *testing.T) {
-		if v, err := common.RunString(rt, `doc.find("datalist").get(0).options()`); assert.NoError(t, err) {
+		if v, err := rt.RunString(`doc.find("datalist").get(0).options()`); assert.NoError(t, err) {
 			assert.Equal(t, 2, len(v.Export().([]goja.Value)))
 			assert.Equal(t, "dl_opt_1", v.Export().([]goja.Value)[0].Export().(OptionElement).Id())
 			assert.Equal(t, "dl_opt_2", v.Export().([]goja.Value)[1].Export().(OptionElement).Id())
@@ -302,35 +302,35 @@ func TestElements(t *testing.T) {
 	})
 	t.Run("FieldSetElement", func(t *testing.T) {
 		t.Run("elements", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("fieldset").get(0).elements()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("fieldset").get(0).elements()`); assert.NoError(t, err) {
 				assert.Equal(t, 5, len(v.Export().([]goja.Value)))
 			}
 		})
 		t.Run("type", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("fieldset").get(0).type()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("fieldset").get(0).type()`); assert.NoError(t, err) {
 				assert.Equal(t, "fieldset", v.Export())
 			}
 		})
 		t.Run("form", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("fieldset").get(0).form().id()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("fieldset").get(0).form().id()`); assert.NoError(t, err) {
 				assert.Equal(t, "fieldset_form", v.Export())
 			}
 		})
 	})
 	t.Run("FormElement", func(t *testing.T) {
 		t.Run("elements", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#fieldset_form").get(0).elements()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#fieldset_form").get(0).elements()`); assert.NoError(t, err) {
 				assert.Equal(t, 6, len(v.Export().([]goja.Value)))
 			}
 		})
 		t.Run("length", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#fieldset_form").get(0).length()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#fieldset_form").get(0).length()`); assert.NoError(t, err) {
 				assert.Equal(t, int64(6), v.Export())
 			}
 		})
 		t.Run("method", func(t *testing.T) {
-			v1, err1 := common.RunString(rt, `doc.find("#form1").get(0).method()`)
-			v2, err2 := common.RunString(rt, `doc.find("#fieldset_form").get(0).method()`)
+			v1, err1 := rt.RunString(`doc.find("#form1").get(0).method()`)
+			v2, err2 := rt.RunString(`doc.find("#fieldset_form").get(0).method()`)
 			if assert.NoError(t, err1) && assert.NoError(t, err2) {
 				assert.Equal(t, "get", v1.Export())
 				assert.Equal(t, "post", v2.Export())
@@ -339,61 +339,61 @@ func TestElements(t *testing.T) {
 	})
 	t.Run("InputElement", func(t *testing.T) {
 		t.Run("form", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#test_dl_input").get(0).list().options()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#test_dl_input").get(0).list().options()`); assert.NoError(t, err) {
 				assert.Equal(t, 2, len(v.Export().([]goja.Value)))
 			}
 		})
 	})
 	t.Run("LabelElement", func(t *testing.T) {
 		t.Run("control", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#form_btn_2_label").get(0).control().value()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#form_btn_2_label").get(0).control().value()`); assert.NoError(t, err) {
 				assert.Equal(t, "form_btn_2_initval", v.Export())
 			}
 		})
 		t.Run("form", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#form_btn_2_label").get(0).form().id()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#form_btn_2_label").get(0).form().id()`); assert.NoError(t, err) {
 				assert.Equal(t, "form1", v.Export())
 			}
 		})
 	})
 	t.Run("LegendElement", func(t *testing.T) {
 		t.Run("form", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#legend_1").get(0).form().id()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#legend_1").get(0).form().id()`); assert.NoError(t, err) {
 				assert.Equal(t, "fieldset_form", v.Export())
 			}
 		})
 	})
 	t.Run("LinkElement", func(t *testing.T) {
 		t.Run("rel list", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("link").get(0).relList()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("link").get(0).relList()`); assert.NoError(t, err) {
 				assert.Equal(t, []string{"alternate", "next"}, v.Export())
 			}
 		})
 	})
 	t.Run("MapElement", func(t *testing.T) {
 		t.Run("areas", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#find_this_map").get(0).areas()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#find_this_map").get(0).areas()`); assert.NoError(t, err) {
 				assert.Equal(t, 3, len(v.Export().([]goja.Value)))
 			}
 		})
 		t.Run("images", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#find_this_map").get(0).images()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#find_this_map").get(0).images()`); assert.NoError(t, err) {
 				assert.Equal(t, 2, len(v.Export().([]goja.Value)))
 			}
 		})
 	})
 	t.Run("ObjectElement", func(t *testing.T) {
 		t.Run("form", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#obj_1").get(0).form().id()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#obj_1").get(0).form().id()`); assert.NoError(t, err) {
 				assert.Equal(t, "form1", v.Export())
 			}
 		})
 	})
 	t.Run("OptionElement", func(t *testing.T) {
 		t.Run("disabled", func(t *testing.T) {
-			v1, err1 := common.RunString(rt, `doc.find("#opt_1").get(0).disabled()`)
-			v2, err2 := common.RunString(rt, `doc.find("#opt_2").get(0).disabled()`)
-			v3, err3 := common.RunString(rt, `doc.find("#opt_3").get(0).disabled()`)
+			v1, err1 := rt.RunString(`doc.find("#opt_1").get(0).disabled()`)
+			v2, err2 := rt.RunString(`doc.find("#opt_2").get(0).disabled()`)
+			v3, err3 := rt.RunString(`doc.find("#opt_3").get(0).disabled()`)
 			if assert.NoError(t, err1) && assert.NoError(t, err2) && assert.NoError(t, err3) {
 				assert.Equal(t, false, v1.Export())
 				assert.Equal(t, true, v2.Export())
@@ -401,34 +401,34 @@ func TestElements(t *testing.T) {
 			}
 		})
 		t.Run("form", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#opt_4").get(0).form().id()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#opt_4").get(0).form().id()`); assert.NoError(t, err) {
 				assert.Equal(t, "form3", v.Export())
 			}
 		})
 		t.Run("index", func(t *testing.T) {
-			v1, err1 := common.RunString(rt, `doc.find("#dl_opt_2").get(0).index()`)
-			v2, err2 := common.RunString(rt, `doc.find("#opt_3").get(0).index()`)
+			v1, err1 := rt.RunString(`doc.find("#dl_opt_2").get(0).index()`)
+			v2, err2 := rt.RunString(`doc.find("#opt_3").get(0).index()`)
 			if assert.NoError(t, err1) && assert.NoError(t, err2) {
 				assert.Equal(t, int64(1), v1.Export())
 				assert.Equal(t, int64(2), v2.Export())
 			}
 		})
 		t.Run("label", func(t *testing.T) {
-			v1, err1 := common.RunString(rt, `doc.find("#opt_1").get(0).label()`)
-			v2, err2 := common.RunString(rt, `doc.find("#opt_2").get(0).label()`)
+			v1, err1 := rt.RunString(`doc.find("#opt_1").get(0).label()`)
+			v2, err2 := rt.RunString(`doc.find("#opt_2").get(0).label()`)
 			if assert.NoError(t, err1) && assert.NoError(t, err2) {
 				assert.Equal(t, "txt_label", v1.Export())
 				assert.Equal(t, "attr_label", v2.Export())
 			}
 		})
 		t.Run("text", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#opt_1").get(0).text()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#opt_1").get(0).text()`); assert.NoError(t, err) {
 				assert.Equal(t, "txt_label", v.Export())
 			}
 		})
 		t.Run("value", func(t *testing.T) {
-			v1, err1 := common.RunString(rt, `doc.find("#opt_1").get(0).value()`)
-			v2, err2 := common.RunString(rt, `doc.find("#opt_2").get(0).value()`)
+			v1, err1 := rt.RunString(`doc.find("#opt_1").get(0).value()`)
+			v2, err2 := rt.RunString(`doc.find("#opt_2").get(0).value()`)
 			if assert.NoError(t, err1) && assert.NoError(t, err2) {
 				assert.Equal(t, "txt_label", v1.Export())
 				assert.Equal(t, "selected_attr_val", v2.Export())
@@ -437,39 +437,39 @@ func TestElements(t *testing.T) {
 	})
 	t.Run("OutputElement", func(t *testing.T) {
 		t.Run("value", func(t *testing.T) {
-			v1, err1 := common.RunString(rt, `doc.find("#output1").get(0).value()`)
-			v2, err2 := common.RunString(rt, `doc.find("#output1").get(0).defaultValue()`)
+			v1, err1 := rt.RunString(`doc.find("#output1").get(0).value()`)
+			v2, err2 := rt.RunString(`doc.find("#output1").get(0).defaultValue()`)
 			if assert.NoError(t, err1) && assert.NoError(t, err2) {
 				assert.Equal(t, "defaultVal", v1.Export())
 				assert.Equal(t, "defaultVal", v2.Export())
 			}
 		})
 		t.Run("labels", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#output1").get(0).labels()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#output1").get(0).labels()`); assert.NoError(t, err) {
 				assert.Equal(t, 2, len(v.Export().([]goja.Value)))
 			}
 		})
 	})
 	t.Run("ProgressElement", func(t *testing.T) {
 		t.Run("max", func(t *testing.T) {
-			v1, err1 := common.RunString(rt, `doc.find("#progress1").get(0).max()`)
-			v2, err2 := common.RunString(rt, `doc.find("#progress2").get(0).max()`)
+			v1, err1 := rt.RunString(`doc.find("#progress1").get(0).max()`)
+			v2, err2 := rt.RunString(`doc.find("#progress2").get(0).max()`)
 			if assert.NoError(t, err1) && assert.NoError(t, err2) {
 				assert.Equal(t, int64(100), v1.Export())
 				assert.Equal(t, int64(1), v2.Export())
 			}
 		})
 		t.Run("value", func(t *testing.T) {
-			v1, err1 := common.RunString(rt, `doc.find("#progress1").get(0).value()`)
-			v2, err2 := common.RunString(rt, `doc.find("#progress2").get(0).value()`)
+			v1, err1 := rt.RunString(`doc.find("#progress1").get(0).value()`)
+			v2, err2 := rt.RunString(`doc.find("#progress2").get(0).value()`)
 			if assert.NoError(t, err1) && assert.NoError(t, err2) {
 				assert.Equal(t, float64(0.7), v1.Export())
 				assert.Equal(t, int64(0), v2.Export())
 			}
 		})
 		t.Run("position", func(t *testing.T) {
-			v1, err1 := common.RunString(rt, `doc.find("#progress1").get(0).position()`)
-			v2, err2 := common.RunString(rt, `doc.find("#progress2").get(0).position()`)
+			v1, err1 := rt.RunString(`doc.find("#progress1").get(0).position()`)
+			v2, err2 := rt.RunString(`doc.find("#progress2").get(0).position()`)
 			if assert.NoError(t, err1) && assert.NoError(t, err2) {
 				assert.Equal(t, float64(0.7), v1.Export())
 				assert.Equal(t, int64(-1), v2.Export())
@@ -478,81 +478,81 @@ func TestElements(t *testing.T) {
 	})
 	t.Run("ScriptElement", func(t *testing.T) {
 		t.Run("text", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#script1").get(0).text()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#script1").get(0).text()`); assert.NoError(t, err) {
 				assert.Equal(t, "script text", v.Export())
 			}
 		})
 	})
 	t.Run("SelectElement", func(t *testing.T) {
 		t.Run("form", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#sel2").get(0).form().id()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#sel2").get(0).form().id()`); assert.NoError(t, err) {
 				assert.Equal(t, "form3", v.Export())
 			}
 		})
 		t.Run("length", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#sel1").get(0).length()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#sel1").get(0).length()`); assert.NoError(t, err) {
 				assert.Equal(t, int64(3), v.Export())
 			}
 		})
 		t.Run("options", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#sel1").get(0).options()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#sel1").get(0).options()`); assert.NoError(t, err) {
 				assert.Equal(t, 3, len(v.Export().([]goja.Value)))
 				assert.Equal(t, "opt_1", v.Export().([]goja.Value)[0].Export().(OptionElement).Id())
 			}
 		})
 		t.Run("selectedOptions", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#sel1").get(0).selectedOptions()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#sel1").get(0).selectedOptions()`); assert.NoError(t, err) {
 				assert.Equal(t, 2, len(v.Export().([]goja.Value)))
 				assert.Equal(t, "opt_2", v.Export().([]goja.Value)[0].Export().(OptionElement).Id())
 			}
 		})
 		t.Run("selectedIndex", func(t *testing.T) {
-			v1, err1 := common.RunString(rt, `doc.find("#sel1").get(0).selectedIndex()`)
-			v2, err2 := common.RunString(rt, `doc.find("#sel2").get(0).selectedIndex()`)
+			v1, err1 := rt.RunString(`doc.find("#sel1").get(0).selectedIndex()`)
+			v2, err2 := rt.RunString(`doc.find("#sel2").get(0).selectedIndex()`)
 			if assert.NoError(t, err1) && assert.NoError(t, err2) {
 				assert.Equal(t, int64(1), v1.Export())
 				assert.Equal(t, int64(-1), v2.Export())
 			}
 		})
 		t.Run("value", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#sel1").get(0).value()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#sel1").get(0).value()`); assert.NoError(t, err) {
 				assert.Equal(t, "selected_attr_val", v.Export())
 			}
 		})
 	})
 	t.Run("StyleElement", func(t *testing.T) {
 		t.Run("text", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#style1").get(0).type()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#style1").get(0).type()`); assert.NoError(t, err) {
 				assert.Equal(t, "text/css", v.Export())
 			}
 		})
 	})
 	t.Run("TableElement", func(t *testing.T) {
 		t.Run("caption", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("table").get(0).caption().textContent()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("table").get(0).caption().textContent()`); assert.NoError(t, err) {
 				assert.Equal(t, "caption text", v.Export())
 			}
 		})
 		t.Run("thead", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("table").get(0).tHead().rows()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("table").get(0).tHead().rows()`); assert.NoError(t, err) {
 				assert.Equal(t, 1, len(v.Export().([]goja.Value)))
 				assert.Equal(t, "thead_row", v.Export().([]goja.Value)[0].Export().(TableRowElement).Id())
 			}
 		})
 		t.Run("tbody", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("table").get(0).tBodies()[0].rows()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("table").get(0).tBodies()[0].rows()`); assert.NoError(t, err) {
 				assert.Equal(t, 2, len(v.Export().([]goja.Value)))
 				assert.Equal(t, "tbody_row", v.Export().([]goja.Value)[1].Export().(TableRowElement).Id())
 			}
 		})
 		t.Run("tfoot", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("table").get(0).tFoot().rows()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("table").get(0).tFoot().rows()`); assert.NoError(t, err) {
 				assert.Equal(t, 3, len(v.Export().([]goja.Value)))
 				assert.Equal(t, "tfoot_row", v.Export().([]goja.Value)[2].Export().(TableRowElement).Id())
 			}
 		})
 		t.Run("rows", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("table").get(0).rows()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("table").get(0).rows()`); assert.NoError(t, err) {
 				assert.Equal(t, 7, len(v.Export().([]goja.Value)))
 				assert.Equal(t, "thead_row", v.Export().([]goja.Value)[0].Export().(TableRowElement).Id())
 				assert.Equal(t, "tfoot_row", v.Export().([]goja.Value)[3].Export().(TableRowElement).Id())
@@ -562,58 +562,58 @@ func TestElements(t *testing.T) {
 		})
 		t.Run("TableCellElement", func(t *testing.T) {
 			t.Run("cellIndex", func(t *testing.T) {
-				if v, err := common.RunString(rt, `doc.find("#td_cell").get(0).cellIndex()`); assert.NoError(t, err) {
+				if v, err := rt.RunString(`doc.find("#td_cell").get(0).cellIndex()`); assert.NoError(t, err) {
 					assert.Equal(t, int64(2), v.Export())
 				}
 			})
 			t.Run("colSpan", func(t *testing.T) {
-				v1, err1 := common.RunString(rt, `doc.find("#td_cell").get(0).colSpan()`)
-				v2, err2 := common.RunString(rt, `doc.find("#th_cell").get(0).colSpan()`)
+				v1, err1 := rt.RunString(`doc.find("#td_cell").get(0).colSpan()`)
+				v2, err2 := rt.RunString(`doc.find("#th_cell").get(0).colSpan()`)
 				if assert.NoError(t, err1) && assert.NoError(t, err2) {
 					assert.Equal(t, int64(1), v1.Export())
 					assert.Equal(t, int64(2), v2.Export())
 				}
 			})
 			t.Run("rowSpan", func(t *testing.T) {
-				v1, err1 := common.RunString(rt, `doc.find("#td_cell").get(0).rowSpan()`)
-				v2, err2 := common.RunString(rt, `doc.find("#th_cell").get(0).rowSpan()`)
+				v1, err1 := rt.RunString(`doc.find("#td_cell").get(0).rowSpan()`)
+				v2, err2 := rt.RunString(`doc.find("#th_cell").get(0).rowSpan()`)
 				if assert.NoError(t, err1) && assert.NoError(t, err2) {
 					assert.Equal(t, int64(2), v1.Export())
 					assert.Equal(t, int64(1), v2.Export())
 				}
 			})
 			t.Run("headers", func(t *testing.T) {
-				if v, err := common.RunString(rt, `doc.find("#td_cell").get(0).headers()`); assert.NoError(t, err) {
+				if v, err := rt.RunString(`doc.find("#td_cell").get(0).headers()`); assert.NoError(t, err) {
 					assert.Equal(t, "th_cell", v.Export())
 				}
 			})
 		})
 		t.Run("TableRowElement", func(t *testing.T) {
 			t.Run("cells", func(t *testing.T) {
-				if v, err := common.RunString(rt, `doc.find("#thead_row").get(0).cells()`); assert.NoError(t, err) {
+				if v, err := rt.RunString(`doc.find("#thead_row").get(0).cells()`); assert.NoError(t, err) {
 					assert.Equal(t, 3, len(v.Export().([]goja.Value)))
 					assert.Equal(t, "th_cell", v.Export().([]goja.Value)[1].Export().(TableHeaderCellElement).Id())
 				}
 			})
 			t.Run("colSpan", func(t *testing.T) {
-				v1, err1 := common.RunString(rt, `doc.find("#td_cell").get(0).colSpan()`)
-				v2, err2 := common.RunString(rt, `doc.find("#th_cell").get(0).colSpan()`)
+				v1, err1 := rt.RunString(`doc.find("#td_cell").get(0).colSpan()`)
+				v2, err2 := rt.RunString(`doc.find("#th_cell").get(0).colSpan()`)
 				if assert.NoError(t, err1) && assert.NoError(t, err2) {
 					assert.Equal(t, int64(1), v1.Export())
 					assert.Equal(t, int64(2), v2.Export())
 				}
 			})
 			t.Run("sectionRowIndex", func(t *testing.T) {
-				v1, err1 := common.RunString(rt, `doc.find("#tfoot_row").get(0).sectionRowIndex()`)
-				v2, err2 := common.RunString(rt, `doc.find("#last_row").get(0).sectionRowIndex()`)
+				v1, err1 := rt.RunString(`doc.find("#tfoot_row").get(0).sectionRowIndex()`)
+				v2, err2 := rt.RunString(`doc.find("#last_row").get(0).sectionRowIndex()`)
 				if assert.NoError(t, err1) && assert.NoError(t, err2) {
 					assert.Equal(t, int64(2), v1.Export())
 					assert.Equal(t, int64(0), v2.Export())
 				}
 			})
 			t.Run("rowIndex", func(t *testing.T) {
-				v1, err1 := common.RunString(rt, `doc.find("#tfoot_row").get(0).rowIndex()`)
-				v2, err2 := common.RunString(rt, `doc.find("#last_row").get(0).rowIndex()`)
+				v1, err1 := rt.RunString(`doc.find("#tfoot_row").get(0).rowIndex()`)
+				v2, err2 := rt.RunString(`doc.find("#last_row").get(0).rowIndex()`)
 				if assert.NoError(t, err1) && assert.NoError(t, err2) {
 					assert.Equal(t, int64(3), v1.Export())
 					assert.Equal(t, int64(6), v2.Export())
@@ -623,7 +623,7 @@ func TestElements(t *testing.T) {
 	})
 	t.Run("VideoElement", func(t *testing.T) {
 		t.Run("text tracks", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("#video1").get(0).textTracks()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("#video1").get(0).textTracks()`); assert.NoError(t, err) {
 				assert.Equal(t, 2, len(v.Export().([]goja.Value)))
 				assert.Equal(t, "trk1", v.Export().([]goja.Value)[0].Export().(TrackElement).Id())
 				assert.Equal(t, "trk2", v.Export().([]goja.Value)[1].Export().(TrackElement).Id())
@@ -632,7 +632,7 @@ func TestElements(t *testing.T) {
 	})
 	t.Run("TitleElement", func(t *testing.T) {
 		t.Run("text tracks", func(t *testing.T) {
-			if v, err := common.RunString(rt, `doc.find("title").get(0).text()`); assert.NoError(t, err) {
+			if v, err := rt.RunString(`doc.find("title").get(0).text()`); assert.NoError(t, err) {
 				assert.Equal(t, "titletest", v.Export())
 			}
 		})

--- a/js/modules/k6/html/html_test.go
+++ b/js/modules/k6/html/html_test.go
@@ -73,12 +73,12 @@ func TestParseHTML(t *testing.T) {
 	// TODO: I literally cannot think of a snippet that makes goquery error.
 	// I'm not sure if it's even possible without like, an invalid reader or something, which would
 	// be impossible to cause from the JS side.
-	_, err := common.RunString(rt, `var doc = html.parseHTML(src)`)
+	_, err := rt.RunString(`var doc = html.parseHTML(src)`)
 	assert.NoError(t, err)
 	assert.IsType(t, Selection{}, rt.Get("doc").Export())
 
 	t.Run("Find", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("h1")`)
+		v, err := rt.RunString(`doc.find("h1")`)
 		if assert.NoError(t, err) && assert.IsType(t, Selection{}, v.Export()) {
 			sel := v.Export().(Selection).sel
 			assert.Equal(t, 1, sel.Length())
@@ -87,7 +87,7 @@ func TestParseHTML(t *testing.T) {
 	})
 	t.Run("Add", func(t *testing.T) {
 		t.Run("Selector", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("h1").add("footer")`)
+			v, err := rt.RunString(`doc.find("h1").add("footer")`)
 			if assert.NoError(t, err) && assert.IsType(t, Selection{}, v.Export()) {
 				sel := v.Export().(Selection).sel
 				assert.Equal(t, 2, sel.Length())
@@ -95,7 +95,7 @@ func TestParseHTML(t *testing.T) {
 			}
 		})
 		t.Run("Selection", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("h1").add(doc.find("footer"))`)
+			v, err := rt.RunString(`doc.find("h1").add(doc.find("footer"))`)
 			if assert.NoError(t, err) && assert.IsType(t, Selection{}, v.Export()) {
 				sel := v.Export().(Selection).sel
 				assert.Equal(t, 2, sel.Length())
@@ -104,30 +104,30 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("Text", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("h1").text()`)
+		v, err := rt.RunString(`doc.find("h1").text()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "Lorem ipsum", v.Export())
 		}
 	})
 	t.Run("Attr", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("h1").attr("id")`)
+		v, err := rt.RunString(`doc.find("h1").attr("id")`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "top", v.Export())
 		}
 		t.Run("Default", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("h1").attr("id", "default")`)
+			v, err := rt.RunString(`doc.find("h1").attr("id", "default")`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, "top", v.Export())
 			}
 		})
 		t.Run("Unset", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("h1").attr("class")`)
+			v, err := rt.RunString(`doc.find("h1").attr("class")`)
 			if assert.NoError(t, err) {
 				assert.True(t, goja.IsUndefined(v), "v is not undefined: %v", v)
 			}
 
 			t.Run("Default", func(t *testing.T) {
-				v, err := common.RunString(rt, `doc.find("h1").attr("class", "default")`)
+				v, err := rt.RunString(`doc.find("h1").attr("class", "default")`)
 				if assert.NoError(t, err) {
 					assert.Equal(t, "default", v.Export())
 				}
@@ -135,38 +135,38 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("Html", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("h1").html()`)
+		v, err := rt.RunString(`doc.find("h1").html()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "Lorem ipsum", v.Export())
 		}
 	})
 	t.Run("Val", func(t *testing.T) {
 		t.Run("Input", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("#text_input").val()`)
+			v, err := rt.RunString(`doc.find("#text_input").val()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, "input-text-value", v.Export())
 			}
 		})
 		t.Run("Select option[selected]", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("#select_one option[selected]").val()`)
+			v, err := rt.RunString(`doc.find("#select_one option[selected]").val()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, "yes this option", v.Export())
 			}
 		})
 		t.Run("Select Option Attr", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("#select_one").val()`)
+			v, err := rt.RunString(`doc.find("#select_one").val()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, "yes this option", v.Export())
 			}
 		})
 		t.Run("Select Option Text", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("#select_text").val()`)
+			v, err := rt.RunString(`doc.find("#select_text").val()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, "yes text", v.Export())
 			}
 		})
 		t.Run("Select Option Multiple", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("#select_multi").val()`)
+			v, err := rt.RunString(`doc.find("#select_multi").val()`)
 			var opts []string
 			if assert.NoError(t, err) && rt.ExportTo(v, &opts) == nil {
 				assert.Equal(t, 2, len(opts))
@@ -175,7 +175,7 @@ func TestParseHTML(t *testing.T) {
 			}
 		})
 		t.Run("TextArea", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("#textarea").val()`)
+			v, err := rt.RunString(`doc.find("#textarea").val()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, "Lorem ipsum dolor sit amet", v.Export())
 			}
@@ -183,7 +183,7 @@ func TestParseHTML(t *testing.T) {
 	})
 	t.Run("Children", func(t *testing.T) {
 		t.Run("All", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("head").children()`)
+			v, err := rt.RunString(`doc.find("head").children()`)
 			if assert.NoError(t, err) {
 				sel := v.Export().(Selection).sel
 				assert.Equal(t, 1, sel.Length())
@@ -191,7 +191,7 @@ func TestParseHTML(t *testing.T) {
 			}
 		})
 		t.Run("With selector", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("body").children("p")`)
+			v, err := rt.RunString(`doc.find("body").children("p")`)
 			if assert.NoError(t, err) {
 				sel := v.Export().(Selection).sel
 				assert.Equal(t, 2, sel.Length())
@@ -200,13 +200,13 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("Closest", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("textarea").closest("form").attr("id")`)
+		v, err := rt.RunString(`doc.find("textarea").closest("form").attr("id")`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "form1", v.Export())
 		}
 	})
 	t.Run("Contents", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("head").contents()`)
+		v, err := rt.RunString(`doc.find("head").contents()`)
 		if assert.NoError(t, err) {
 			sel := v.Export().(Selection).sel
 			assert.Equal(t, 3, sel.Length())
@@ -215,7 +215,7 @@ func TestParseHTML(t *testing.T) {
 	})
 	t.Run("Each", func(t *testing.T) {
 		t.Run("Func arg", func(t *testing.T) {
-			v, err := common.RunString(rt, `{ var elems = []; doc.find("#select_multi option").each(function(idx, elem) { elems[idx] = elem.innerHTML(); }); elems }`)
+			v, err := rt.RunString(`{ var elems = []; doc.find("#select_multi option").each(function(idx, elem) { elems[idx] = elem.innerHTML(); }); elems }`)
 			var elems []string
 			if assert.NoError(t, err) && rt.ExportTo(v, &elems) == nil {
 				assert.Equal(t, 3, len(elems))
@@ -224,7 +224,7 @@ func TestParseHTML(t *testing.T) {
 			}
 		})
 		t.Run("Invalid arg", func(t *testing.T) {
-			_, err := common.RunString(rt, `doc.find("#select_multi option").each("");`)
+			_, err := rt.RunString(`doc.find("#select_multi option").each("");`)
 			if assert.Error(t, err) {
 				assert.IsType(t, &goja.Exception{}, err)
 				assert.Contains(t, err.Error(), "must be a function")
@@ -233,19 +233,19 @@ func TestParseHTML(t *testing.T) {
 	})
 	t.Run("Is", func(t *testing.T) {
 		t.Run("String selector", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("h1").is("h1")`)
+			v, err := rt.RunString(`doc.find("h1").is("h1")`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, true, v.Export())
 			}
 		})
 		t.Run("Function selector", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("h1").is(function(idx, val){ return val.text() == "Lorem ipsum" })`)
+			v, err := rt.RunString(`doc.find("h1").is(function(idx, val){ return val.text() == "Lorem ipsum" })`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, true, v.Export())
 			}
 		})
 		t.Run("Selection selector", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("body").children().first().is(doc.find("h1"))`)
+			v, err := rt.RunString(`doc.find("body").children().first().is(doc.find("h1"))`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, true, v.Export())
 			}
@@ -253,21 +253,21 @@ func TestParseHTML(t *testing.T) {
 	})
 	t.Run("Filter", func(t *testing.T) {
 		t.Run("String", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("body").children().filter("p")`)
+			v, err := rt.RunString(`doc.find("body").children().filter("p")`)
 			if assert.NoError(t, err) {
 				sel := v.Export().(Selection).sel
 				assert.Equal(t, 2, sel.Length())
 			}
 		})
 		t.Run("Function", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("body").children().filter(function(idx, val){ return val.is("p") })`)
+			v, err := rt.RunString(`doc.find("body").children().filter(function(idx, val){ return val.is("p") })`)
 			if assert.NoError(t, err) {
 				sel := v.Export().(Selection).sel
 				assert.Equal(t, 2, sel.Length())
 			}
 		})
 		t.Run("Selection", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("body").children().filter(doc.find("p"))`)
+			v, err := rt.RunString(`doc.find("body").children().filter(doc.find("p"))`)
 			if assert.NoError(t, err) {
 				sel := v.Export().(Selection).sel
 				assert.Equal(t, 2, sel.Length())
@@ -275,39 +275,39 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("End", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("body").children().filter("p").end()`)
+		v, err := rt.RunString(`doc.find("body").children().filter("p").end()`)
 		if assert.NoError(t, err) {
 			sel := v.Export().(Selection).sel
 			assert.Equal(t, 5, sel.Length())
 		}
 	})
 	t.Run("Eq", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("body").children().eq(3).attr("id")`)
+		v, err := rt.RunString(`doc.find("body").children().eq(3).attr("id")`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "form1", v.Export())
 		}
 	})
 	t.Run("First", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("body").children().first().attr("id")`)
+		v, err := rt.RunString(`doc.find("body").children().first().attr("id")`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "top", v.Export())
 		}
 	})
 	t.Run("Last", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("body").children().last().text()`)
+		v, err := rt.RunString(`doc.find("body").children().last().text()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "This is the footer.", v.Export())
 		}
 	})
 	t.Run("Has", func(t *testing.T) {
 		t.Run("String selector", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("body").children().has("input").size()`)
+			v, err := rt.RunString(`doc.find("body").children().has("input").size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(1), v.Export())
 			}
 		})
 		t.Run("Selection selector", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("body").children().has(doc.find("input")).size()`)
+			v, err := rt.RunString(`doc.find("body").children().has(doc.find("input")).size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(1), v.Export())
 			}
@@ -315,7 +315,7 @@ func TestParseHTML(t *testing.T) {
 	})
 	t.Run("Map", func(t *testing.T) {
 		t.Run("Valid", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("#select_multi option").map(function(idx, val) { return val.text() })`)
+			v, err := rt.RunString(`doc.find("#select_multi option").map(function(idx, val) { return val.text() })`)
 			if assert.NoError(t, err) {
 				mapped := v.Export().([]string)
 				assert.Equal(t, 3, len(mapped))
@@ -323,14 +323,14 @@ func TestParseHTML(t *testing.T) {
 			}
 		})
 		t.Run("Invalid arg", func(t *testing.T) {
-			_, err := common.RunString(rt, `doc.find("#select_multi option").map("");`)
+			_, err := rt.RunString(`doc.find("#select_multi option").map("");`)
 			if assert.Error(t, err) {
 				assert.IsType(t, &goja.Exception{}, err)
 				assert.Contains(t, err.Error(), "must be a function")
 			}
 		})
 		t.Run("Map with attr must return string", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("#select_multi").map(function(idx, val) { return val.attr("name") })`)
+			v, err := rt.RunString(`doc.find("#select_multi").map(function(idx, val) { return val.attr("name") })`)
 			if assert.NoError(t, err) {
 				mapped := v.Export().([]string)
 				assert.Equal(t, 1, len(mapped))
@@ -340,7 +340,7 @@ func TestParseHTML(t *testing.T) {
 	})
 	t.Run("Next", func(t *testing.T) {
 		t.Run("No arg", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("h1").next()`)
+			v, err := rt.RunString(`doc.find("h1").next()`)
 			if assert.NoError(t, err) {
 				sel := v.Export().(Selection).sel
 				assert.Equal(t, 1, sel.Length())
@@ -348,7 +348,7 @@ func TestParseHTML(t *testing.T) {
 			}
 		})
 		t.Run("Filter arg", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("p").next("form")`)
+			v, err := rt.RunString(`doc.find("p").next("form")`)
 			if assert.NoError(t, err) {
 				sel := v.Export().(Selection).sel
 				assert.Equal(t, 1, sel.Length())
@@ -357,14 +357,14 @@ func TestParseHTML(t *testing.T) {
 	})
 	t.Run("NextAll", func(t *testing.T) {
 		t.Run("No arg", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("h1").nextAll()`)
+			v, err := rt.RunString(`doc.find("h1").nextAll()`)
 			if assert.NoError(t, err) {
 				sel := v.Export().(Selection).sel
 				assert.Equal(t, 4, sel.Length())
 			}
 		})
 		t.Run("Filter arg", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("h1").nextAll("p")`)
+			v, err := rt.RunString(`doc.find("h1").nextAll("p")`)
 			if assert.NoError(t, err) {
 				sel := v.Export().(Selection).sel
 				assert.Equal(t, 2, sel.Length())
@@ -373,14 +373,14 @@ func TestParseHTML(t *testing.T) {
 	})
 	t.Run("Prev", func(t *testing.T) {
 		t.Run("No arg", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("footer").prev()`)
+			v, err := rt.RunString(`doc.find("footer").prev()`)
 			if assert.NoError(t, err) {
 				sel := v.Export().(Selection).sel
 				assert.True(t, sel.Is("form"))
 			}
 		})
 		t.Run("Filter arg", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("footer").prev("form")`)
+			v, err := rt.RunString(`doc.find("footer").prev("form")`)
 			if assert.NoError(t, err) {
 				sel := v.Export().(Selection).sel
 				assert.Equal(t, 1, sel.Length())
@@ -389,14 +389,14 @@ func TestParseHTML(t *testing.T) {
 	})
 	t.Run("PrevAll", func(t *testing.T) {
 		t.Run("No arg", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("form").prevAll()`)
+			v, err := rt.RunString(`doc.find("form").prevAll()`)
 			if assert.NoError(t, err) {
 				sel := v.Export().(Selection).sel
 				assert.Equal(t, 3, sel.Length())
 			}
 		})
 		t.Run("Filter arg", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("form").prevAll("p")`)
+			v, err := rt.RunString(`doc.find("form").prevAll("p")`)
 			if assert.NoError(t, err) {
 				sel := v.Export().(Selection).sel
 				assert.Equal(t, 2, sel.Length())
@@ -405,37 +405,37 @@ func TestParseHTML(t *testing.T) {
 	})
 	t.Run("PrevUntil", func(t *testing.T) {
 		t.Run("String", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("footer").prevUntil("h1").size()`)
+			v, err := rt.RunString(`doc.find("footer").prevUntil("h1").size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(3), v.Export())
 			}
 		})
 		t.Run("Query", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("footer").prevUntil(doc.find("h1")).size()`)
+			v, err := rt.RunString(`doc.find("footer").prevUntil(doc.find("h1")).size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(3), v.Export())
 			}
 		})
 		t.Run("String filtered", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("form").prevUntil("h1", "p").size()`)
+			v, err := rt.RunString(`doc.find("form").prevUntil("h1", "p").size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(2), v.Export())
 			}
 		})
 		t.Run("Query filtered", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("form").prevUntil(doc.find("h1"), "p").size()`)
+			v, err := rt.RunString(`doc.find("form").prevUntil(doc.find("h1"), "p").size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(2), v.Export())
 			}
 		})
 		t.Run("All", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("footer").prevUntil().size()`)
+			v, err := rt.RunString(`doc.find("footer").prevUntil().size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(4), v.Export())
 			}
 		})
 		t.Run("All filtered", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("footer").prevUntil(null, "p").size()`)
+			v, err := rt.RunString(`doc.find("footer").prevUntil(null, "p").size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(2), v.Export())
 			}
@@ -443,37 +443,37 @@ func TestParseHTML(t *testing.T) {
 	})
 	t.Run("NextUntil", func(t *testing.T) {
 		t.Run("String", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("h1").nextUntil("footer").size()`)
+			v, err := rt.RunString(`doc.find("h1").nextUntil("footer").size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(3), v.Export())
 			}
 		})
 		t.Run("Query", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("h1").nextUntil(doc.find("footer")).size()`)
+			v, err := rt.RunString(`doc.find("h1").nextUntil(doc.find("footer")).size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(3), v.Export())
 			}
 		})
 		t.Run("String filtered", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("h1").nextUntil("footer", "p").size()`)
+			v, err := rt.RunString(`doc.find("h1").nextUntil("footer", "p").size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(2), v.Export())
 			}
 		})
 		t.Run("Query filtered", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("h1").nextUntil(doc.find("footer"), "p").size()`)
+			v, err := rt.RunString(`doc.find("h1").nextUntil(doc.find("footer"), "p").size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(2), v.Export())
 			}
 		})
 		t.Run("All", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("h1").nextUntil().size()`)
+			v, err := rt.RunString(`doc.find("h1").nextUntil().size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(4), v.Export())
 			}
 		})
 		t.Run("All filtered", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("h1").nextUntil(null, "p").size()`)
+			v, err := rt.RunString(`doc.find("h1").nextUntil(null, "p").size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(2), v.Export())
 			}
@@ -481,13 +481,13 @@ func TestParseHTML(t *testing.T) {
 	})
 	t.Run("Parent", func(t *testing.T) {
 		t.Run("No filter", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("textarea").parent().attr("id")`)
+			v, err := rt.RunString(`doc.find("textarea").parent().attr("id")`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, "form1", v.Export())
 			}
 		})
 		t.Run("Filtered", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("textarea").parent("form").attr("id")`)
+			v, err := rt.RunString(`doc.find("textarea").parent("form").attr("id")`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, "form1", v.Export())
 			}
@@ -495,13 +495,13 @@ func TestParseHTML(t *testing.T) {
 	})
 	t.Run("Parents", func(t *testing.T) {
 		t.Run("No filter", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("textarea").parents().size()`)
+			v, err := rt.RunString(`doc.find("textarea").parents().size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(3), v.Export())
 			}
 		})
 		t.Run("Filtered", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("textarea").parents("body").size()`)
+			v, err := rt.RunString(`doc.find("textarea").parents("body").size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(1), v.Export())
 			}
@@ -509,37 +509,37 @@ func TestParseHTML(t *testing.T) {
 	})
 	t.Run("ParentsUntil", func(t *testing.T) {
 		t.Run("String", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("textarea").parentsUntil("html").size()`)
+			v, err := rt.RunString(`doc.find("textarea").parentsUntil("html").size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(2), v.Export())
 			}
 		})
 		t.Run("Query", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("textarea").parentsUntil(doc.find("html")).size()`)
+			v, err := rt.RunString(`doc.find("textarea").parentsUntil(doc.find("html")).size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(2), v.Export())
 			}
 		})
 		t.Run("String filtered", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("textarea").parentsUntil("html", "body").size()`)
+			v, err := rt.RunString(`doc.find("textarea").parentsUntil("html", "body").size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(1), v.Export())
 			}
 		})
 		t.Run("Query filtered", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("textarea").parentsUntil(doc.find("html"), "body").size()`)
+			v, err := rt.RunString(`doc.find("textarea").parentsUntil(doc.find("html"), "body").size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(1), v.Export())
 			}
 		})
 		t.Run("All", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("textarea").parentsUntil().size()`)
+			v, err := rt.RunString(`doc.find("textarea").parentsUntil().size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(3), v.Export())
 			}
 		})
 		t.Run("All filtered", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("textarea").parentsUntil(null, "body").size()`)
+			v, err := rt.RunString(`doc.find("textarea").parentsUntil(null, "body").size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(1), v.Export())
 			}
@@ -547,19 +547,19 @@ func TestParseHTML(t *testing.T) {
 	})
 	t.Run("Not", func(t *testing.T) {
 		t.Run("String selector", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("body").children().not("p").size()`)
+			v, err := rt.RunString(`doc.find("body").children().not("p").size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(3), v.Export())
 			}
 		})
 		t.Run("Selection selector", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("body").children().not(doc.find("p")).size()`)
+			v, err := rt.RunString(`doc.find("body").children().not(doc.find("p")).size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(3), v.Export())
 			}
 		})
 		t.Run("Function selector", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("body").children().not(function(idx, val){ return val.is("p") }).size()`)
+			v, err := rt.RunString(`doc.find("body").children().not(function(idx, val){ return val.is("p") }).size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(3), v.Export())
 			}
@@ -567,13 +567,13 @@ func TestParseHTML(t *testing.T) {
 	})
 	t.Run("Siblings", func(t *testing.T) {
 		t.Run("No filter", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("form").siblings().size()`)
+			v, err := rt.RunString(`doc.find("form").siblings().size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(4), v.Export())
 			}
 		})
 		t.Run("Filtered", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("form").siblings("p").size()`)
+			v, err := rt.RunString(`doc.find("form").siblings("p").size()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(2), v.Export())
 			}
@@ -581,7 +581,7 @@ func TestParseHTML(t *testing.T) {
 	})
 	t.Run("Slice", func(t *testing.T) {
 		t.Run("No filter", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("body").children().slice(1, 2)`)
+			v, err := rt.RunString(`doc.find("body").children().slice(1, 2)`)
 			if assert.NoError(t, err) {
 				sel := v.Export().(Selection).sel
 				assert.Equal(t, 1, sel.Length())
@@ -590,7 +590,7 @@ func TestParseHTML(t *testing.T) {
 			}
 		})
 		t.Run("Filtered", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("body").children().slice(3)`)
+			v, err := rt.RunString(`doc.find("body").children().slice(3)`)
 			if assert.NoError(t, err) {
 				sel := v.Export().(Selection).sel
 				assert.Equal(t, 2, sel.Length())
@@ -600,7 +600,7 @@ func TestParseHTML(t *testing.T) {
 	})
 	t.Run("Get", func(t *testing.T) {
 		t.Run("No args", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("body").children().get()`)
+			v, err := rt.RunString(`doc.find("body").children().get()`)
 			if assert.NoError(t, err) {
 				elems := v.Export().([]goja.Value)
 
@@ -610,14 +610,14 @@ func TestParseHTML(t *testing.T) {
 			}
 		})
 		t.Run("+ve index", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("body").children().get(1)`)
+			v, err := rt.RunString(`doc.find("body").children().get(1)`)
 			if assert.NoError(t, err) {
 				elem, _ := v.Export().(Element)
 				assert.Contains(t, elem.InnerHTML(), "Lorem ipsum dolor sit amet")
 			}
 		})
 		t.Run("-ve index", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("body").children().get(-1)`)
+			v, err := rt.RunString(`doc.find("body").children().get(-1)`)
 			if assert.NoError(t, err) {
 				elem, _ := v.Export().(Element)
 				assert.Equal(t, "This is the footer.", elem.InnerHTML().String())
@@ -625,7 +625,7 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("ToArray", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("p").toArray()`)
+		v, err := rt.RunString(`doc.find("p").toArray()`)
 		if assert.NoError(t, err) {
 			arr := v.Export().([]Selection)
 			assert.Equal(t, 2, len(arr))
@@ -637,19 +637,19 @@ func TestParseHTML(t *testing.T) {
 	})
 	t.Run("Index", func(t *testing.T) {
 		t.Run("No args", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("p").index()`)
+			v, err := rt.RunString(`doc.find("p").index()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(1), v.Export())
 			}
 		})
 		t.Run("String selector", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("form").index("body > *")`)
+			v, err := rt.RunString(`doc.find("form").index("body > *")`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(3), v.Export())
 			}
 		})
 		t.Run("Selection selector", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("body").children().index(doc.find("footer"))`)
+			v, err := rt.RunString(`doc.find("body").children().index(doc.find("footer"))`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(4), v.Export())
 			}
@@ -657,37 +657,37 @@ func TestParseHTML(t *testing.T) {
 	})
 	t.Run("Data <h1>", func(t *testing.T) {
 		t.Run("string attr", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("h1").data("test")`)
+			v, err := rt.RunString(`doc.find("h1").data("test")`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, "dataval", v.Export())
 			}
 		})
 		t.Run("numeric attr 1", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("h1").data("num-a")`)
+			v, err := rt.RunString(`doc.find("h1").data("num-a")`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(123), v.Export())
 			}
 		})
 		t.Run("numeric attr 2", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("h1").data("num-b")`)
+			v, err := rt.RunString(`doc.find("h1").data("num-b")`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, float64(1.5), v.Export())
 			}
 		})
 		t.Run("not numeric attr 1", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("h1").data("not-num-a")`)
+			v, err := rt.RunString(`doc.find("h1").data("not-num-a")`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, "1.50", v.Export())
 			}
 		})
 		t.Run("not numeric attr 2", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("h1").data("not-num-b")`)
+			v, err := rt.RunString(`doc.find("h1").data("not-num-b")`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, "1.1e02", v.Export())
 			}
 		})
 		t.Run("dataset", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("h1").data()`)
+			v, err := rt.RunString(`doc.find("h1").data()`)
 			if assert.NoError(t, err) {
 				data := v.Export().(map[string]interface{})
 				assert.Equal(t, "dataval", data["test"])
@@ -697,37 +697,37 @@ func TestParseHTML(t *testing.T) {
 	})
 	t.Run("Data <p>", func(t *testing.T) {
 		t.Run("boolean attr", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("p").data("test-b")`)
+			v, err := rt.RunString(`doc.find("p").data("test-b")`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, true, v.Export())
 			}
 		})
 		t.Run("snakeCase attr name", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("p").data("testB")`)
+			v, err := rt.RunString(`doc.find("p").data("testB")`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, true, v.Export())
 			}
 		})
 		t.Run("empty string", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("p").data("test-empty")`)
+			v, err := rt.RunString(`doc.find("p").data("test-empty")`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, nil, v.Export())
 			}
 		})
 		t.Run("json attr", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("p").data("opts").id`)
+			v, err := rt.RunString(`doc.find("p").data("opts").id`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(101), v.Export())
 			}
 		})
 		t.Run("dataset property", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("p").data().testB`)
+			v, err := rt.RunString(`doc.find("p").data().testB`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, true, v.Export())
 			}
 		})
 		t.Run("dataset object", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("p").data().opts.id`)
+			v, err := rt.RunString(`doc.find("p").data().opts.id`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, int64(101), v.Export())
 			}

--- a/js/modules/k6/html/serialize_test.go
+++ b/js/modules/k6/html/serialize_test.go
@@ -75,13 +75,13 @@ func TestSerialize(t *testing.T) {
 	rt.Set("src", testSerializeHTML)
 	rt.Set("html", common.Bind(rt, New(), &ctx))
 
-	_, err := common.RunString(rt, `var doc = html.parseHTML(src)`)
+	_, err := rt.RunString(`var doc = html.parseHTML(src)`)
 	assert.NoError(t, err)
 	assert.IsType(t, Selection{}, rt.Get("doc").Export())
 
 	t.Run("SerializeArray", func(t *testing.T) {
 		t.Run("form", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("form").serializeArray()`)
+			v, err := rt.RunString(`doc.find("form").serializeArray()`)
 			if assert.NoError(t, err) {
 				arr := v.Export().([]FormValue)
 				assert.Equal(t, 11, len(arr))
@@ -125,7 +125,7 @@ func TestSerialize(t *testing.T) {
 		})
 
 		t.Run("controls", func(t *testing.T) {
-			v, err := common.RunString(rt, `doc.find("input").serializeArray()`)
+			v, err := rt.RunString(`doc.find("input").serializeArray()`)
 			if assert.NoError(t, err) {
 				arr := v.Export().([]FormValue)
 				assert.Equal(t, 7, len(arr))
@@ -155,7 +155,7 @@ func TestSerialize(t *testing.T) {
 	})
 
 	t.Run("SerializeObject", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("form").serializeObject()`)
+		v, err := rt.RunString(`doc.find("form").serializeObject()`)
 		if assert.NoError(t, err) {
 			obj := v.Export().(map[string]goja.Value)
 			assert.Equal(t, 11, len(obj))
@@ -178,7 +178,7 @@ func TestSerialize(t *testing.T) {
 	})
 
 	t.Run("Serialize", func(t *testing.T) {
-		v, err := common.RunString(rt, `doc.find("form").serialize()`)
+		v, err := rt.RunString(`doc.find("form").serialize()`)
 		if assert.NoError(t, err) {
 			url := v.String()
 			assert.Equal(t, "checkbox1=some+checkbox"+

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -66,7 +66,7 @@ func runES6String(tb testing.TB, rt *goja.Runtime, src string) (goja.Value, erro
 		return goja.Undefined(), err
 	}
 
-	return common.RunString(rt, src)
+	return rt.RunString(src)
 }
 
 func TestRunES6String(t *testing.T) {
@@ -190,7 +190,7 @@ func TestRequestAndBatch(t *testing.T) {
 
 	t.Run("Redirects", func(t *testing.T) {
 		t.Run("tracing", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 			var res = http.get("HTTPBIN_URL/redirect/9");
 			`))
 			assert.NoError(t, err)
@@ -215,11 +215,11 @@ func TestRequestAndBatch(t *testing.T) {
 		})
 
 		t.Run("10", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`http.get("HTTPBIN_URL/redirect/10")`))
+			_, err := rt.RunString(sr(`http.get("HTTPBIN_URL/redirect/10")`))
 			assert.NoError(t, err)
 		})
 		t.Run("11", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 			var res = http.get("HTTPBIN_URL/redirect/11");
 			if (res.status != 302) { throw new Error("wrong status: " + res.status) }
 			if (res.url != "HTTPBIN_URL/relative-redirect/1") { throw new Error("incorrect URL: " + res.url) }
@@ -235,7 +235,7 @@ func TestRequestAndBatch(t *testing.T) {
 				defer func() { state.Options = oldOpts }()
 				state.Options.MaxRedirects = null.NewInt(10, false)
 
-				_, err := common.RunString(rt, sr(`
+				_, err := rt.RunString(sr(`
 				var res = http.get("HTTPBIN_URL/redirect/11");
 				if (res.status != 302) { throw new Error("wrong status: " + res.status) }
 				if (res.url != "HTTPBIN_URL/relative-redirect/1") { throw new Error("incorrect URL: " + res.url) }
@@ -252,7 +252,7 @@ func TestRequestAndBatch(t *testing.T) {
 			})
 		})
 		t.Run("requestScopeRedirects", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 			var res = http.get("HTTPBIN_URL/redirect/1", {redirects: 3});
 			if (res.status != 200) { throw new Error("wrong status: " + res.status) }
 			if (res.url != "HTTPBIN_URL/get") { throw new Error("incorrect URL: " + res.url) }
@@ -260,7 +260,7 @@ func TestRequestAndBatch(t *testing.T) {
 			assert.NoError(t, err)
 		})
 		t.Run("requestScopeNoRedirects", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 			var res = http.get("HTTPBIN_URL/redirect/1", {redirects: 0});
 			if (res.status != 302) { throw new Error("wrong status: " + res.status) }
 			if (res.url != "HTTPBIN_URL/redirect/1") { throw new Error("incorrect URL: " + res.url) }
@@ -275,7 +275,7 @@ func TestRequestAndBatch(t *testing.T) {
 				_, _ = io.Copy(ioutil.Discard, r.Body)
 				http.Redirect(w, r, sr("HTTPBIN_URL/post"), http.StatusPermanentRedirect)
 			}))
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 			var res = http.post("HTTPBIN_URL/post-redirect", "pesho", {redirects: 1});
 
 			if (res.status != 200) { throw new Error("wrong status: " + res.status) }
@@ -287,7 +287,7 @@ func TestRequestAndBatch(t *testing.T) {
 	})
 	t.Run("Timeout", func(t *testing.T) {
 		t.Run("10s", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				http.get("HTTPBIN_URL/delay/1", {
 					timeout: 5*1000,
 				})
@@ -299,7 +299,7 @@ func TestRequestAndBatch(t *testing.T) {
 			defer hook.Reset()
 
 			startTime := time.Now()
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				http.get("HTTPBIN_URL/delay/10", {
 					timeout: 1*1000,
 				})
@@ -317,7 +317,7 @@ func TestRequestAndBatch(t *testing.T) {
 			defer hook.Reset()
 
 			startTime := time.Now()
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				http.get("HTTPBIN_URL/delay/10", {
 					timeout: "1s",
 				})
@@ -332,7 +332,7 @@ func TestRequestAndBatch(t *testing.T) {
 		})
 	})
 	t.Run("UserAgent", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 			var res = http.get("HTTPBIN_URL/headers");
 			var headers = res.json()["headers"];
 			if (headers['User-Agent'] != "TestUserAgent") {
@@ -342,7 +342,7 @@ func TestRequestAndBatch(t *testing.T) {
 		assert.NoError(t, err)
 
 		t.Run("Override", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var res = http.get("HTTPBIN_URL/headers", {
 					headers: { "User-Agent": "OtherUserAgent" },
 				});
@@ -355,7 +355,7 @@ func TestRequestAndBatch(t *testing.T) {
 		})
 
 		t.Run("Override empty", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var res = http.get("HTTPBIN_URL/headers", {
 					headers: { "User-Agent": "" },
 				});
@@ -374,7 +374,7 @@ func TestRequestAndBatch(t *testing.T) {
 			}()
 
 			state.Options.UserAgent = null.NewString("", true)
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var res = http.get("HTTPBIN_URL/headers");
 				var headers = res.json()["headers"]
 				if (typeof headers['User-Agent'] !== 'undefined') {
@@ -391,7 +391,7 @@ func TestRequestAndBatch(t *testing.T) {
 			}()
 
 			state.Options.UserAgent = null.NewString("Default one", false)
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var res = http.get("HTTPBIN_URL/headers");
 				var headers = res.json()["headers"]
 				if (headers['User-Agent'] != "Default one") {
@@ -403,7 +403,7 @@ func TestRequestAndBatch(t *testing.T) {
 	})
 	t.Run("Compression", func(t *testing.T) {
 		t.Run("gzip", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var res = http.get("HTTPSBIN_IP_URL/gzip");
 				if (res.json()['gzipped'] != true) {
 					throw new Error("unexpected body data: " + res.json()['gzipped'])
@@ -412,7 +412,7 @@ func TestRequestAndBatch(t *testing.T) {
 			assert.NoError(t, err)
 		})
 		t.Run("deflate", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var res = http.get("HTTPBIN_URL/deflate");
 				if (res.json()['deflated'] != true) {
 					throw new Error("unexpected body data: " + res.json()['deflated'])
@@ -421,7 +421,7 @@ func TestRequestAndBatch(t *testing.T) {
 			assert.NoError(t, err)
 		})
 		t.Run("zstd", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var res = http.get("HTTPSBIN_IP_URL/zstd");
 				if (res.json()['compression'] != 'zstd') {
 					throw new Error("unexpected body data: " + res.json()['compression'])
@@ -430,7 +430,7 @@ func TestRequestAndBatch(t *testing.T) {
 			assert.NoError(t, err)
 		})
 		t.Run("brotli", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var res = http.get("HTTPSBIN_IP_URL/brotli");
 				if (res.json()['compression'] != 'br') {
 					throw new Error("unexpected body data: " + res.json()['compression'])
@@ -439,7 +439,7 @@ func TestRequestAndBatch(t *testing.T) {
 			assert.NoError(t, err)
 		})
 		t.Run("zstd-br", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var res = http.get("HTTPSBIN_IP_URL/zstd-br");
 				if (res.json()['compression'] != 'zstd, br') {
 					throw new Error("unexpected compression: " + res.json()['compression'])
@@ -455,7 +455,7 @@ func TestRequestAndBatch(t *testing.T) {
 				assert.NoError(t, err)
 			}))
 
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var res = http.get("HTTPBIN_URL/customcompression");
 				if (res.json()["custom"] != true) {
 					throw new Error("unexpected body data: " + res.body)
@@ -466,7 +466,7 @@ func TestRequestAndBatch(t *testing.T) {
 	})
 	t.Run("CompressionWithAcceptEncodingHeader", func(t *testing.T) {
 		t.Run("gzip", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var params = { headers: { "Accept-Encoding": "gzip" } };
 				var res = http.get("HTTPBIN_URL/gzip", params);
 				if (res.json()['gzipped'] != true) {
@@ -476,7 +476,7 @@ func TestRequestAndBatch(t *testing.T) {
 			assert.NoError(t, err)
 		})
 		t.Run("deflate", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var params = { headers: { "Accept-Encoding": "deflate" } };
 				var res = http.get("HTTPBIN_URL/deflate", params);
 				if (res.json()['deflated'] != true) {
@@ -496,13 +496,13 @@ func TestRequestAndBatch(t *testing.T) {
 		*ctx = newctx
 		defer func() { *ctx = oldctx }()
 
-		_, err := common.RunString(rt, sr(`http.get("HTTPBIN_URL/get/");`))
+		_, err := rt.RunString(sr(`http.get("HTTPBIN_URL/get/");`))
 		assert.Error(t, err)
 		assert.Nil(t, hook.LastEntry())
 	})
 	t.Run("HTTP/2", func(t *testing.T) {
 		stats.GetBufferedSamples(samples) // Clean up buffered samples from previous tests
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 		var res = http.request("GET", "HTTP2BIN_URL/get");
 		if (res.status != 200) { throw new Error("wrong status: " + res.status) }
 		if (res.proto != "HTTP/2.0") { throw new Error("wrong proto: " + res.proto) }
@@ -521,7 +521,7 @@ func TestRequestAndBatch(t *testing.T) {
 	})
 	t.Run("TLS", func(t *testing.T) {
 		t.Run("cert_expired", func(t *testing.T) {
-			_, err := common.RunString(rt, `http.get("https://expired.badssl.com/");`)
+			_, err := rt.RunString(`http.get("https://expired.badssl.com/");`)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "x509: certificate has expired or is not yet valid")
 		})
@@ -534,7 +534,7 @@ func TestRequestAndBatch(t *testing.T) {
 		}
 		for _, versionTest := range tlsVersionTests {
 			t.Run(versionTest.Name, func(t *testing.T) {
-				_, err := common.RunString(rt, fmt.Sprintf(`
+				_, err := rt.RunString(fmt.Sprintf(`
 					var res = http.get("%s");
 					if (res.tls_version != %s) { throw new Error("wrong TLS version: " + res.tls_version); }
 				`, versionTest.URL, versionTest.Version))
@@ -550,7 +550,7 @@ func TestRequestAndBatch(t *testing.T) {
 		}
 		for _, cipherSuiteTest := range tlsCipherSuiteTests {
 			t.Run(cipherSuiteTest.Name, func(t *testing.T) {
-				_, err := common.RunString(rt, fmt.Sprintf(`
+				_, err := rt.RunString(fmt.Sprintf(`
 					var res = http.get("%s");
 					if (res.tls_cipher_suite != "%s") { throw new Error("wrong TLS cipher suite: " + res.tls_cipher_suite); }
 				`, cipherSuiteTest.URL, cipherSuiteTest.CipherSuite))
@@ -560,7 +560,7 @@ func TestRequestAndBatch(t *testing.T) {
 		}
 		t.Run("ocsp_stapled_good", func(t *testing.T) {
 			website := "https://www.wikipedia.org/"
-			_, err := common.RunString(rt, fmt.Sprintf(`
+			_, err := rt.RunString(fmt.Sprintf(`
 			var res = http.request("GET", "%s");
 			if (res.ocsp.status != http.OCSP_STATUS_GOOD) { throw new Error("wrong ocsp stapled response status: " + res.ocsp.status); }
 			`, website))
@@ -572,7 +572,7 @@ func TestRequestAndBatch(t *testing.T) {
 		hook := logtest.NewLocal(state.Logger)
 		defer hook.Reset()
 
-		_, err := common.RunString(rt, `http.request("", "");`)
+		_, err := rt.RunString(`http.request("", "");`)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported protocol scheme")
 
@@ -583,7 +583,7 @@ func TestRequestAndBatch(t *testing.T) {
 			hook := logtest.NewLocal(state.Logger)
 			defer hook.Reset()
 
-			_, err := common.RunString(rt, `
+			_, err := rt.RunString(`
 				var res = http.request("GET", "some://example.com", null, { throw: false });
 				if (res.error.search('unsupported protocol scheme "some"')  == -1) {
 					throw new Error("wrong error:" + res.error);
@@ -602,14 +602,14 @@ func TestRequestAndBatch(t *testing.T) {
 		})
 	})
 	t.Run("Unroutable", func(t *testing.T) {
-		_, err := common.RunString(rt, `http.request("GET", "http://sdafsgdhfjg/");`)
+		_, err := rt.RunString(`http.request("GET", "http://sdafsgdhfjg/");`)
 		assert.Error(t, err)
 	})
 
 	t.Run("Params", func(t *testing.T) {
 		for _, literal := range []string{`undefined`, `null`} {
 			t.Run(literal, func(t *testing.T) {
-				_, err := common.RunString(rt, fmt.Sprintf(sr(`
+				_, err := rt.RunString(fmt.Sprintf(sr(`
 				var res = http.request("GET", "HTTPBIN_URL/headers", null, %s);
 				if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				`), literal))
@@ -623,7 +623,7 @@ func TestRequestAndBatch(t *testing.T) {
 				cookieJar, err := cookiejar.New(nil)
 				assert.NoError(t, err)
 				state.CookieJar = cookieJar
-				_, err = common.RunString(rt, sr(`
+				_, err = rt.RunString(sr(`
 				var res = http.request("GET", "HTTPBIN_URL/cookies/set?key=value", null, { redirects: 0 });
 				if (res.cookies.key[0].value != "value") { throw new Error("wrong cookie value: " + res.cookies.key[0].value); }
 				var props = ["name", "value", "domain", "path", "expires", "max_age", "secure", "http_only"];
@@ -645,7 +645,7 @@ func TestRequestAndBatch(t *testing.T) {
 				cookieJar, err := cookiejar.New(nil)
 				assert.NoError(t, err)
 				state.CookieJar = cookieJar
-				_, err = common.RunString(rt, sr(`
+				_, err = rt.RunString(sr(`
 				var jar = http.cookieJar();
 				jar.set("HTTPBIN_URL/cookies", "key", "value");
 				var res = http.request("GET", "HTTPBIN_URL/cookies", null, { cookies: { key2: "value2" } });
@@ -663,7 +663,7 @@ func TestRequestAndBatch(t *testing.T) {
 				cookieJar, err := cookiejar.New(nil)
 				assert.NoError(t, err)
 				state.CookieJar = cookieJar
-				_, err = common.RunString(rt, sr(`
+				_, err = rt.RunString(sr(`
 				var res = http.request("GET", "HTTPBIN_URL/cookies", null, { cookies: { key: "value" } });
 				if (res.json().key != "value") { throw new Error("wrong cookie value: " + res.json().key); }
 				var jar = http.cookieJar();
@@ -678,7 +678,7 @@ func TestRequestAndBatch(t *testing.T) {
 				cookieJar, err := cookiejar.New(nil)
 				assert.NoError(t, err)
 				state.CookieJar = cookieJar
-				_, err = common.RunString(rt, sr(`
+				_, err = rt.RunString(sr(`
 				var jar = http.cookieJar();
 				jar.set("HTTPBIN_URL/cookies", "key", "value");
 				var res = http.request("GET", "HTTPBIN_URL/cookies", null, { cookies: { key: { value: "replaced", replace: true } } });
@@ -707,7 +707,7 @@ func TestRequestAndBatch(t *testing.T) {
 					cookieJar, err := cookiejar.New(nil)
 					require.NoError(t, err)
 					state.CookieJar = cookieJar
-					_, err = common.RunString(rt, sr(`
+					_, err = rt.RunString(sr(`
 						var res = http.request("GET", "HTTPBIN_URL/redirect-to?url=HTTPSBIN_URL/set-cookie-without-redirect");
 						if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 					`))
@@ -733,7 +733,7 @@ func TestRequestAndBatch(t *testing.T) {
 					cookieJar, err := cookiejar.New(nil)
 					require.NoError(t, err)
 					state.CookieJar = cookieJar
-					_, err = common.RunString(rt, sr(`
+					_, err = rt.RunString(sr(`
 						var res = http.request("GET", "HTTPSBIN_URL/cookies/set?key=value");
 						if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 					`))
@@ -774,7 +774,7 @@ func TestRequestAndBatch(t *testing.T) {
 						http.Redirect(w, r, sr("HTTPBIN_IP_URL/get"), http.StatusMovedPermanently)
 					}))
 
-					_, err = common.RunString(rt, sr(`
+					_, err = rt.RunString(sr(`
 						var res = http.request("GET", "HTTPBIN_IP_URL/redirect-to?url=HTTPSBIN_URL/set-cookie-and-redirect");
 						if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 					`))
@@ -809,7 +809,7 @@ func TestRequestAndBatch(t *testing.T) {
 				cookieJar, err := cookiejar.New(nil)
 				assert.NoError(t, err)
 				state.CookieJar = cookieJar
-				_, err = common.RunString(rt, sr(`
+				_, err = rt.RunString(sr(`
 				var jar = http.cookieJar();
 				jar.set("HTTPBIN_URL/cookies", "key", "value", { domain: "HTTPBIN_DOMAIN" });
 				var res = http.request("GET", "HTTPBIN_URL/cookies");
@@ -833,7 +833,7 @@ func TestRequestAndBatch(t *testing.T) {
 				cookieJar, err := cookiejar.New(nil)
 				assert.NoError(t, err)
 				state.CookieJar = cookieJar
-				_, err = common.RunString(rt, sr(`
+				_, err = rt.RunString(sr(`
 				var jar = http.cookieJar();
 				jar.set("HTTPBIN_URL/cookies", "key", "value", { path: "/cookies" });
 				var res = http.request("GET", "HTTPBIN_URL/cookies");
@@ -857,7 +857,7 @@ func TestRequestAndBatch(t *testing.T) {
 				cookieJar, err := cookiejar.New(nil)
 				assert.NoError(t, err)
 				state.CookieJar = cookieJar
-				_, err = common.RunString(rt, sr(`
+				_, err = rt.RunString(sr(`
 				var jar = http.cookieJar();
 				jar.set("HTTPBIN_URL/cookies", "key", "value", { expires: "Sun, 24 Jul 1983 17:01:02 GMT" });
 				var res = http.request("GET", "HTTPBIN_URL/cookies");
@@ -878,7 +878,7 @@ func TestRequestAndBatch(t *testing.T) {
 				cookieJar, err := cookiejar.New(nil)
 				assert.NoError(t, err)
 				state.CookieJar = cookieJar
-				_, err = common.RunString(rt, sr(`
+				_, err = rt.RunString(sr(`
 				var jar = http.cookieJar();
 				jar.set("HTTPSBIN_IP_URL/cookies", "key", "value", { secure: true });
 				var res = http.request("GET", "HTTPSBIN_IP_URL/cookies");
@@ -894,7 +894,7 @@ func TestRequestAndBatch(t *testing.T) {
 				cookieJar, err := cookiejar.New(nil)
 				assert.NoError(t, err)
 				state.CookieJar = cookieJar
-				_, err = common.RunString(rt, sr(`
+				_, err = rt.RunString(sr(`
 				var jar = new http.CookieJar();
 				jar.set("HTTPBIN_URL/cookies", "key", "value");
 				var res = http.request("GET", "HTTPBIN_URL/cookies", null, { cookies: { key2: "value2" }, jar: jar });
@@ -914,7 +914,7 @@ func TestRequestAndBatch(t *testing.T) {
 				url := sr("http://bob:pass@HTTPBIN_IP:HTTPBIN_PORT/basic-auth/bob/pass")
 				urlExpected := sr("http://****:****@HTTPBIN_IP:HTTPBIN_PORT/basic-auth/bob/pass")
 
-				_, err := common.RunString(rt, fmt.Sprintf(`
+				_, err := rt.RunString(fmt.Sprintf(`
 				var res = http.request("GET", "%s", null, {});
 				if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				`, url))
@@ -926,7 +926,7 @@ func TestRequestAndBatch(t *testing.T) {
 					url := sr("http://bob:pass@HTTPBIN_IP:HTTPBIN_PORT/digest-auth/auth/bob/pass")
 					urlRaw := sr("HTTPBIN_IP_URL/digest-auth/auth/bob/pass")
 
-					_, err := common.RunString(rt, fmt.Sprintf(`
+					_, err := rt.RunString(fmt.Sprintf(`
 					var res = http.request("GET", "%s", null, { auth: "digest" });
 					if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 					if (res.error_code != 0) { throw new Error("wrong error code: " + res.error_code); }
@@ -942,7 +942,7 @@ func TestRequestAndBatch(t *testing.T) {
 				t.Run("failure", func(t *testing.T) {
 					url := sr("http://bob:pass@HTTPBIN_IP:HTTPBIN_PORT/digest-auth/failure")
 
-					_, err := common.RunString(rt, fmt.Sprintf(`
+					_, err := rt.RunString(fmt.Sprintf(`
 					var res = http.request("GET", "%s", null, { auth: "digest", timeout: 1, throw: false });
 					`, url))
 					assert.NoError(t, err)
@@ -953,7 +953,7 @@ func TestRequestAndBatch(t *testing.T) {
 		t.Run("headers", func(t *testing.T) {
 			for _, literal := range []string{`null`, `undefined`} {
 				t.Run(literal, func(t *testing.T) {
-					_, err := common.RunString(rt, fmt.Sprintf(sr(`
+					_, err := rt.RunString(fmt.Sprintf(sr(`
 					var res = http.request("GET", "HTTPBIN_URL/headers", null, { headers: %s });
 					if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 					`), literal))
@@ -963,7 +963,7 @@ func TestRequestAndBatch(t *testing.T) {
 			}
 
 			t.Run("object", func(t *testing.T) {
-				_, err := common.RunString(rt, sr(`
+				_, err := rt.RunString(sr(`
 				var res = http.request("GET", "HTTPBIN_URL/headers", null, {
 					headers: { "X-My-Header": "value" },
 				});
@@ -975,7 +975,7 @@ func TestRequestAndBatch(t *testing.T) {
 			})
 
 			t.Run("Host", func(t *testing.T) {
-				_, err := common.RunString(rt, sr(`
+				_, err := rt.RunString(sr(`
 				var res = http.request("GET", "HTTPBIN_URL/headers", null, {
 					headers: { "Host": "HTTPBIN_DOMAIN" },
 				});
@@ -987,7 +987,7 @@ func TestRequestAndBatch(t *testing.T) {
 			})
 
 			t.Run("response_request", func(t *testing.T) {
-				_, err := common.RunString(rt, sr(`
+				_, err := rt.RunString(sr(`
 				var res = http.request("GET", "HTTPBIN_URL/headers", null, {
 					headers: { "host": "HTTPBIN_DOMAIN" },
 				});
@@ -999,7 +999,7 @@ func TestRequestAndBatch(t *testing.T) {
 			})
 
 			t.Run("differentHost", func(t *testing.T) {
-				_, err := common.RunString(rt, sr(`
+				_, err := rt.RunString(sr(`
 				var custHost = 'k6.io';
 				var res = http.request("GET", "HTTPBIN_URL/headers", null, {
 					headers: { "host": custHost },
@@ -1015,7 +1015,7 @@ func TestRequestAndBatch(t *testing.T) {
 		t.Run("tags", func(t *testing.T) {
 			for _, literal := range []string{`null`, `undefined`} {
 				t.Run(literal, func(t *testing.T) {
-					_, err := common.RunString(rt, fmt.Sprintf(sr(`
+					_, err := rt.RunString(fmt.Sprintf(sr(`
 					var res = http.request("GET", "HTTPBIN_URL/headers", null, { tags: %s });
 					if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 					`), literal))
@@ -1025,7 +1025,7 @@ func TestRequestAndBatch(t *testing.T) {
 			}
 
 			t.Run("name/none", func(t *testing.T) {
-				_, err := common.RunString(rt, sr(`
+				_, err := rt.RunString(sr(`
 					var res = http.request("GET", "HTTPBIN_URL/headers");
 					if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				`))
@@ -1035,7 +1035,7 @@ func TestRequestAndBatch(t *testing.T) {
 			})
 
 			t.Run("name/request", func(t *testing.T) {
-				_, err := common.RunString(rt, sr(`
+				_, err := rt.RunString(sr(`
 					var res = http.request("GET", "HTTPBIN_URL/headers", null, { tags: { name: "myReq" }});
 					if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				`))
@@ -1054,7 +1054,7 @@ func TestRequestAndBatch(t *testing.T) {
 			})
 
 			t.Run("object", func(t *testing.T) {
-				_, err := common.RunString(rt, sr(`
+				_, err := rt.RunString(sr(`
 				var res = http.request("GET", "HTTPBIN_URL/headers", null, { tags: { tag: "value" } });
 				if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				`))
@@ -1075,7 +1075,7 @@ func TestRequestAndBatch(t *testing.T) {
 				defer func() { state.Tags = oldTags }()
 				state.Tags = map[string]string{"runtag1": "val1", "runtag2": "val2"}
 
-				_, err := common.RunString(rt, sr(`
+				_, err := rt.RunString(sr(`
 				var res = http.request("GET", "HTTPBIN_URL/headers", null, { tags: { method: "test", name: "myName", runtag1: "fromreq" } });
 				if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				`))
@@ -1107,7 +1107,7 @@ func TestRequestAndBatch(t *testing.T) {
 	})
 
 	t.Run("GET", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 		var res = http.get("HTTPBIN_URL/get?a=1&b=2");
 		if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 		if (res.json().args.a != "1") { throw new Error("wrong ?a: " + res.json().args.a); }
@@ -1130,7 +1130,7 @@ func TestRequestAndBatch(t *testing.T) {
 		})
 	})
 	t.Run("HEAD", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 		var res = http.head("HTTPBIN_URL/get?a=1&b=2");
 		if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 		if (res.body.length != 0) { throw new Error("HEAD responses shouldn't have a body"); }
@@ -1141,7 +1141,7 @@ func TestRequestAndBatch(t *testing.T) {
 	})
 
 	t.Run("OPTIONS", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 		var res = http.options("HTTPBIN_URL/?a=1&b=2");
 		if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 		if (!res.headers["Access-Control-Allow-Methods"]) { throw new Error("Missing Access-Control-Allow-Methods header!"); }
@@ -1155,7 +1155,7 @@ func TestRequestAndBatch(t *testing.T) {
 	// https://stackoverflow.com/questions/299628/is-an-entity-body-allowed-for-an-http-delete-request
 	// https://tools.ietf.org/html/rfc7231#section-4.3.5
 	t.Run("DELETE", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 		var res = http.del("HTTPBIN_URL/delete?test=mest");
 		if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 		if (res.json().args.test != "mest") { throw new Error("wrong args: " + JSON.stringify(res.json().args)); }
@@ -1171,7 +1171,7 @@ func TestRequestAndBatch(t *testing.T) {
 	}
 	for method, fn := range postMethods {
 		t.Run(method, func(t *testing.T) {
-			_, err := common.RunString(rt, fmt.Sprintf(sr(`
+			_, err := rt.RunString(fmt.Sprintf(sr(`
 				var res = http.%s("HTTPBIN_URL/%s", "data");
 				if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				if (res.json().data != "data") { throw new Error("wrong data: " + res.json().data); }
@@ -1181,7 +1181,7 @@ func TestRequestAndBatch(t *testing.T) {
 			assertRequestMetricsEmitted(t, stats.GetBufferedSamples(samples), method, sr("HTTPBIN_URL/")+strings.ToLower(method), "", 200, "")
 
 			t.Run("object", func(t *testing.T) {
-				_, err := common.RunString(rt, fmt.Sprintf(sr(`
+				_, err := rt.RunString(fmt.Sprintf(sr(`
 				var res = http.%s("HTTPBIN_URL/%s", {a: "a", b: 2});
 				if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				if (res.json().form.a != "a") { throw new Error("wrong a=: " + res.json().form.a); }
@@ -1191,7 +1191,7 @@ func TestRequestAndBatch(t *testing.T) {
 				assert.NoError(t, err)
 				assertRequestMetricsEmitted(t, stats.GetBufferedSamples(samples), method, sr("HTTPBIN_URL/")+strings.ToLower(method), "", 200, "")
 				t.Run("Content-Type", func(t *testing.T) {
-					_, err := common.RunString(rt, fmt.Sprintf(sr(`
+					_, err := rt.RunString(fmt.Sprintf(sr(`
 						var res = http.%s("HTTPBIN_URL/%s", {a: "a", b: 2}, {headers: {"Content-Type": "application/x-www-form-urlencoded; charset=utf-8"}});
 						if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 						if (res.json().form.a != "a") { throw new Error("wrong a=: " + res.json().form.a); }
@@ -1207,11 +1207,11 @@ func TestRequestAndBatch(t *testing.T) {
 
 	t.Run("Batch", func(t *testing.T) {
 		t.Run("error", func(t *testing.T) {
-			_, err := common.RunString(rt, `var res = http.batch("https://somevalidurl.com");`)
+			_, err := rt.RunString(`var res = http.batch("https://somevalidurl.com");`)
 			require.Error(t, err)
 		})
 		t.Run("GET", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 			var reqs = [
 				["GET", "HTTPBIN_URL/"],
 				["GET", "HTTPBIN_IP_URL/"],
@@ -1245,7 +1245,7 @@ func TestRequestAndBatch(t *testing.T) {
 			})
 
 			t.Run("Shorthand", func(t *testing.T) {
-				_, err := common.RunString(rt, sr(`
+				_, err := rt.RunString(sr(`
 				var reqs = [
 					"HTTPBIN_URL/",
 					"HTTPBIN_IP_URL/",
@@ -1280,7 +1280,7 @@ func TestRequestAndBatch(t *testing.T) {
 			})
 
 			t.Run("ObjectForm", func(t *testing.T) {
-				_, err := common.RunString(rt, sr(`
+				_, err := rt.RunString(sr(`
 				var reqs = [
 					{ method: "GET", url: "HTTPBIN_URL/" },
 					{ url: "HTTPBIN_IP_URL/", method: "GET"},
@@ -1297,7 +1297,7 @@ func TestRequestAndBatch(t *testing.T) {
 			})
 
 			t.Run("ObjectKeys", func(t *testing.T) {
-				_, err := common.RunString(rt, sr(`
+				_, err := rt.RunString(sr(`
 				var reqs = {
 					shorthand: "HTTPBIN_URL/get?r=shorthand",
 					arr: ["GET", "HTTPBIN_URL/get?r=arr", null, {tags: {name: 'arr'}}],
@@ -1322,7 +1322,7 @@ func TestRequestAndBatch(t *testing.T) {
 				rt.Set("someStrFile", testStr)
 				rt.Set("someBinFile", []byte(testStr))
 
-				_, err := common.RunString(rt, sr(`
+				_, err := rt.RunString(sr(`
 					var reqs = [
 						["POST", "HTTPBIN_URL/post", "testbody"],
 						["POST", "HTTPBIN_URL/post", someStrFile],
@@ -1361,7 +1361,7 @@ func TestRequestAndBatch(t *testing.T) {
 			})
 		})
 		t.Run("POST", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 			var res = http.batch([ ["POST", "HTTPBIN_URL/post", { key: "value" }] ]);
 			for (var key in res) {
 				if (res[key].status != 200) { throw new Error("wrong status: " + key + ": " + res[key].status); }
@@ -1371,7 +1371,7 @@ func TestRequestAndBatch(t *testing.T) {
 			assertRequestMetricsEmitted(t, stats.GetBufferedSamples(samples), "POST", sr("HTTPBIN_URL/post"), "", 200, "")
 		})
 		t.Run("PUT", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 			var res = http.batch([ ["PUT", "HTTPBIN_URL/put", { key: "value" }] ]);
 			for (var key in res) {
 				if (res[key].status != 200) { throw new Error("wrong status: " + key + ": " + res[key].status); }
@@ -1384,7 +1384,7 @@ func TestRequestAndBatch(t *testing.T) {
 
 	t.Run("HTTPRequest", func(t *testing.T) {
 		t.Run("EmptyBody", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var reqUrl = "HTTPBIN_URL/cookies"
 				var res = http.get(reqUrl);
 				var jar = new http.CookieJar();
@@ -1406,7 +1406,7 @@ func TestRequestAndBatch(t *testing.T) {
 			assert.NoError(t, err)
 		})
 		t.Run("NonEmptyBody", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var res = http.post("HTTPBIN_URL/post", {a: "a", b: 2}, {headers: {"Content-Type": "application/x-www-form-urlencoded; charset=utf-8"}});
 				if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				if (res.request["body"] != "a=a&b=2") { throw new Error("http request body was not set properly: " + JSON.stringify(res.request))}
@@ -1442,7 +1442,7 @@ func TestRequestArrayBufferBody(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.arr, func(t *testing.T) {
-			_, err := common.RunString(rt, sr(fmt.Sprintf(`
+			_, err := rt.RunString(sr(fmt.Sprintf(`
 			var arr = new %[1]s([104, 101, 108, 108, 111]); // "hello"
 			var res = http.post("HTTPBIN_URL/post-arraybuffer", arr.buffer, { responseType: 'binary' });
 
@@ -1623,7 +1623,7 @@ func TestRequestCompression(t *testing.T) {
 
 		// TODO: move to some other test?
 		t.Run("correct length", func(t *testing.T) {
-			_, err := common.RunString(rt, tb.Replacer.Replace(
+			_, err := rt.RunString(tb.Replacer.Replace(
 				`http.post("HTTPBIN_URL/post", "0123456789", { "headers": {"Content-Length": "10"}});`,
 			))
 			require.NoError(t, err)
@@ -1631,7 +1631,7 @@ func TestRequestCompression(t *testing.T) {
 		})
 
 		t.Run("content-length is set", func(t *testing.T) {
-			_, err := common.RunString(rt, tb.Replacer.Replace(`
+			_, err := rt.RunString(tb.Replacer.Replace(`
 				var resp = http.post("HTTPBIN_URL/post", "0123456789");
 				if (resp.json().headers["Content-Length"][0] != "10") {
 					throw new Error("content-length not set: " + JSON.stringify(resp.json().headers));
@@ -1687,7 +1687,7 @@ func TestResponseTypes(t *testing.T) {
 		).Replace(tb.Replacer.Replace(s))
 	}
 
-	_, err := common.RunString(rt, replace(`
+	_, err := rt.RunString(replace(`
 		var expText = "EXP_TEXT";
 		var expBinLength = EXP_BIN_LEN;
 
@@ -1736,7 +1736,7 @@ func TestResponseTypes(t *testing.T) {
 	// Verify that if we enable discardResponseBodies globally, the default value is none
 	state.Options.DiscardResponseBodies = null.BoolFrom(true)
 
-	_, err = common.RunString(rt, replace(`
+	_, err = rt.RunString(replace(`
 		var expText = "EXP_TEXT";
 
 		// Check default behaviour
@@ -1860,8 +1860,7 @@ func TestErrorCodes(t *testing.T) {
 		// clear the Samples
 		stats.GetBufferedSamples(samples)
 		t.Run(testCase.name, func(t *testing.T) {
-			_, err := common.RunString(rt,
-				sr(testCase.script+"\n"+fmt.Sprintf(`
+			_, err := rt.RunString(sr(testCase.script + "\n" + fmt.Sprintf(`
 			if (res.status != %d) { throw new Error("wrong status: "+ res.status);}
 			if (res.error.indexOf(%q, 0) === -1) { throw new Error("wrong error: '" + res.error + "'");}
 			if (res.error_code != %d) { throw new Error("wrong error_code: "+ res.error_code);}
@@ -1909,7 +1908,7 @@ func TestResponseWaitingAndReceivingTimings(t *testing.T) {
 		assert.Equal(t, 10, n)
 	}))
 
-	_, err := common.RunString(rt, tb.Replacer.Replace(`
+	_, err := rt.RunString(tb.Replacer.Replace(`
 		var resp = http.get("HTTPBIN_URL/slow-response");
 
 		if (resp.timings.waiting < 1000) {
@@ -1935,7 +1934,7 @@ func TestResponseTimingsWhenTimeout(t *testing.T) {
 	// We expect a failed request
 	state.Options.Throw = null.BoolFrom(false)
 
-	_, err := common.RunString(rt, tb.Replacer.Replace(`
+	_, err := rt.RunString(tb.Replacer.Replace(`
 		var resp = http.get("HTTPBIN_URL/delay/10", { timeout: 2500 });
 
 		if (resp.timings.waiting < 2000) {
@@ -1957,7 +1956,7 @@ func TestNoResponseBodyMangling(t *testing.T) {
 	// We don't expect any failed requests
 	state.Options.Throw = null.BoolFrom(true)
 
-	_, err := common.RunString(rt, tb.Replacer.Replace(`
+	_, err := rt.RunString(tb.Replacer.Replace(`
 	    var batchSize = 100;
 
 		var requests = [];
@@ -1991,7 +1990,7 @@ func TestRedirectMetricTags(t *testing.T) {
 		http.post("HTTPBIN_URL/redirect/post", {data: "some data"});
 	`)
 
-	_, err := common.RunString(rt, script)
+	_, err := rt.RunString(script)
 	require.NoError(t, err)
 
 	require.Len(t, samples, 2)
@@ -2078,7 +2077,7 @@ func BenchmarkHandlingOfResponseBodies(b *testing.B) {
 		testCode := strings.Replace(testCodeTemplate, "TEST_RESPONSE_TYPE", responseType, -1)
 		return func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, err := common.RunString(rt, testCode)
+				_, err := rt.RunString(testCode)
 				if err != nil {
 					b.Error(err)
 				}
@@ -2105,7 +2104,7 @@ func TestErrorsWithDecompression(t *testing.T) {
 		_, _ = fmt.Fprintf(w, "Definitely not %s, but it's all cool...", enc)
 	}))
 
-	_, err := common.RunString(rt, tb.Replacer.Replace(`
+	_, err := rt.RunString(tb.Replacer.Replace(`
 		function handleResponseEncodingError (encoding) {
 			var resp = http.get("HTTPBIN_URL/broken-archive?encoding=" + encoding);
 			if (resp.error_code != 1701) {
@@ -2138,7 +2137,7 @@ func TestDigestAuthWithBody(t *testing.T) {
 		"http://testuser:testpwd@HTTPBIN_IP:HTTPBIN_PORT/digest-auth-with-post/auth/testuser/testpwd",
 	)
 
-	_, err := common.RunString(rt, fmt.Sprintf(`
+	_, err := rt.RunString(fmt.Sprintf(`
 		var res = http.post(%q, "super secret body", { auth: "digest" });
 		if (res.status !== 200) { throw new Error("wrong status: " + res.status); }
 		if (res.error_code !== 0) { throw new Error("wrong error code: " + res.error_code); }

--- a/js/modules/k6/http/response_test.go
+++ b/js/modules/k6/http/response_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/loadimpact/k6/js/common"
 	"github.com/loadimpact/k6/lib/netext/httpext"
 	"github.com/loadimpact/k6/stats"
 )
@@ -135,7 +134,7 @@ func TestResponse(t *testing.T) {
 	tb.Mux.HandleFunc("/invalidjson", invalidJSONHandler)
 
 	t.Run("Html", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 			var res = http.request("GET", "HTTPBIN_URL/html");
 			if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 			if (res.body.indexOf("Herman Melville - Moby-Dick") == -1) { throw new Error("wrong body: " + res.body); }
@@ -144,20 +143,20 @@ func TestResponse(t *testing.T) {
 		assertRequestMetricsEmitted(t, stats.GetBufferedSamples(samples), "GET", sr("HTTPBIN_URL/html"), "", 200, "")
 
 		t.Run("html", func(t *testing.T) {
-			_, err := common.RunString(rt, `
+			_, err := rt.RunString(`
 				if (res.html().find("h1").text() != "Herman Melville - Moby-Dick") { throw new Error("wrong title: " + res.body); }
 			`)
 			assert.NoError(t, err)
 
 			t.Run("shorthand", func(t *testing.T) {
-				_, err := common.RunString(rt, `
+				_, err := rt.RunString(`
 					if (res.html("h1").text() != "Herman Melville - Moby-Dick") { throw new Error("wrong title: " + res.body); }
 				`)
 				assert.NoError(t, err)
 			})
 
 			t.Run("url", func(t *testing.T) {
-				_, err := common.RunString(rt, sr(`
+				_, err := rt.RunString(sr(`
 					if (res.html().url != "HTTPBIN_URL/html") { throw new Error("url incorrect: " + res.html().url); }
 				`))
 				assert.NoError(t, err)
@@ -176,7 +175,7 @@ func TestResponse(t *testing.T) {
 				}()
 			}
 
-			_, err = common.RunString(rt, sr(`
+			_, err = rt.RunString(sr(`
 				var res = http.request("GET", "HTTPBIN_URL/html");
 				if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				if (res.body.indexOf("Herman Melville - Moby-Dick") == -1) { throw new Error("wrong body: " + res.body); }
@@ -186,7 +185,7 @@ func TestResponse(t *testing.T) {
 		})
 	})
 	t.Run("Json", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 			var res = http.request("GET", "HTTPBIN_URL/get?a=1&b=2");
 			if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 			if (res.json().args.a != "1") { throw new Error("wrong ?a: " + res.json().args.a); }
@@ -196,19 +195,19 @@ func TestResponse(t *testing.T) {
 		assertRequestMetricsEmitted(t, stats.GetBufferedSamples(samples), "GET", sr("HTTPBIN_URL/get?a=1&b=2"), "", 200, "")
 
 		t.Run("Invalid", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`http.request("GET", "HTTPBIN_URL/html").json();`))
+			_, err := rt.RunString(sr(`http.request("GET", "HTTPBIN_URL/html").json();`))
 			//nolint:lll
 			assert.Contains(t, err.Error(), "GoError: cannot parse json due to an error at line 1, character 2 , error: invalid character '<' looking for beginning of value")
 		})
 
 		t.Run("Invalid", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`http.request("GET", "HTTPBIN_URL/invalidjson").json();`))
+			_, err := rt.RunString(sr(`http.request("GET", "HTTPBIN_URL/invalidjson").json();`))
 			//nolint:lll
 			assert.Contains(t, err.Error(), "GoError: cannot parse json due to an error at line 3, character 9 , error: invalid character 'e' in literal true (expecting 'r')")
 		})
 	})
 	t.Run("JsonSelector", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 			var res = http.request("GET", "HTTPBIN_URL/json");
 			if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 
@@ -252,7 +251,7 @@ func TestResponse(t *testing.T) {
 
 	t.Run("SubmitForm", func(t *testing.T) {
 		t.Run("withoutArgs", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var res = http.request("GET", "HTTPBIN_URL/forms/post");
 				if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				res = res.submitForm()
@@ -271,7 +270,7 @@ func TestResponse(t *testing.T) {
 		})
 
 		t.Run("withFields", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var res = http.request("GET", "HTTPBIN_URL/forms/post");
 				if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				res = res.submitForm({ fields: { custname: "test", extradata: "test2" } })
@@ -290,7 +289,7 @@ func TestResponse(t *testing.T) {
 		})
 
 		t.Run("withRequestParams", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var res = http.request("GET", "HTTPBIN_URL/forms/post");
 				if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				res = res.submitForm({ params: { headers: { "My-Fancy-Header": "SomeValue" } }})
@@ -303,7 +302,7 @@ func TestResponse(t *testing.T) {
 		})
 
 		t.Run("withFormSelector", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var res = http.request("GET", "HTTPBIN_URL/forms/post");
 				if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				res = res.submitForm({ formSelector: 'form[method="post"]' })
@@ -322,7 +321,7 @@ func TestResponse(t *testing.T) {
 		})
 
 		t.Run("withNonExistentForm", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var res = http.request("GET", "HTTPBIN_URL/forms/post");
 				if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				res.submitForm({ formSelector: "#doesNotExist" })
@@ -331,7 +330,7 @@ func TestResponse(t *testing.T) {
 		})
 
 		t.Run("withGetMethod", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var res = http.request("GET", "HTTPBIN_URL/myforms/get");
 				if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				res = res.submitForm()
@@ -351,7 +350,7 @@ func TestResponse(t *testing.T) {
 
 	t.Run("ClickLink", func(t *testing.T) {
 		t.Run("withoutArgs", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var res = http.request("GET", "HTTPBIN_URL/links/10/0");
 				if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				res = res.clickLink()
@@ -362,7 +361,7 @@ func TestResponse(t *testing.T) {
 		})
 
 		t.Run("withSelector", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var res = http.request("GET", "HTTPBIN_URL/links/10/0");
 				if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				res = res.clickLink({ selector: 'a:nth-child(4)' })
@@ -373,7 +372,7 @@ func TestResponse(t *testing.T) {
 		})
 
 		t.Run("withNonExistentLink", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var res = http.request("GET", "HTTPBIN_URL/links/10/0");
 				if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				res = res.clickLink({ selector: 'a#doesNotExist' })
@@ -382,7 +381,7 @@ func TestResponse(t *testing.T) {
 		})
 
 		t.Run("withRequestParams", func(t *testing.T) {
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 				var res = http.request("GET", "HTTPBIN_URL");
 				if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				res = res.clickLink({ selector: 'a[href="/get"]', params: { headers: { "My-Fancy-Header": "SomeValue" } } })

--- a/js/modules/k6/http/tls_test.go
+++ b/js/modules/k6/http/tls_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/guregu/null.v3"
 
-	"github.com/loadimpact/k6/js/common"
 	"github.com/loadimpact/k6/lib"
 )
 
@@ -47,7 +46,7 @@ func TestTLS13Support(t *testing.T) {
 	state.Options.Throw = null.BoolFrom(true)
 	state.Options.Apply(lib.Options{TLSVersion: &lib.TLSVersions{Max: lib.TLSVersion13}})
 
-	_, err := common.RunString(rt, tb.Replacer.Replace(`
+	_, err := rt.RunString(tb.Replacer.Replace(`
 		var resp = http.get("HTTPSBIN_URL/tls-version");
 		if (resp.body != "tls1.3") {
 			throw new Error("unexpected tls version: " + resp.body);

--- a/js/modules/k6/k6_test.go
+++ b/js/modules/k6/k6_test.go
@@ -40,7 +40,7 @@ import (
 func TestFail(t *testing.T) {
 	rt := goja.New()
 	rt.Set("k6", common.Bind(rt, New(), nil))
-	_, err := common.RunString(rt, `k6.fail("blah")`)
+	_, err := rt.RunString(`k6.fail("blah")`)
 	assert.Contains(t, err.Error(), "GoError: blah")
 }
 
@@ -57,7 +57,7 @@ func TestSleep(t *testing.T) {
 	for name, d := range testdata {
 		t.Run(name, func(t *testing.T) {
 			startTime := time.Now()
-			_, err := common.RunString(rt, `k6.sleep(1)`)
+			_, err := rt.RunString(`k6.sleep(1)`)
 			endTime := time.Now()
 			assert.NoError(t, err)
 			assert.True(t, endTime.Sub(startTime) > d, "did not sleep long enough")
@@ -68,7 +68,7 @@ func TestSleep(t *testing.T) {
 		dch := make(chan time.Duration)
 		go func() {
 			startTime := time.Now()
-			_, err := common.RunString(rt, `k6.sleep(10)`)
+			_, err := rt.RunString(`k6.sleep(10)`)
 			endTime := time.Now()
 			assert.NoError(t, err)
 			dch <- endTime.Sub(startTime)
@@ -93,13 +93,13 @@ func TestRandSeed(t *testing.T) {
 	rt.Set("k6", common.Bind(rt, New(), &ctx))
 
 	rand := 0.8487305991992138
-	_, err := common.RunString(rt, fmt.Sprintf(`
+	_, err := rt.RunString(fmt.Sprintf(`
 		var rnd = Math.random();
 		if (rnd == %.16f) { throw new Error("wrong random: " + rnd); }
 	`, rand))
 	assert.NoError(t, err)
 
-	_, err = common.RunString(rt, fmt.Sprintf(`
+	_, err = rt.RunString(fmt.Sprintf(`
 		k6.randomSeed(12345)
 		var rnd = Math.random();
 		if (rnd != %.16f) { throw new Error("wrong random: " + rnd); }
@@ -125,16 +125,17 @@ func TestGroup(t *testing.T) {
 			assert.Equal(t, state.Group.Name, "my group")
 			assert.Equal(t, state.Group.Parent, root)
 		})
-		_, err = common.RunString(rt, `k6.group("my group", fn)`)
+		_, err = rt.RunString(`k6.group("my group", fn)`)
 		assert.NoError(t, err)
 		assert.Equal(t, state.Group, root)
 	})
 
 	t.Run("Invalid", func(t *testing.T) {
-		_, err := common.RunString(rt, `k6.group("::", function() { throw new Error("nooo") })`)
+		_, err := rt.RunString(`k6.group("::", function() { throw new Error("nooo") })`)
 		assert.Contains(t, err.Error(), "GoError: group and check names may not contain '::'")
 	})
 }
+
 func TestCheck(t *testing.T) {
 	rt := goja.New()
 
@@ -162,7 +163,7 @@ func TestCheck(t *testing.T) {
 		state, samples := getState()
 		*ctx = lib.WithState(baseCtx, state)
 
-		_, err := common.RunString(rt, `k6.check(null, { "check": true })`)
+		_, err := rt.RunString(`k6.check(null, { "check": true })`)
 		assert.NoError(t, err)
 
 		bufSamples := stats.GetBufferedSamples(samples)
@@ -183,7 +184,7 @@ func TestCheck(t *testing.T) {
 			state, samples := getState()
 			*ctx = lib.WithState(baseCtx, state)
 
-			_, err := common.RunString(rt, `k6.check(null, { "a": true, "b": false })`)
+			_, err := rt.RunString(`k6.check(null, { "a": true, "b": false })`)
 			assert.NoError(t, err)
 
 			bufSamples := stats.GetBufferedSamples(samples)
@@ -210,7 +211,7 @@ func TestCheck(t *testing.T) {
 		})
 
 		t.Run("Invalid", func(t *testing.T) {
-			_, err := common.RunString(rt, `k6.check(null, { "::": true })`)
+			_, err := rt.RunString(`k6.check(null, { "::": true })`)
 			assert.Contains(t, err.Error(), "GoError: group and check names may not contain '::'")
 		})
 	})
@@ -219,7 +220,7 @@ func TestCheck(t *testing.T) {
 		state, samples := getState()
 		*ctx = lib.WithState(baseCtx, state)
 
-		_, err := common.RunString(rt, `k6.check(null, [ true ])`)
+		_, err := rt.RunString(`k6.check(null, [ true ])`)
 		assert.NoError(t, err)
 
 		bufSamples := stats.GetBufferedSamples(samples)
@@ -241,7 +242,7 @@ func TestCheck(t *testing.T) {
 		state, samples := getState()
 		*ctx = lib.WithState(baseCtx, state)
 
-		_, err := common.RunString(rt, `k6.check(null, 12345)`)
+		_, err := rt.RunString(`k6.check(null, 12345)`)
 		assert.NoError(t, err)
 		assert.Len(t, stats.GetBufferedSamples(samples), 0)
 	})
@@ -250,7 +251,7 @@ func TestCheck(t *testing.T) {
 		state, samples := getState()
 		*ctx = lib.WithState(baseCtx, state)
 
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		k6.check(null, {
 			"a": function() { throw new Error("error A") },
 			"b": function() { throw new Error("error B") },
@@ -292,13 +293,15 @@ func TestCheck(t *testing.T) {
 			`undefined`: false,
 		}
 		for name, tpl := range templates {
+			name, tpl := name, tpl
 			t.Run(name, func(t *testing.T) {
 				for value, succ := range testdata {
+					value, succ := value, succ
 					t.Run(value, func(t *testing.T) {
 						state, samples := getState()
 						*ctx = lib.WithState(baseCtx, state)
 
-						v, err := common.RunString(rt, fmt.Sprintf(tpl, value))
+						v, err := rt.RunString(fmt.Sprintf(tpl, value))
 						if assert.NoError(t, err) {
 							assert.Equal(t, succ, v.Export())
 						}
@@ -333,7 +336,7 @@ func TestCheck(t *testing.T) {
 			ctx2, cancel := context.WithCancel(lib.WithState(baseCtx, state))
 			*ctx = ctx2
 
-			v, err := common.RunString(rt, `k6.check(null, { "check": true })`)
+			v, err := rt.RunString(`k6.check(null, { "check": true })`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, true, v.Export())
 			}
@@ -344,7 +347,7 @@ func TestCheck(t *testing.T) {
 
 			cancel()
 
-			v, err = common.RunString(rt, `k6.check(null, { "check": true })`)
+			v, err = rt.RunString(`k6.check(null, { "check": true })`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, true, v.Export())
 			}
@@ -358,7 +361,7 @@ func TestCheck(t *testing.T) {
 		state, samples := getState()
 		*ctx = lib.WithState(baseCtx, state)
 
-		v, err := common.RunString(rt, `k6.check(null, {"check": true}, {a: 1, b: "2"})`)
+		v, err := rt.RunString(`k6.check(null, {"check": true}, {a: 1, b: "2"})`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, true, v.Export())
 		}

--- a/js/modules/k6/metrics/metrics_test.go
+++ b/js/modules/k6/metrics/metrics_test.go
@@ -80,16 +80,14 @@ func TestMetrics(t *testing.T) {
 					if isTime {
 						isTimeString = `, true`
 					}
-					_, err := common.RunString(rt,
-						fmt.Sprintf(`var m = new metrics.%s("my_metric"%s)`, fn, isTimeString),
-					)
+					_, err := rt.RunString(fmt.Sprintf(`var m = new metrics.%s("my_metric"%s)`, fn, isTimeString))
 					if !assert.NoError(t, err) {
 						return
 					}
 
 					t.Run("ExitInit", func(t *testing.T) {
 						*ctxPtr = lib.WithState(*ctxPtr, state)
-						_, err := common.RunString(rt, fmt.Sprintf(`new metrics.%s("my_metric")`, fn))
+						_, err := rt.RunString(fmt.Sprintf(`new metrics.%s("my_metric")`, fn))
 						assert.EqualError(t, err, "GoError: metrics must be declared in the init context at apply (native)")
 					})
 
@@ -103,9 +101,10 @@ func TestMetrics(t *testing.T) {
 							state.Group = g
 							state.Tags["group"] = g.Path
 							for name, val := range values {
+								name, val := name, val
 								t.Run(name, func(t *testing.T) {
 									t.Run("Simple", func(t *testing.T) {
-										_, err := common.RunString(rt, fmt.Sprintf(`m.add(%v)`, val.JS))
+										_, err := rt.RunString(fmt.Sprintf(`m.add(%v)`, val.JS))
 										assert.NoError(t, err)
 										bufSamples := stats.GetBufferedSamples(samples)
 										if assert.Len(t, bufSamples, 1) {
@@ -123,7 +122,7 @@ func TestMetrics(t *testing.T) {
 										}
 									})
 									t.Run("Tags", func(t *testing.T) {
-										_, err := common.RunString(rt, fmt.Sprintf(`m.add(%v, {a:1})`, val.JS))
+										_, err := rt.RunString(fmt.Sprintf(`m.add(%v, {a:1})`, val.JS))
 										assert.NoError(t, err)
 										bufSamples := stats.GetBufferedSamples(samples)
 										if assert.Len(t, bufSamples, 1) {
@@ -153,7 +152,7 @@ func TestMetrics(t *testing.T) {
 
 func TestMetricNames(t *testing.T) {
 	t.Parallel()
-	var testMap = map[string]bool{
+	testMap := map[string]bool{
 		"simple":       true,
 		"still_simple": true,
 		"":             false,

--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -122,7 +122,7 @@ func TestSession(t *testing.T) {
 	rt.Set("ws", common.Bind(rt, New(), &ctx))
 
 	t.Run("connect_ws", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 		var res = ws.connect("WSBIN_URL/ws-echo", function(socket){
 			socket.close()
 		});
@@ -133,7 +133,7 @@ func TestSession(t *testing.T) {
 	assertSessionMetricsEmitted(t, stats.GetBufferedSamples(samples), "", sr("WSBIN_URL/ws-echo"), 101, "")
 
 	t.Run("connect_wss", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 		var res = ws.connect("WSSBIN_URL/ws-echo", function(socket){
 			socket.close()
 		});
@@ -144,7 +144,7 @@ func TestSession(t *testing.T) {
 	assertSessionMetricsEmitted(t, stats.GetBufferedSamples(samples), "", sr("WSSBIN_URL/ws-echo"), 101, "")
 
 	t.Run("open", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 		var opened = false;
 		var res = ws.connect("WSBIN_URL/ws-echo", function(socket){
 			socket.on("open", function() {
@@ -159,7 +159,7 @@ func TestSession(t *testing.T) {
 	assertSessionMetricsEmitted(t, stats.GetBufferedSamples(samples), "", sr("WSBIN_URL/ws-echo"), 101, "")
 
 	t.Run("send_receive", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 		var res = ws.connect("WSBIN_URL/ws-echo", function(socket){
 			socket.on("open", function() {
 				socket.send("test")
@@ -181,7 +181,7 @@ func TestSession(t *testing.T) {
 	assertMetricEmitted(t, metrics.WSMessagesReceived, samplesBuf, sr("WSBIN_URL/ws-echo"))
 
 	t.Run("interval", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 		var counter = 0;
 		var res = ws.connect("WSBIN_URL/ws-echo", function(socket){
 			socket.setInterval(function () {
@@ -195,7 +195,7 @@ func TestSession(t *testing.T) {
 	})
 	assertSessionMetricsEmitted(t, stats.GetBufferedSamples(samples), "", sr("WSBIN_URL/ws-echo"), 101, "")
 	t.Run("bad interval", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 		var counter = 0;
 		var res = ws.connect("WSBIN_URL/ws-echo", function(socket){
 			socket.setInterval(function () {
@@ -209,7 +209,7 @@ func TestSession(t *testing.T) {
 	})
 
 	t.Run("timeout", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 		var start = new Date().getTime();
 		var ellapsed = new Date().getTime() - start;
 		var res = ws.connect("WSBIN_URL/ws-echo", function(socket){
@@ -226,7 +226,7 @@ func TestSession(t *testing.T) {
 	})
 
 	t.Run("bad timeout", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 		var start = new Date().getTime();
 		var ellapsed = new Date().getTime() - start;
 		var res = ws.connect("WSBIN_URL/ws-echo", function(socket){
@@ -242,7 +242,7 @@ func TestSession(t *testing.T) {
 	assertSessionMetricsEmitted(t, stats.GetBufferedSamples(samples), "", sr("WSBIN_URL/ws-echo"), 101, "")
 
 	t.Run("ping", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 		var pongReceived = false;
 		var res = ws.connect("WSBIN_URL/ws-echo", function(socket){
 			socket.on("open", function(data) {
@@ -266,7 +266,7 @@ func TestSession(t *testing.T) {
 	assertMetricEmitted(t, metrics.WSPing, samplesBuf, sr("WSBIN_URL/ws-echo"))
 
 	t.Run("multiple_handlers", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 		var pongReceived = false;
 		var otherPongReceived = false;
 
@@ -300,7 +300,7 @@ func TestSession(t *testing.T) {
 	assertMetricEmitted(t, metrics.WSPing, samplesBuf, sr("WSBIN_URL/ws-echo"))
 
 	t.Run("client_close", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 		var closed = false;
 		var res = ws.connect("WSBIN_URL/ws-echo", function(socket){
 			socket.on("open", function() {
@@ -330,7 +330,7 @@ func TestSession(t *testing.T) {
 	for _, tc := range serverCloseTests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := common.RunString(rt, sr(fmt.Sprintf(`
+			_, err := rt.RunString(sr(fmt.Sprintf(`
 			var closed = false;
 			var res = ws.connect("WSBIN_URL%s", function(socket){
 				socket.on("open", function() {
@@ -375,7 +375,7 @@ func TestErrors(t *testing.T) {
 	rt.Set("ws", common.Bind(rt, New(), &ctx))
 
 	t.Run("invalid_url", func(t *testing.T) {
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		var res = ws.connect("INVALID", function(socket){
 			socket.on("open", function() {
 				socket.close();
@@ -387,7 +387,7 @@ func TestErrors(t *testing.T) {
 
 	t.Run("invalid_url_message_panic", func(t *testing.T) {
 		// Attempting to send a message to a non-existent socket shouldn't panic
-		_, err := common.RunString(rt, `
+		_, err := rt.RunString(`
 		var res = ws.connect("INVALID", function(socket){
 			socket.send("new message");
 		});
@@ -396,7 +396,7 @@ func TestErrors(t *testing.T) {
 	})
 
 	t.Run("error_in_setup", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 		var res = ws.connect("WSBIN_URL/ws-echo-invalid", function(socket){
 			throw new Error("error in setup");
 		});
@@ -405,7 +405,7 @@ func TestErrors(t *testing.T) {
 	})
 
 	t.Run("send_after_close", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 		var hasError = false;
 		var res = ws.connect("WSBIN_URL/ws-echo-invalid", function(socket){
 			socket.on("open", function() {
@@ -426,7 +426,7 @@ func TestErrors(t *testing.T) {
 	})
 
 	t.Run("error on close", func(t *testing.T) {
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 		var closed = false;
 		var res = ws.connect("WSBIN_URL/ws-close", function(socket){
 			socket.on('open', function open() {
@@ -490,7 +490,7 @@ func TestSystemTags(t *testing.T) {
 		expectedTag := expectedTag
 		t.Run("only "+expectedTag, func(t *testing.T) {
 			state.Options.SystemTags = stats.ToSystemTagSet([]string{expectedTag})
-			_, err := common.RunString(rt, sr(`
+			_, err := rt.RunString(sr(`
 			var res = ws.connect("WSBIN_URL/ws-echo", function(socket){
 				socket.on("open", function() {
 					socket.send("test")
@@ -554,7 +554,7 @@ func TestTLSConfig(t *testing.T) {
 			InsecureSkipVerify: true,
 		}
 
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 		var res = ws.connect("WSSBIN_URL/ws-close", function(socket){
 			socket.close()
 		});
@@ -567,7 +567,7 @@ func TestTLSConfig(t *testing.T) {
 	t.Run("custom certificates", func(t *testing.T) {
 		state.TLSConfig = tb.TLSClientConfig
 
-		_, err := common.RunString(rt, sr(`
+		_, err := rt.RunString(sr(`
 			var res = ws.connect("WSSBIN_URL/ws-close", function(socket){
 				socket.close()
 			});


### PR DESCRIPTION
I used github.com/rsc/rf with
```
ex {
import "github.com/loadimpact/k6/js/common"
import "github.com/dop251/goja"

var rt *goja.Runtime
var s string
common.RunString(rt, s) -> rt.RunString(s)
}
```
to make it, which worked for all packages but `js` itself but that was
quick by hand.

This change has 0 practical changes apart from the fact that it doesn't
use a useless utility function. The utility function in the past was
doing stuff but that was changed in 923f8867 , but I didn't actually
drop the no longer needed utility function at the time, either because I
didn't realize it's not needed or under a time constraint.

The additional changes in k6_test.go and metrics_test.go are because of
golangci-lint and gofumpt.

