### PR TITLE
Rewrite SharedArray to use goja.DynamicArray

### DIFF
--- a/js/modules/k6/data/data.go
+++ b/js/modules/k6/data/data.go
@@ -82,7 +82,7 @@ func getShareArrayFromCall(rt *goja.Runtime, call goja.Callable) sharedArray {
 	for i := range arr {
 		val, err = stringify(goja.Undefined(), obj.Get(strconv.Itoa(i)))
 		if err != nil {
-			common.Throw(rt, err)
+			panic(err)
 		}
 		arr[i] = val.String()
 	}

--- a/js/modules/k6/data/share.go
+++ b/js/modules/k6/data/share.go
@@ -21,10 +21,7 @@
 package data
 
 import (
-	"context"
-
 	"github.com/dop251/goja"
-	"github.com/loadimpact/k6/js/common"
 )
 
 // TODO fix it not working really well with setupData or just make it more broken
@@ -33,103 +30,74 @@ type sharedArray struct {
 	arr []string
 }
 
-func (s sharedArray) wrap(ctxPtr *context.Context, rt *goja.Runtime) goja.Value {
-	cal, err := rt.RunString(arrayWrapperCode)
-	if err != nil {
-		common.Throw(rt, err)
-	}
-	call, _ := goja.AssertFunction(cal)
-	wrapped, err := call(goja.Undefined(), rt.ToValue(common.Bind(rt, s, ctxPtr)))
-	if err != nil {
-		common.Throw(rt, err)
-	}
+type wrappedSharedArray struct {
+	sharedArray
 
-	return wrapped
+	rt       *goja.Runtime
+	freeze   goja.Callable
+	isFrozen goja.Callable
+	parse    goja.Callable
 }
 
-func (s sharedArray) Get(index int) (interface{}, error) {
+func (s sharedArray) wrap(rt *goja.Runtime) goja.Value {
+	freeze, _ := goja.AssertFunction(rt.GlobalObject().Get("Object").ToObject(rt).Get("freeze"))
+	isFrozen, _ := goja.AssertFunction(rt.GlobalObject().Get("Object").ToObject(rt).Get("isFrozen"))
+	parse, _ := goja.AssertFunction(rt.GlobalObject().Get("JSON").ToObject(rt).Get("parse"))
+	return rt.NewDynamicArray(wrappedSharedArray{
+		sharedArray: s,
+		rt:          rt,
+		freeze:      freeze,
+		isFrozen:    isFrozen,
+		parse:       parse,
+	})
+}
+
+func (s wrappedSharedArray) Set(index int, val goja.Value) bool {
+	panic(s.rt.NewTypeError("SharedArray is immutable")) // this is specifically a type error
+}
+
+func (s wrappedSharedArray) SetLen(len int) bool {
+	panic(s.rt.NewTypeError("SharedArray is immutable")) // this is specifically a type error
+}
+
+func (s wrappedSharedArray) Get(index int) goja.Value {
 	if index < 0 || index >= len(s.arr) {
-		return goja.Undefined(), nil
+		return goja.Undefined()
 	}
+	val, err := s.parse(goja.Undefined(), s.rt.ToValue(s.arr[index]))
+	if err != nil {
+		panic(err)
+	}
+	s.deepFreeze(s.rt, val)
 
-	// we specifically use JSON.parse to get the json to an object inside as otherwise we won't be
-	// able to freeze it as goja doesn't let us unless it is a pure goja object and this is the
-	// easiest way to get one.
-	return s.arr[index], nil
+	return val
 }
 
-func (s sharedArray) Length() int {
+func (s wrappedSharedArray) Len() int {
 	return len(s.arr)
 }
 
-/* This implementation is commented as with it - it is harder to deepFreeze it with this implementation.
-type sharedArrayIterator struct {
-	a     *sharedArray
-	index int
-}
-
-func (sai *sharedArrayIterator) Next() (interface{}, error) {
-	if sai.index == len(sai.a.arr)-1 {
-		return map[string]bool{"done": true}, nil
+func (s wrappedSharedArray) deepFreeze(rt *goja.Runtime, val goja.Value) {
+	_, err := s.freeze(goja.Undefined(), val)
+	if err != nil {
+		panic(s.rt.NewTypeError(err))
 	}
-	sai.index++
-	var tmp interface{}
-	if err := json.Unmarshal(sai.a.arr[sai.index], &tmp); err != nil {
-		return goja.Undefined(), err
+
+	if goja.IsUndefined(val) {
+		return
 	}
-	return map[string]interface{}{"value": tmp}, nil
-}
 
-func (s sharedArray) Iterator() *sharedArrayIterator {
-	return &sharedArrayIterator{a: &s, index: -1}
-}
-*/
-
-const arrayWrapperCode = `(function(val) {
-	function deepFreeze(o) {
-		Object.freeze(o);
-		if (o === undefined) {
-			return o;
+	o := val.ToObject(rt)
+	for _, key := range o.Keys() {
+		prop := o.Get(key)
+		if prop != nil {
+			frozen, err := s.isFrozen(goja.Undefined(), prop)
+			if err != nil {
+				panic(s.rt.NewTypeError(err))
+			}
+			if !frozen.ToBoolean() {
+				s.deepFreeze(rt, prop)
+			}
 		}
-
-		Object.getOwnPropertyNames(o).forEach(function (prop) {
-			if (o[prop] !== null
-				&& (typeof o[prop] === "object" || typeof o[prop] === "function")
-				&& !Object.isFrozen(o[prop])) {
-				deepFreeze(o[prop]);
-			}
-		});
-
-		return o;
-	};
-
-	var arrayHandler = {
-		get: function(target, property, receiver) {
-			switch (property){
-			case "length":
-				return target.length();
-			case Symbol.iterator:
-				return function(){
-					var index = 0;
-					return {
-						"next": function() {
-							if (index >= target.length()) {
-								return {done: true}
-							}
-							var result = {value: deepFreeze(JSON.parse(target.get(index)))};
-							index++;
-							return result;
-						}
-					}
-				}
-			}
-			var i = parseInt(property);
-			if (isNaN(i)) {
-				return undefined;
-			}
-
-			return deepFreeze(JSON.parse(target.get(i)));
-		}
-	};
-	return new Proxy(val, arrayHandler);
-})`
+	}
+}

--- a/js/modules/k6/data/share_test.go
+++ b/js/modules/k6/data/share_test.go
@@ -126,13 +126,13 @@ func TestSharedArrayAnotherRuntimeExceptions(t *testing.T) {
 			code: `'use strict'; array[2].data2 = "bad2"`,
 			err:  "Cannot add property data2, object is not extensible",
 		},
-		"setting property on the proxy": {
+		"setting property on the shared array": {
 			code: `'use strict'; array.something = "something"`,
-			err:  "Host object field something cannot be made configurable",
+			err:  `Cannot set property "something" on a dynamic array`,
 		},
-		"setting index on the proxy": {
+		"setting index on the shared array": {
 			code: `'use strict'; array[2] = "something"`,
-			err:  "Host object field 2 cannot be made configurable",
+			err:  "SharedArray is immutable",
 		},
 	}
 
@@ -184,6 +184,16 @@ func TestSharedArrayAnotherRuntimeWorking(t *testing.T) {
 		}
 		i++;
 	}
+
+	i = 0;
+	array.forEach(function(v){
+		if (v.value !== "something"+i) {
+			throw new Error("bad v.value="+v.value+" for i="+i);
+		}
+		i++;
+	});
+
+
 	`)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
This should make it considerably faster, but probably more importantly, a
lot easier to reason about and also supporting all operations supported
by a normal Array in JavaScript.

From my quick testing it seems that now the difference even for 10
elements is within 5% CPU difference, which IMO is even within the
margin of error.

fixes #1820