### PR TITLE
Add `global` as in nodejs for backwards compatibility

### DIFF
--- a/js/bundle.go
+++ b/js/bundle.go
@@ -295,6 +295,10 @@ func (b *Bundle) instantiate(logger logrus.FieldLogger, rt *goja.Runtime, init *
 	rt.Set("__VU", vuID)
 	rt.Set("console", common.Bind(rt, newConsole(logger), init.ctxPtr))
 
+	if init.compatibilityMode == lib.CompatibilityModeExtended {
+		rt.Set("global", rt.GlobalObject())
+	}
+
 	// TODO: get rid of the unused ctxPtr, use a real external context (so we
 	// can interrupt), build the common.InitEnvironment earlier and reuse it
 	initenv := &common.InitEnvironment{

--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -114,6 +114,18 @@ func TestNewBundle(t *testing.T) {
 		}
 	})
 	t.Run("CompatibilityMode", func(t *testing.T) {
+		t.Run("Extended/ok/global", func(t *testing.T) {
+			rtOpts := lib.RuntimeOptions{
+				CompatibilityMode: null.StringFrom(lib.CompatibilityModeExtended.String()),
+			}
+			_, err := getSimpleBundle(t, "/script.js",
+				`module.exports.default = function() {}
+				if (global.Math != Math) {
+					throw new Error("global is not defined");
+				}`, rtOpts)
+
+			assert.NoError(t, err)
+		})
 		t.Run("Base/ok/Minimal", func(t *testing.T) {
 			rtOpts := lib.RuntimeOptions{
 				CompatibilityMode: null.StringFrom(lib.CompatibilityModeBase.String()),


### PR DESCRIPTION
this is only being added to the "extented" compatibility-mode as it was
being provided by core-js before it was dropped.
