### PR TITLE
Add a way to mark http requests as failed or not(passed)

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -108,6 +108,20 @@ func NewEngine(
 		e.submetrics[parent] = append(e.submetrics[parent], sm)
 	}
 
+	// TODO: refactor this out of here when https://github.com/loadimpact/k6/issues/1832 lands and
+	// there is a better way to enable a metric with tag
+	if opts.SystemTags.Has(stats.TagExpectedResponse) {
+		for _, name := range []string{
+			"http_req_duration{expected_response:true}",
+		} {
+			if _, ok := e.thresholds[name]; ok {
+				continue
+			}
+			parent, sm := stats.NewSubmetric(name)
+			e.submetrics[parent] = append(e.submetrics[parent], sm)
+		}
+	}
+
 	return e, nil
 }
 

--- a/core/local/local_test.go
+++ b/core/local/local_test.go
@@ -329,12 +329,13 @@ func TestExecutionSchedulerSystemTags(t *testing.T) {
 	}()
 
 	expCommonTrailTags := stats.IntoSampleTags(&map[string]string{
-		"group":  "",
-		"method": "GET",
-		"name":   sr("HTTPBIN_IP_URL/"),
-		"url":    sr("HTTPBIN_IP_URL/"),
-		"proto":  "HTTP/1.1",
-		"status": "200",
+		"group":             "",
+		"method":            "GET",
+		"name":              sr("HTTPBIN_IP_URL/"),
+		"url":               sr("HTTPBIN_IP_URL/"),
+		"proto":             "HTTP/1.1",
+		"status":            "200",
+		"expected_response": "true",
 	})
 	expTrailPVUTagsRaw := expCommonTrailTags.CloneTags()
 	expTrailPVUTagsRaw["scenario"] = "per_vu_test"

--- a/js/internal/modules/modules.go
+++ b/js/internal/modules/modules.go
@@ -35,7 +35,18 @@ var (
 func Get(name string) interface{} {
 	mx.RLock()
 	defer mx.RUnlock()
-	return modules[name]
+	mod := modules[name]
+	if i, ok := mod.(HasModuleInstancePerVU); ok {
+		return i.NewModuleInstancePerVU()
+	}
+	return mod
+}
+
+// HasModuleInstancePerVU should be implemented by all native Golang modules that
+// would require per-VU state. k6 will call their NewModuleInstancePerVU() methods
+// every time a VU imports the module and use its result as the returned object.
+type HasModuleInstancePerVU interface {
+	NewModuleInstancePerVU() interface{}
 }
 
 // Register the given mod as a JavaScript module, available

--- a/js/modules/k6/http/file_test.go
+++ b/js/modules/k6/http/file_test.go
@@ -80,7 +80,7 @@ func TestHTTPFile(t *testing.T) {
 					assert.Equal(t, tc.expErr, fmt.Sprintf("%s", val["value"]))
 				}()
 			}
-			h := New()
+			h := new(GlobalHTTP).NewModuleInstancePerVU().(*HTTP)
 			ctx := common.WithRuntime(context.Background(), rt)
 			out := h.File(ctx, tc.input, tc.args...)
 			assert.Equal(t, tc.expected, out)

--- a/js/modules/k6/http/http.go
+++ b/js/modules/k6/http/http.go
@@ -30,7 +30,7 @@ import (
 )
 
 func init() {
-	modules.Register("k6/http", New())
+	modules.Register("k6/http", new(GlobalHTTP))
 }
 
 const (
@@ -45,6 +45,36 @@ const (
 
 // ErrJarForbiddenInInitContext is used when a cookie jar was made in the init context
 var ErrJarForbiddenInInitContext = common.NewInitContextError("Making cookie jars in the init context is not supported")
+
+// GlobalHTTP is a global HTTP module for a k6 instance/test run
+type GlobalHTTP struct{}
+
+var _ modules.HasModuleInstancePerVU = new(GlobalHTTP)
+
+// NewModuleInstancePerVU returns an HTTP instance for each VU
+func (g *GlobalHTTP) NewModuleInstancePerVU() interface{} { // this here needs to return interface{}
+	return &HTTP{ // change the below fields to be not writable or not fields
+		SSL_3_0:                            netext.SSL_3_0,
+		TLS_1_0:                            netext.TLS_1_0,
+		TLS_1_1:                            netext.TLS_1_1,
+		TLS_1_2:                            netext.TLS_1_2,
+		TLS_1_3:                            netext.TLS_1_3,
+		OCSP_STATUS_GOOD:                   netext.OCSP_STATUS_GOOD,
+		OCSP_STATUS_REVOKED:                netext.OCSP_STATUS_REVOKED,
+		OCSP_STATUS_SERVER_FAILED:          netext.OCSP_STATUS_SERVER_FAILED,
+		OCSP_STATUS_UNKNOWN:                netext.OCSP_STATUS_UNKNOWN,
+		OCSP_REASON_UNSPECIFIED:            netext.OCSP_REASON_UNSPECIFIED,
+		OCSP_REASON_KEY_COMPROMISE:         netext.OCSP_REASON_KEY_COMPROMISE,
+		OCSP_REASON_CA_COMPROMISE:          netext.OCSP_REASON_CA_COMPROMISE,
+		OCSP_REASON_AFFILIATION_CHANGED:    netext.OCSP_REASON_AFFILIATION_CHANGED,
+		OCSP_REASON_SUPERSEDED:             netext.OCSP_REASON_SUPERSEDED,
+		OCSP_REASON_CESSATION_OF_OPERATION: netext.OCSP_REASON_CESSATION_OF_OPERATION,
+		OCSP_REASON_CERTIFICATE_HOLD:       netext.OCSP_REASON_CERTIFICATE_HOLD,
+		OCSP_REASON_REMOVE_FROM_CRL:        netext.OCSP_REASON_REMOVE_FROM_CRL,
+		OCSP_REASON_PRIVILEGE_WITHDRAWN:    netext.OCSP_REASON_PRIVILEGE_WITHDRAWN,
+		OCSP_REASON_AA_COMPROMISE:          netext.OCSP_REASON_AA_COMPROMISE,
+	}
+}
 
 //nolint: golint
 type HTTP struct {
@@ -67,31 +97,6 @@ type HTTP struct {
 	OCSP_REASON_REMOVE_FROM_CRL        string `js:"OCSP_REASON_REMOVE_FROM_CRL"`
 	OCSP_REASON_PRIVILEGE_WITHDRAWN    string `js:"OCSP_REASON_PRIVILEGE_WITHDRAWN"`
 	OCSP_REASON_AA_COMPROMISE          string `js:"OCSP_REASON_AA_COMPROMISE"`
-}
-
-func New() *HTTP {
-	//TODO: move this as an anonymous struct somewhere...
-	return &HTTP{
-		SSL_3_0:                            netext.SSL_3_0,
-		TLS_1_0:                            netext.TLS_1_0,
-		TLS_1_1:                            netext.TLS_1_1,
-		TLS_1_2:                            netext.TLS_1_2,
-		TLS_1_3:                            netext.TLS_1_3,
-		OCSP_STATUS_GOOD:                   netext.OCSP_STATUS_GOOD,
-		OCSP_STATUS_REVOKED:                netext.OCSP_STATUS_REVOKED,
-		OCSP_STATUS_SERVER_FAILED:          netext.OCSP_STATUS_SERVER_FAILED,
-		OCSP_STATUS_UNKNOWN:                netext.OCSP_STATUS_UNKNOWN,
-		OCSP_REASON_UNSPECIFIED:            netext.OCSP_REASON_UNSPECIFIED,
-		OCSP_REASON_KEY_COMPROMISE:         netext.OCSP_REASON_KEY_COMPROMISE,
-		OCSP_REASON_CA_COMPROMISE:          netext.OCSP_REASON_CA_COMPROMISE,
-		OCSP_REASON_AFFILIATION_CHANGED:    netext.OCSP_REASON_AFFILIATION_CHANGED,
-		OCSP_REASON_SUPERSEDED:             netext.OCSP_REASON_SUPERSEDED,
-		OCSP_REASON_CESSATION_OF_OPERATION: netext.OCSP_REASON_CESSATION_OF_OPERATION,
-		OCSP_REASON_CERTIFICATE_HOLD:       netext.OCSP_REASON_CERTIFICATE_HOLD,
-		OCSP_REASON_REMOVE_FROM_CRL:        netext.OCSP_REASON_REMOVE_FROM_CRL,
-		OCSP_REASON_PRIVILEGE_WITHDRAWN:    netext.OCSP_REASON_PRIVILEGE_WITHDRAWN,
-		OCSP_REASON_AA_COMPROMISE:          netext.OCSP_REASON_AA_COMPROMISE,
-	}
 }
 
 func (*HTTP) XCookieJar(ctx *context.Context) *HTTPCookieJar {

--- a/js/modules/k6/http/http.go
+++ b/js/modules/k6/http/http.go
@@ -73,6 +73,8 @@ func (g *GlobalHTTP) NewModuleInstancePerVU() interface{} { // this here needs t
 		OCSP_REASON_REMOVE_FROM_CRL:        netext.OCSP_REASON_REMOVE_FROM_CRL,
 		OCSP_REASON_PRIVILEGE_WITHDRAWN:    netext.OCSP_REASON_PRIVILEGE_WITHDRAWN,
 		OCSP_REASON_AA_COMPROMISE:          netext.OCSP_REASON_AA_COMPROMISE,
+
+		responseCallback: defaultExpectedStatuses.match,
 	}
 }
 
@@ -97,6 +99,8 @@ type HTTP struct {
 	OCSP_REASON_REMOVE_FROM_CRL        string `js:"OCSP_REASON_REMOVE_FROM_CRL"`
 	OCSP_REASON_PRIVILEGE_WITHDRAWN    string `js:"OCSP_REASON_PRIVILEGE_WITHDRAWN"`
 	OCSP_REASON_AA_COMPROMISE          string `js:"OCSP_REASON_AA_COMPROMISE"`
+
+	responseCallback func(int) bool
 }
 
 func (*HTTP) XCookieJar(ctx *context.Context) *HTTPCookieJar {

--- a/js/modules/k6/http/http_test.go
+++ b/js/modules/k6/http/http_test.go
@@ -34,7 +34,7 @@ import (
 func TestTagURL(t *testing.T) {
 	rt := goja.New()
 	rt.SetFieldNameMapper(common.FieldNameMapper{})
-	rt.Set("http", common.Bind(rt, New(), nil))
+	rt.Set("http", common.Bind(rt, new(GlobalHTTP).NewModuleInstancePerVU(), nil))
 
 	testdata := map[string]struct{ u, n string }{
 		`http://localhost/anything/`:               {"http://localhost/anything/", "http://localhost/anything/"},

--- a/js/modules/k6/http/request.go
+++ b/js/modules/k6/http/request.go
@@ -113,7 +113,7 @@ func (h *HTTP) Request(ctx context.Context, method string, url goja.Value, args 
 	if err != nil {
 		return nil, err
 	}
-	return responseFromHttpext(resp), nil
+	return h.responseFromHttpext(resp), nil
 }
 
 //TODO break this function up
@@ -377,7 +377,7 @@ func (h *HTTP) prepareBatchArray(
 			ParsedHTTPRequest: parsedReq,
 			Response:          response,
 		}
-		results[i] = &Response{response}
+		results[i] = h.responseFromHttpext(response)
 	}
 
 	return batchReqs, results, nil
@@ -401,7 +401,7 @@ func (h *HTTP) prepareBatchObject(
 			ParsedHTTPRequest: parsedReq,
 			Response:          response,
 		}
-		results[key] = &Response{response}
+		results[key] = h.responseFromHttpext(response)
 		i++
 	}
 

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -169,7 +169,7 @@ func newRuntime(
 	ctx := new(context.Context)
 	*ctx = lib.WithState(tb.Context, state)
 	*ctx = common.WithRuntime(*ctx, rt)
-	rt.Set("http", common.Bind(rt, New(), ctx))
+	rt.Set("http", common.Bind(rt, new(GlobalHTTP).NewModuleInstancePerVU(), ctx))
 
 	return tb, state, samples, rt, ctx
 }

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -81,6 +81,7 @@ func TestRunES6String(t *testing.T) {
 	})
 }
 
+// TODO replace this with the Single version
 func assertRequestMetricsEmitted(t *testing.T, sampleContainers []stats.SampleContainer, method, url, name string, status int, group string) {
 	if name == "" {
 		name = url
@@ -128,6 +129,29 @@ func assertRequestMetricsEmitted(t *testing.T, sampleContainers []stats.SampleCo
 	assert.True(t, seenSending, "url %s didn't emit Sending", url)
 	assert.True(t, seenWaiting, "url %s didn't emit Waiting", url)
 	assert.True(t, seenReceiving, "url %s didn't emit Receiving", url)
+}
+
+func assertRequestMetricsEmittedSingle(t *testing.T, sampleContainer stats.SampleContainer, expectedTags map[string]string, metrics []*stats.Metric, callback func(sample stats.Sample)) {
+	t.Helper()
+
+	metricMap := make(map[string]bool, len(metrics))
+	for _, m := range metrics {
+		metricMap[m.Name] = false
+	}
+	for _, sample := range sampleContainer.GetSamples() {
+		tags := sample.Tags.CloneTags()
+		v, ok := metricMap[sample.Metric.Name]
+		assert.True(t, ok, "unexpected metric %s", sample.Metric.Name)
+		assert.False(t, v, "second metric %s", sample.Metric.Name)
+		metricMap[sample.Metric.Name] = true
+		assert.EqualValues(t, expectedTags, tags, "%s", tags)
+		if callback != nil {
+			callback(sample)
+		}
+	}
+	for k, v := range metricMap {
+		assert.True(t, v, "didn't emit %s", k)
+	}
 }
 
 func newRuntime(
@@ -1945,26 +1969,28 @@ func TestRedirectMetricTags(t *testing.T) {
 
 	checkTags := func(sc stats.SampleContainer, expTags map[string]string) {
 		allSamples := sc.GetSamples()
-		assert.Len(t, allSamples, 8)
+		assert.Len(t, allSamples, 9)
 		for _, s := range allSamples {
 			assert.Equal(t, expTags, s.Tags.CloneTags())
 		}
 	}
 	expPOSTtags := map[string]string{
-		"group":  "",
-		"method": "POST",
-		"url":    sr("HTTPBIN_URL/redirect/post"),
-		"name":   sr("HTTPBIN_URL/redirect/post"),
-		"status": "301",
-		"proto":  "HTTP/1.1",
+		"group":             "",
+		"method":            "POST",
+		"url":               sr("HTTPBIN_URL/redirect/post"),
+		"name":              sr("HTTPBIN_URL/redirect/post"),
+		"status":            "301",
+		"proto":             "HTTP/1.1",
+		"expected_response": "true",
 	}
 	expGETtags := map[string]string{
-		"group":  "",
-		"method": "GET",
-		"url":    sr("HTTPBIN_URL/get"),
-		"name":   sr("HTTPBIN_URL/get"),
-		"status": "200",
-		"proto":  "HTTP/1.1",
+		"group":             "",
+		"method":            "GET",
+		"url":               sr("HTTPBIN_URL/get"),
+		"name":              sr("HTTPBIN_URL/get"),
+		"status":            "200",
+		"proto":             "HTTP/1.1",
+		"expected_response": "true",
 	}
 	checkTags(<-samples, expPOSTtags)
 	checkTags(<-samples, expGETtags)

--- a/js/modules/k6/http/response.go
+++ b/js/modules/k6/http/response.go
@@ -36,11 +36,11 @@ import (
 // Response is a representation of an HTTP response to be returned to the goja VM
 type Response struct {
 	*httpext.Response `js:"-"`
+	h                 *HTTP
 }
 
-func responseFromHttpext(resp *httpext.Response) *Response {
-	res := Response{resp}
-	return &res
+func (h *HTTP) responseFromHttpext(resp *httpext.Response) *Response {
+	return &Response{Response: resp, h: h}
 }
 
 // JSON parses the body of a response as json and returns it to the goja VM
@@ -159,9 +159,9 @@ func (res *Response) SubmitForm(args ...goja.Value) (*Response, error) {
 			q.Add(k, v.String())
 		}
 		requestURL.RawQuery = q.Encode()
-		return New().Request(res.GetCtx(), requestMethod, rt.ToValue(requestURL.String()), goja.Null(), requestParams)
+		return res.h.Request(res.GetCtx(), requestMethod, rt.ToValue(requestURL.String()), goja.Null(), requestParams)
 	}
-	return New().Request(res.GetCtx(), requestMethod, rt.ToValue(requestURL.String()), rt.ToValue(values), requestParams)
+	return res.h.Request(res.GetCtx(), requestMethod, rt.ToValue(requestURL.String()), rt.ToValue(values), requestParams)
 }
 
 // ClickLink parses the body as an html, looks for a link and than makes a request as if the link was
@@ -202,5 +202,5 @@ func (res *Response) ClickLink(args ...goja.Value) (*Response, error) {
 	}
 	requestURL := responseURL.ResolveReference(hrefURL)
 
-	return New().Get(res.GetCtx(), rt.ToValue(requestURL.String()), requestParams)
+	return res.h.Get(res.GetCtx(), rt.ToValue(requestURL.String()), requestParams)
 }

--- a/js/modules/k6/http/response_callback.go
+++ b/js/modules/k6/http/response_callback.go
@@ -1,0 +1,117 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2021 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/dop251/goja"
+	"github.com/loadimpact/k6/js/common"
+)
+
+//nolint:gochecknoglobals
+var defaultExpectedStatuses = expectedStatuses{
+	minmax: [][2]int{{200, 399}},
+}
+
+// expectedStatuses is specifically totally unexported so it can't be used for anything else but
+// SetResponseCallback and nothing can be done from the js side to modify it or make an instance of
+// it except using ExpectedStatuses
+type expectedStatuses struct {
+	minmax [][2]int
+	exact  []int
+}
+
+func (e expectedStatuses) match(status int) bool {
+	for _, v := range e.exact {
+		if v == status {
+			return true
+		}
+	}
+
+	for _, v := range e.minmax {
+		if v[0] <= status && status <= v[1] {
+			return true
+		}
+	}
+	return false
+}
+
+// ExpectedStatuses returns expectedStatuses object based on the provided arguments.
+// The arguments must be either integers or object of `{min: <integer>, max: <integer>}`
+// kind. The "integer"ness is checked by the Number.isInteger.
+func (*HTTP) ExpectedStatuses(ctx context.Context, args ...goja.Value) *expectedStatuses { //nolint: golint
+	rt := common.GetRuntime(ctx)
+
+	if len(args) == 0 {
+		common.Throw(rt, errors.New("no arguments"))
+	}
+	var result expectedStatuses
+
+	jsIsInt, _ := goja.AssertFunction(rt.GlobalObject().Get("Number").ToObject(rt).Get("isInteger"))
+	isInt := func(a goja.Value) bool {
+		v, err := jsIsInt(goja.Undefined(), a)
+		return err == nil && v.ToBoolean()
+	}
+
+	errMsg := "argument number %d to expectedStatuses was neither an integer nor an object like {min:100, max:329}"
+	for i, arg := range args {
+		o := arg.ToObject(rt)
+		if o == nil {
+			common.Throw(rt, fmt.Errorf(errMsg, i+1))
+		}
+
+		if isInt(arg) {
+			result.exact = append(result.exact, int(o.ToInteger()))
+		} else {
+			min := o.Get("min")
+			max := o.Get("max")
+			if min == nil || max == nil {
+				common.Throw(rt, fmt.Errorf(errMsg, i+1))
+			}
+			if !(isInt(min) && isInt(max)) {
+				common.Throw(rt, fmt.Errorf("both min and max need to be integers for argument number %d", i+1))
+			}
+
+			result.minmax = append(result.minmax, [2]int{int(min.ToInteger()), int(max.ToInteger())})
+		}
+	}
+	return &result
+}
+
+// SetResponseCallback sets the responseCallback to the value provided. Supported values are
+// expectedStatuses object or a `null` which means that metrics shouldn't be tagged as failed and
+// `http_req_failed` should not be emitted - the behaviour previous to this
+func (h *HTTP) SetResponseCallback(ctx context.Context, val goja.Value) {
+	if val != nil && !goja.IsNull(val) {
+		// This is done this way as ExportTo exports functions to empty structs without an error
+		if es, ok := val.Export().(*expectedStatuses); ok {
+			h.responseCallback = es.match
+		} else {
+			//nolint:golint
+			common.Throw(common.GetRuntime(ctx), fmt.Errorf("unsupported argument, expected http.expectedStatuses"))
+		}
+	} else {
+		h.responseCallback = nil
+	}
+}

--- a/js/modules/k6/http/response_callback_test.go
+++ b/js/modules/k6/http/response_callback_test.go
@@ -1,0 +1,562 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2021 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package http
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/dop251/goja"
+	"github.com/loadimpact/k6/js/common"
+	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/lib/metrics"
+	"github.com/loadimpact/k6/stats"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpectedStatuses(t *testing.T) {
+	t.Parallel()
+	rt := goja.New()
+	rt.SetFieldNameMapper(common.FieldNameMapper{})
+	ctx := context.Background()
+
+	ctx = common.WithRuntime(ctx, rt)
+	rt.Set("http", common.Bind(rt, new(GlobalHTTP).NewModuleInstancePerVU(), &ctx))
+	cases := map[string]struct {
+		code, err string
+		expected  expectedStatuses
+	}{
+		"good example": {
+			expected: expectedStatuses{exact: []int{200, 300}, minmax: [][2]int{{200, 300}}},
+			code:     `(http.expectedStatuses(200, 300, {min: 200, max:300}))`,
+		},
+
+		"strange example": {
+			expected: expectedStatuses{exact: []int{200, 300}, minmax: [][2]int{{200, 300}}},
+			code:     `(http.expectedStatuses(200, 300, {min: 200, max:300, other: "attribute"}))`,
+		},
+
+		"string status code": {
+			code: `(http.expectedStatuses(200, "300", {min: 200, max:300}))`,
+			err:  "argument number 2 to expectedStatuses was neither an integer nor an object like {min:100, max:329}",
+		},
+
+		"string max status code": {
+			code: `(http.expectedStatuses(200, 300, {min: 200, max:"300"}))`,
+			err:  "both min and max need to be integers for argument number 3",
+		},
+		"float status code": {
+			err:  "argument number 2 to expectedStatuses was neither an integer nor an object like {min:100, max:329}",
+			code: `(http.expectedStatuses(200, 300.5, {min: 200, max:300}))`,
+		},
+
+		"float max status code": {
+			err:  "both min and max need to be integers for argument number 3",
+			code: `(http.expectedStatuses(200, 300, {min: 200, max:300.5}))`,
+		},
+		"no arguments": {
+			code: `(http.expectedStatuses())`,
+			err:  "no arguments",
+		},
+	}
+
+	for name, testCase := range cases {
+		name, testCase := name, testCase
+		t.Run(name, func(t *testing.T) {
+			val, err := rt.RunString(testCase.code)
+			if testCase.err == "" {
+				require.NoError(t, err)
+				got := new(expectedStatuses)
+				err = rt.ExportTo(val, &got)
+				require.NoError(t, err)
+				require.Equal(t, testCase.expected, *got)
+				return // the t.Run
+			}
+
+			require.Error(t, err)
+			exc := err.(*goja.Exception)
+			require.Contains(t, exc.Error(), testCase.err)
+		})
+	}
+}
+
+type expectedSample struct {
+	tags    map[string]string
+	metrics []*stats.Metric
+}
+
+func TestResponseCallbackInAction(t *testing.T) {
+	t.Parallel()
+	tb, _, samples, rt, ctx := newRuntime(t)
+	defer tb.Cleanup()
+	sr := tb.Replacer.Replace
+	httpModule := new(GlobalHTTP).NewModuleInstancePerVU().(*HTTP)
+	rt.Set("http", common.Bind(rt, httpModule, ctx))
+
+	HTTPMetricsWithoutFailed := []*stats.Metric{
+		metrics.HTTPReqs,
+		metrics.HTTPReqBlocked,
+		metrics.HTTPReqConnecting,
+		metrics.HTTPReqDuration,
+		metrics.HTTPReqReceiving,
+		metrics.HTTPReqWaiting,
+		metrics.HTTPReqSending,
+		metrics.HTTPReqTLSHandshaking,
+	}
+
+	allHTTPMetrics := append(HTTPMetricsWithoutFailed, metrics.HTTPReqFailed)
+
+	testCases := map[string]struct {
+		code            string
+		expectedSamples []expectedSample
+	}{
+		"basic": {
+			code: `http.request("GET", "HTTPBIN_URL/redirect/1");`,
+			expectedSamples: []expectedSample{
+				{
+					tags: map[string]string{
+						"method":            "GET",
+						"url":               sr("HTTPBIN_URL/redirect/1"),
+						"name":              sr("HTTPBIN_URL/redirect/1"),
+						"status":            "302",
+						"group":             "",
+						"expected_response": "true",
+						"proto":             "HTTP/1.1",
+					},
+					metrics: allHTTPMetrics,
+				},
+				{
+					tags: map[string]string{
+						"method":            "GET",
+						"url":               sr("HTTPBIN_URL/get"),
+						"name":              sr("HTTPBIN_URL/get"),
+						"status":            "200",
+						"group":             "",
+						"expected_response": "true",
+						"proto":             "HTTP/1.1",
+					},
+					metrics: allHTTPMetrics,
+				},
+			},
+		},
+		"overwrite per request": {
+			code: `
+			http.setResponseCallback(http.expectedStatuses(200));
+			res = http.request("GET", "HTTPBIN_URL/redirect/1");
+			`,
+			expectedSamples: []expectedSample{
+				{
+					tags: map[string]string{
+						"method":            "GET",
+						"url":               sr("HTTPBIN_URL/redirect/1"),
+						"name":              sr("HTTPBIN_URL/redirect/1"),
+						"status":            "302",
+						"group":             "",
+						"expected_response": "false", // this is on purpose
+						"proto":             "HTTP/1.1",
+					},
+					metrics: allHTTPMetrics,
+				},
+				{
+					tags: map[string]string{
+						"method":            "GET",
+						"url":               sr("HTTPBIN_URL/get"),
+						"name":              sr("HTTPBIN_URL/get"),
+						"status":            "200",
+						"group":             "",
+						"expected_response": "true",
+						"proto":             "HTTP/1.1",
+					},
+					metrics: allHTTPMetrics,
+				},
+			},
+		},
+
+		"global overwrite": {
+			code: `http.request("GET", "HTTPBIN_URL/redirect/1", null, {responseCallback: http.expectedStatuses(200)});`,
+			expectedSamples: []expectedSample{
+				{
+					tags: map[string]string{
+						"method":            "GET",
+						"url":               sr("HTTPBIN_URL/redirect/1"),
+						"name":              sr("HTTPBIN_URL/redirect/1"),
+						"status":            "302",
+						"group":             "",
+						"expected_response": "false", // this is on purpose
+						"proto":             "HTTP/1.1",
+					},
+					metrics: allHTTPMetrics,
+				},
+				{
+					tags: map[string]string{
+						"method":            "GET",
+						"url":               sr("HTTPBIN_URL/get"),
+						"name":              sr("HTTPBIN_URL/get"),
+						"status":            "200",
+						"group":             "",
+						"expected_response": "true",
+						"proto":             "HTTP/1.1",
+					},
+					metrics: allHTTPMetrics,
+				},
+			},
+		},
+		"per request overwrite with null": {
+			code: `http.request("GET", "HTTPBIN_URL/redirect/1", null, {responseCallback: null});`,
+			expectedSamples: []expectedSample{
+				{
+					tags: map[string]string{
+						"method": "GET",
+						"url":    sr("HTTPBIN_URL/redirect/1"),
+						"name":   sr("HTTPBIN_URL/redirect/1"),
+						"status": "302",
+						"group":  "",
+						"proto":  "HTTP/1.1",
+					},
+					metrics: HTTPMetricsWithoutFailed,
+				},
+				{
+					tags: map[string]string{
+						"method": "GET",
+						"url":    sr("HTTPBIN_URL/get"),
+						"name":   sr("HTTPBIN_URL/get"),
+						"status": "200",
+						"group":  "",
+						"proto":  "HTTP/1.1",
+					},
+					metrics: HTTPMetricsWithoutFailed,
+				},
+			},
+		},
+		"global overwrite with null": {
+			code: `
+			http.setResponseCallback(null);
+			res = http.request("GET", "HTTPBIN_URL/redirect/1");
+			`,
+			expectedSamples: []expectedSample{
+				{
+					tags: map[string]string{
+						"method": "GET",
+						"url":    sr("HTTPBIN_URL/redirect/1"),
+						"name":   sr("HTTPBIN_URL/redirect/1"),
+						"status": "302",
+						"group":  "",
+						"proto":  "HTTP/1.1",
+					},
+					metrics: HTTPMetricsWithoutFailed,
+				},
+				{
+					tags: map[string]string{
+						"method": "GET",
+						"url":    sr("HTTPBIN_URL/get"),
+						"name":   sr("HTTPBIN_URL/get"),
+						"status": "200",
+						"group":  "",
+						"proto":  "HTTP/1.1",
+					},
+					metrics: HTTPMetricsWithoutFailed,
+				},
+			},
+		},
+	}
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			httpModule.responseCallback = defaultExpectedStatuses.match
+
+			_, err := rt.RunString(sr(testCase.code))
+			assert.NoError(t, err)
+			bufSamples := stats.GetBufferedSamples(samples)
+
+			reqsCount := 0
+			for _, container := range bufSamples {
+				for _, sample := range container.GetSamples() {
+					if sample.Metric.Name == "http_reqs" {
+						reqsCount++
+					}
+				}
+			}
+
+			require.Equal(t, len(testCase.expectedSamples), reqsCount)
+
+			for i, expectedSample := range testCase.expectedSamples {
+				assertRequestMetricsEmittedSingle(t, bufSamples[i], expectedSample.tags, expectedSample.metrics, nil)
+			}
+		})
+	}
+}
+
+func TestResponseCallbackBatch(t *testing.T) {
+	t.Parallel()
+	tb, _, samples, rt, ctx := newRuntime(t)
+	defer tb.Cleanup()
+	sr := tb.Replacer.Replace
+	httpModule := new(GlobalHTTP).NewModuleInstancePerVU().(*HTTP)
+	rt.Set("http", common.Bind(rt, httpModule, ctx))
+
+	HTTPMetricsWithoutFailed := []*stats.Metric{
+		metrics.HTTPReqs,
+		metrics.HTTPReqBlocked,
+		metrics.HTTPReqConnecting,
+		metrics.HTTPReqDuration,
+		metrics.HTTPReqReceiving,
+		metrics.HTTPReqWaiting,
+		metrics.HTTPReqSending,
+		metrics.HTTPReqTLSHandshaking,
+	}
+
+	allHTTPMetrics := append(HTTPMetricsWithoutFailed, metrics.HTTPReqFailed)
+	// IMPORTANT: the tests here depend on the fact that the url they hit can be ordered in the same
+	// order as the expectedSamples even if they are made concurrently
+	testCases := map[string]struct {
+		code            string
+		expectedSamples []expectedSample
+	}{
+		"basic": {
+			code: `
+	http.batch([["GET", "HTTPBIN_URL/status/200", null, {responseCallback: null}],
+			["GET", "HTTPBIN_URL/status/201"],
+			["GET", "HTTPBIN_URL/status/202", null, {responseCallback: http.expectedStatuses(4)}],
+			["GET", "HTTPBIN_URL/status/405", null, {responseCallback: http.expectedStatuses(405)}],
+	]);`,
+			expectedSamples: []expectedSample{
+				{
+					tags: map[string]string{
+						"method": "GET",
+						"url":    sr("HTTPBIN_URL/status/200"),
+						"name":   sr("HTTPBIN_URL/status/200"),
+						"status": "200",
+						"group":  "",
+						"proto":  "HTTP/1.1",
+					},
+					metrics: HTTPMetricsWithoutFailed,
+				},
+				{
+					tags: map[string]string{
+						"method":            "GET",
+						"url":               sr("HTTPBIN_URL/status/201"),
+						"name":              sr("HTTPBIN_URL/status/201"),
+						"status":            "201",
+						"group":             "",
+						"expected_response": "true",
+						"proto":             "HTTP/1.1",
+					},
+					metrics: allHTTPMetrics,
+				},
+				{
+					tags: map[string]string{
+						"method":            "GET",
+						"url":               sr("HTTPBIN_URL/status/202"),
+						"name":              sr("HTTPBIN_URL/status/202"),
+						"status":            "202",
+						"group":             "",
+						"expected_response": "false",
+						"proto":             "HTTP/1.1",
+					},
+					metrics: allHTTPMetrics,
+				},
+				{
+					tags: map[string]string{
+						"method":            "GET",
+						"url":               sr("HTTPBIN_URL/status/405"),
+						"name":              sr("HTTPBIN_URL/status/405"),
+						"status":            "405",
+						"error_code":        "1405",
+						"group":             "",
+						"expected_response": "true",
+						"proto":             "HTTP/1.1",
+					},
+					metrics: allHTTPMetrics,
+				},
+			},
+		},
+	}
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			httpModule.responseCallback = defaultExpectedStatuses.match
+
+			_, err := rt.RunString(sr(testCase.code))
+			assert.NoError(t, err)
+			bufSamples := stats.GetBufferedSamples(samples)
+
+			reqsCount := 0
+			for _, container := range bufSamples {
+				for _, sample := range container.GetSamples() {
+					if sample.Metric.Name == "http_reqs" {
+						reqsCount++
+					}
+				}
+			}
+			sort.Slice(bufSamples, func(i, j int) bool {
+				iURL, _ := bufSamples[i].GetSamples()[0].Tags.Get("url")
+				jURL, _ := bufSamples[j].GetSamples()[0].Tags.Get("url")
+				return iURL < jURL
+			})
+
+			require.Equal(t, len(testCase.expectedSamples), reqsCount)
+
+			for i, expectedSample := range testCase.expectedSamples {
+				assertRequestMetricsEmittedSingle(t, bufSamples[i], expectedSample.tags, expectedSample.metrics, nil)
+			}
+		})
+	}
+}
+
+func TestResponseCallbackInActionWithoutPassedTag(t *testing.T) {
+	t.Parallel()
+	tb, state, samples, rt, ctx := newRuntime(t)
+	defer tb.Cleanup()
+	sr := tb.Replacer.Replace
+	allHTTPMetrics := []*stats.Metric{
+		metrics.HTTPReqs,
+		metrics.HTTPReqFailed,
+		metrics.HTTPReqBlocked,
+		metrics.HTTPReqConnecting,
+		metrics.HTTPReqDuration,
+		metrics.HTTPReqReceiving,
+		metrics.HTTPReqSending,
+		metrics.HTTPReqWaiting,
+		metrics.HTTPReqTLSHandshaking,
+	}
+	deleteSystemTag(state, stats.TagExpectedResponse.String())
+	httpModule := new(GlobalHTTP).NewModuleInstancePerVU().(*HTTP)
+	rt.Set("http", common.Bind(rt, httpModule, ctx))
+
+	_, err := rt.RunString(sr(`http.request("GET", "HTTPBIN_URL/redirect/1", null, {responseCallback: http.expectedStatuses(200)});`))
+	assert.NoError(t, err)
+	bufSamples := stats.GetBufferedSamples(samples)
+
+	reqsCount := 0
+	for _, container := range bufSamples {
+		for _, sample := range container.GetSamples() {
+			if sample.Metric.Name == "http_reqs" {
+				reqsCount++
+			}
+		}
+	}
+
+	require.Equal(t, 2, reqsCount)
+
+	tags := map[string]string{
+		"method": "GET",
+		"url":    sr("HTTPBIN_URL/redirect/1"),
+		"name":   sr("HTTPBIN_URL/redirect/1"),
+		"status": "302",
+		"group":  "",
+		"proto":  "HTTP/1.1",
+	}
+	assertRequestMetricsEmittedSingle(t, bufSamples[0], tags, allHTTPMetrics, func(sample stats.Sample) {
+		if sample.Metric.Name == metrics.HTTPReqFailed.Name {
+			require.EqualValues(t, sample.Value, 1)
+		}
+	})
+	tags["url"] = sr("HTTPBIN_URL/get")
+	tags["name"] = tags["url"]
+	tags["status"] = "200"
+	assertRequestMetricsEmittedSingle(t, bufSamples[1], tags, allHTTPMetrics, func(sample stats.Sample) {
+		if sample.Metric.Name == metrics.HTTPReqFailed.Name {
+			require.EqualValues(t, sample.Value, 0)
+		}
+	})
+}
+
+func TestDigestWithResponseCallback(t *testing.T) {
+	t.Parallel()
+	tb, _, samples, rt, ctx := newRuntime(t)
+	defer tb.Cleanup()
+
+	httpModule := new(GlobalHTTP).NewModuleInstancePerVU().(*HTTP)
+	rt.Set("http", common.Bind(rt, httpModule, ctx))
+
+	urlWithCreds := tb.Replacer.Replace(
+		"http://testuser:testpwd@HTTPBIN_IP:HTTPBIN_PORT/digest-auth/auth/testuser/testpwd",
+	)
+
+	allHTTPMetrics := []*stats.Metric{
+		metrics.HTTPReqs,
+		metrics.HTTPReqFailed,
+		metrics.HTTPReqBlocked,
+		metrics.HTTPReqConnecting,
+		metrics.HTTPReqDuration,
+		metrics.HTTPReqReceiving,
+		metrics.HTTPReqSending,
+		metrics.HTTPReqWaiting,
+		metrics.HTTPReqTLSHandshaking,
+	}
+	_, err := rt.RunString(fmt.Sprintf(`
+		var res = http.get(%q,  { auth: "digest" });
+		if (res.status !== 200) { throw new Error("wrong status: " + res.status); }
+		if (res.error_code !== 0) { throw new Error("wrong error code: " + res.error_code); }
+	`, urlWithCreds))
+	require.NoError(t, err)
+	bufSamples := stats.GetBufferedSamples(samples)
+
+	reqsCount := 0
+	for _, container := range bufSamples {
+		for _, sample := range container.GetSamples() {
+			if sample.Metric.Name == "http_reqs" {
+				reqsCount++
+			}
+		}
+	}
+
+	require.Equal(t, 2, reqsCount)
+
+	urlRaw := tb.Replacer.Replace(
+		"http://HTTPBIN_IP:HTTPBIN_PORT/digest-auth/auth/testuser/testpwd")
+
+	tags := map[string]string{
+		"method":            "GET",
+		"url":               urlRaw,
+		"name":              urlRaw,
+		"status":            "401",
+		"group":             "",
+		"proto":             "HTTP/1.1",
+		"expected_response": "true",
+		"error_code":        "1401",
+	}
+	assertRequestMetricsEmittedSingle(t, bufSamples[0], tags, allHTTPMetrics, func(sample stats.Sample) {
+		if sample.Metric.Name == metrics.HTTPReqFailed.Name {
+			require.EqualValues(t, sample.Value, 0)
+		}
+	})
+	tags["status"] = "200"
+	delete(tags, "error_code")
+	assertRequestMetricsEmittedSingle(t, bufSamples[1], tags, allHTTPMetrics, func(sample stats.Sample) {
+		if sample.Metric.Name == metrics.HTTPReqFailed.Name {
+			require.EqualValues(t, sample.Value, 0)
+		}
+	})
+}
+
+func deleteSystemTag(state *lib.State, tag string) {
+	enabledTags := state.Options.SystemTags.Map()
+	delete(enabledTags, tag)
+	tagsList := make([]string, 0, len(enabledTags))
+	for k := range enabledTags {
+		tagsList = append(tagsList, k)
+	}
+	state.Options.SystemTags = stats.ToSystemTagSet(tagsList)
+}

--- a/js/modules/k6/http/response_test.go
+++ b/js/modules/k6/http/response_test.go
@@ -55,6 +55,7 @@ const testGetFormHTML = `
 	</form>
 </body>
 `
+
 const jsonData = `{"glossary": {
     "friends": [
       {"first": "Dale", "last": "Murphy", "age": 44},

--- a/js/modules/k6/http/response_test.go
+++ b/js/modules/k6/http/response_test.go
@@ -413,7 +413,7 @@ func BenchmarkResponseJson(b *testing.B) {
 		tc := tc
 		b.Run(fmt.Sprintf("Selector %s ", tc.selector), func(b *testing.B) {
 			for n := 0; n < b.N; n++ {
-				resp := responseFromHttpext(&httpext.Response{Body: jsonData})
+				resp := new(HTTP).responseFromHttpext(&httpext.Response{Body: jsonData})
 				resp.JSON(tc.selector)
 			}
 		})
@@ -421,7 +421,7 @@ func BenchmarkResponseJson(b *testing.B) {
 
 	b.Run("Without selector", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			resp := responseFromHttpext(&httpext.Response{Body: jsonData})
+			resp := new(HTTP).responseFromHttpext(&httpext.Response{Body: jsonData})
 			resp.JSON()
 		}
 	})

--- a/js/runner.go
+++ b/js/runner.go
@@ -179,7 +179,7 @@ func (r *Runner) newVU(id int64, samplesOut chan<- stats.SampleContainer) (*VU, 
 	}
 
 	tlsConfig := &tls.Config{
-		InsecureSkipVerify: r.Bundle.Options.InsecureSkipTLSVerify.Bool,
+		InsecureSkipVerify: r.Bundle.Options.InsecureSkipTLSVerify.Bool, //nolint:gosec
 		CipherSuites:       cipherSuites,
 		MinVersion:         uint16(tlsVersions.Min),
 		MaxVersion:         uint16(tlsVersions.Max),
@@ -244,6 +244,7 @@ func (r *Runner) newVU(id int64, samplesOut chan<- stats.SampleContainer) (*VU, 
 	return vu, nil
 }
 
+// Setup runs the setup function if there is one and sets the setupData to the returned value
 func (r *Runner) Setup(ctx context.Context, out chan<- stats.SampleContainer) error {
 	setupCtx, setupCancel := context.WithTimeout(ctx, r.getTimeoutFor(consts.SetupFn))
 	defer setupCancel()

--- a/lib/metrics/metrics.go
+++ b/lib/metrics/metrics.go
@@ -24,7 +24,7 @@ import (
 	"github.com/loadimpact/k6/stats"
 )
 
-//TODO: refactor this, using non thread-safe global variables seems like a bad idea for various reasons...
+// TODO: refactor this, using non thread-safe global variables seems like a bad idea for various reasons...
 
 //nolint:gochecknoglobals
 var (
@@ -42,6 +42,7 @@ var (
 
 	// HTTP-related.
 	HTTPReqs              = stats.New("http_reqs", stats.Counter)
+	HTTPReqFailed         = stats.New("http_req_failed", stats.Rate)
 	HTTPReqDuration       = stats.New("http_req_duration", stats.Trend, stats.Time)
 	HTTPReqBlocked        = stats.New("http_req_blocked", stats.Trend, stats.Time)
 	HTTPReqConnecting     = stats.New("http_req_connecting", stats.Trend, stats.Time)

--- a/lib/netext/httpext/tracer.go
+++ b/lib/netext/httpext/tracer.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/loadimpact/k6/lib/metrics"
 	"github.com/loadimpact/k6/stats"
+	"gopkg.in/guregu/null.v3"
 )
 
 // A Trail represents detailed information about an HTTP request.
@@ -53,6 +54,7 @@ type Trail struct {
 	ConnReused     bool
 	ConnRemoteAddr net.Addr
 
+	Failed null.Bool
 	// Populated by SaveSamples()
 	Tags    *stats.SampleTags
 	Samples []stats.Sample
@@ -61,17 +63,17 @@ type Trail struct {
 // SaveSamples populates the Trail's sample slice so they're accesible via GetSamples()
 func (tr *Trail) SaveSamples(tags *stats.SampleTags) {
 	tr.Tags = tags
-	tr.Samples = []stats.Sample{
+	tr.Samples = make([]stats.Sample, 0, 9) // this is with 1 more for a possible HTTPReqFailed
+	tr.Samples = append(tr.Samples, []stats.Sample{
 		{Metric: metrics.HTTPReqs, Time: tr.EndTime, Tags: tags, Value: 1},
 		{Metric: metrics.HTTPReqDuration, Time: tr.EndTime, Tags: tags, Value: stats.D(tr.Duration)},
-
 		{Metric: metrics.HTTPReqBlocked, Time: tr.EndTime, Tags: tags, Value: stats.D(tr.Blocked)},
 		{Metric: metrics.HTTPReqConnecting, Time: tr.EndTime, Tags: tags, Value: stats.D(tr.Connecting)},
 		{Metric: metrics.HTTPReqTLSHandshaking, Time: tr.EndTime, Tags: tags, Value: stats.D(tr.TLSHandshaking)},
 		{Metric: metrics.HTTPReqSending, Time: tr.EndTime, Tags: tags, Value: stats.D(tr.Sending)},
 		{Metric: metrics.HTTPReqWaiting, Time: tr.EndTime, Tags: tags, Value: stats.D(tr.Waiting)},
 		{Metric: metrics.HTTPReqReceiving, Time: tr.EndTime, Tags: tags, Value: stats.D(tr.Receiving)},
-	}
+	}...)
 }
 
 // GetSamples implements the stats.SampleContainer interface.

--- a/lib/netext/httpext/transport_test.go
+++ b/lib/netext/httpext/transport_test.go
@@ -1,0 +1,86 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2021 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package httpext
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/loadimpact/k6/lib"
+	"github.com/loadimpact/k6/stats"
+	"github.com/sirupsen/logrus"
+)
+
+func BenchmarkMeasureAndEmitMetrics(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	samples := make(chan stats.SampleContainer, 10)
+	defer close(samples)
+	go func() {
+		for range samples {
+		}
+	}()
+	logger := logrus.New()
+	logger.Level = logrus.DebugLevel
+
+	state := &lib.State{
+		Options: lib.Options{
+			RunTags:    &stats.SampleTags{},
+			SystemTags: &stats.DefaultSystemTagSet,
+		},
+		Samples: samples,
+		Logger:  logger,
+	}
+	t := transport{
+		state: state,
+		ctx:   ctx,
+	}
+
+	b.ResetTimer()
+	unfRequest := &unfinishedRequest{
+		tracer: &Tracer{},
+		response: &http.Response{
+			StatusCode: 200,
+		},
+		request: &http.Request{
+			URL: &url.URL{
+				Host:   "example.com",
+				Scheme: "https",
+			},
+		},
+	}
+
+	b.Run("no responseCallback", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			t.measureAndEmitMetrics(unfRequest)
+		}
+	})
+
+	t.responseCallback = func(n int) bool { return true }
+
+	b.Run("responseCallback", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			t.measureAndEmitMetrics(unfRequest)
+		}
+	})
+}

--- a/stats/cloud/bench_test.go
+++ b/stats/cloud/bench_test.go
@@ -330,3 +330,33 @@ func BenchmarkHTTPPush(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkNewSampleFromTrail(b *testing.B) {
+	tags := generateTags(1, 200)
+	now := time.Now()
+	trail := &httpext.Trail{
+		Blocked:        200 * 100 * time.Millisecond,
+		Connecting:     200 * 200 * time.Millisecond,
+		TLSHandshaking: 200 * 300 * time.Millisecond,
+		Sending:        200 * 400 * time.Millisecond,
+		Waiting:        500 * time.Millisecond,
+		Receiving:      600 * time.Millisecond,
+		EndTime:        now,
+		ConnDuration:   500 * time.Millisecond,
+		Duration:       150 * 1500 * time.Millisecond,
+		Tags:           tags,
+	}
+
+	b.Run("no failed", func(b *testing.B) {
+		for s := 0; s < b.N; s++ {
+			_ = NewSampleFromTrail(trail)
+		}
+	})
+	trail.Failed = null.BoolFrom(true)
+
+	b.Run("failed", func(b *testing.B) {
+		for s := 0; s < b.N; s++ {
+			_ = NewSampleFromTrail(trail)
+		}
+	})
+}

--- a/stats/cloud/cloud_easyjson.go
+++ b/stats/cloud/cloud_easyjson.go
@@ -382,6 +382,7 @@ func easyjson9def2ecdDecode(in *jlexer.Lexer, out *struct {
 	Sending        AggregatedMetric `json:"http_req_sending"`
 	Waiting        AggregatedMetric `json:"http_req_waiting"`
 	Receiving      AggregatedMetric `json:"http_req_receiving"`
+	Failed         AggregatedRate   `json:"http_req_failed,omitempty"`
 }) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
@@ -415,6 +416,8 @@ func easyjson9def2ecdDecode(in *jlexer.Lexer, out *struct {
 			easyjson9def2ecdDecodeGithubComLoadimpactK6StatsCloud4(in, &out.Waiting)
 		case "http_req_receiving":
 			easyjson9def2ecdDecodeGithubComLoadimpactK6StatsCloud4(in, &out.Receiving)
+		case "http_req_failed":
+			easyjson9def2ecdDecodeGithubComLoadimpactK6StatsCloud5(in, &out.Failed)
 		default:
 			in.SkipRecursive()
 		}
@@ -433,6 +436,7 @@ func easyjson9def2ecdEncode(out *jwriter.Writer, in struct {
 	Sending        AggregatedMetric `json:"http_req_sending"`
 	Waiting        AggregatedMetric `json:"http_req_waiting"`
 	Receiving      AggregatedMetric `json:"http_req_receiving"`
+	Failed         AggregatedRate   `json:"http_req_failed,omitempty"`
 }) {
 	out.RawByte('{')
 	first := true
@@ -471,6 +475,60 @@ func easyjson9def2ecdEncode(out *jwriter.Writer, in struct {
 		const prefix string = ",\"http_req_receiving\":"
 		out.RawString(prefix)
 		easyjson9def2ecdEncodeGithubComLoadimpactK6StatsCloud4(out, in.Receiving)
+	}
+	if (in.Failed).IsDefined() {
+		const prefix string = ",\"http_req_failed\":"
+		out.RawString(prefix)
+		easyjson9def2ecdEncodeGithubComLoadimpactK6StatsCloud5(out, in.Failed)
+	}
+	out.RawByte('}')
+}
+func easyjson9def2ecdDecodeGithubComLoadimpactK6StatsCloud5(in *jlexer.Lexer, out *AggregatedRate) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "count":
+			out.Count = float64(in.Float64())
+		case "nz_count":
+			out.NzCount = float64(in.Float64())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson9def2ecdEncodeGithubComLoadimpactK6StatsCloud5(out *jwriter.Writer, in AggregatedRate) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"count\":"
+		out.RawString(prefix[1:])
+		out.Float64(float64(in.Count))
+	}
+	{
+		const prefix string = ",\"nz_count\":"
+		out.RawString(prefix)
+		out.Float64(float64(in.NzCount))
 	}
 	out.RawByte('}')
 }
@@ -530,7 +588,7 @@ func easyjson9def2ecdEncodeGithubComLoadimpactK6StatsCloud4(out *jwriter.Writer,
 	}
 	out.RawByte('}')
 }
-func easyjson9def2ecdDecodeGithubComLoadimpactK6StatsCloud5(in *jlexer.Lexer, out *Sample) {
+func easyjson9def2ecdDecodeGithubComLoadimpactK6StatsCloud6(in *jlexer.Lexer, out *Sample) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -571,7 +629,7 @@ func easyjson9def2ecdDecodeGithubComLoadimpactK6StatsCloud5(in *jlexer.Lexer, ou
 		in.Consumed()
 	}
 }
-func easyjson9def2ecdEncodeGithubComLoadimpactK6StatsCloud5(out *jwriter.Writer, in Sample) {
+func easyjson9def2ecdEncodeGithubComLoadimpactK6StatsCloud6(out *jwriter.Writer, in Sample) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -601,10 +659,10 @@ func easyjson9def2ecdEncodeGithubComLoadimpactK6StatsCloud5(out *jwriter.Writer,
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v Sample) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson9def2ecdEncodeGithubComLoadimpactK6StatsCloud5(w, v)
+	easyjson9def2ecdEncodeGithubComLoadimpactK6StatsCloud6(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *Sample) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson9def2ecdDecodeGithubComLoadimpactK6StatsCloud5(l, v)
+	easyjson9def2ecdDecodeGithubComLoadimpactK6StatsCloud6(l, v)
 }

--- a/stats/system_tag.go
+++ b/stats/system_tag.go
@@ -97,6 +97,7 @@ const (
 	TagTLSVersion
 	TagScenario
 	TagService
+	TagExpectedResponse
 
 	// System tags not enabled by default.
 	TagIter
@@ -109,7 +110,7 @@ const (
 // Other tags that are not enabled by default include: iter, vu, ocsp_status, ip
 //nolint:gochecknoglobals
 var DefaultSystemTagSet = TagProto | TagSubproto | TagStatus | TagMethod | TagURL | TagName | TagGroup |
-	TagCheck | TagCheck | TagError | TagErrorCode | TagTLSVersion | TagScenario | TagService
+	TagCheck | TagCheck | TagError | TagErrorCode | TagTLSVersion | TagScenario | TagService | TagExpectedResponse
 
 // Add adds a tag to tag set.
 func (i *SystemTagSet) Add(tag SystemTagSet) {

--- a/stats/system_tag_set_gen.go
+++ b/stats/system_tag_set_gen.go
@@ -7,26 +7,27 @@ import (
 	"fmt"
 )
 
-const _SystemTagSetName = "protosubprotostatusmethodurlnamegroupcheckerrorerror_codetls_versionscenarioserviceitervuocsp_statusip"
+const _SystemTagSetName = "protosubprotostatusmethodurlnamegroupcheckerrorerror_codetls_versionscenarioserviceexpected_responseitervuocsp_statusip"
 
 var _SystemTagSetMap = map[SystemTagSet]string{
-	1:     _SystemTagSetName[0:5],
-	2:     _SystemTagSetName[5:13],
-	4:     _SystemTagSetName[13:19],
-	8:     _SystemTagSetName[19:25],
-	16:    _SystemTagSetName[25:28],
-	32:    _SystemTagSetName[28:32],
-	64:    _SystemTagSetName[32:37],
-	128:   _SystemTagSetName[37:42],
-	256:   _SystemTagSetName[42:47],
-	512:   _SystemTagSetName[47:57],
-	1024:  _SystemTagSetName[57:68],
-	2048:  _SystemTagSetName[68:76],
-	4096:  _SystemTagSetName[76:83],
-	8192:  _SystemTagSetName[83:87],
-	16384: _SystemTagSetName[87:89],
-	32768: _SystemTagSetName[89:100],
-	65536: _SystemTagSetName[100:102],
+	1:      _SystemTagSetName[0:5],
+	2:      _SystemTagSetName[5:13],
+	4:      _SystemTagSetName[13:19],
+	8:      _SystemTagSetName[19:25],
+	16:     _SystemTagSetName[25:28],
+	32:     _SystemTagSetName[28:32],
+	64:     _SystemTagSetName[32:37],
+	128:    _SystemTagSetName[37:42],
+	256:    _SystemTagSetName[42:47],
+	512:    _SystemTagSetName[47:57],
+	1024:   _SystemTagSetName[57:68],
+	2048:   _SystemTagSetName[68:76],
+	4096:   _SystemTagSetName[76:83],
+	8192:   _SystemTagSetName[83:100],
+	16384:  _SystemTagSetName[100:104],
+	32768:  _SystemTagSetName[104:106],
+	65536:  _SystemTagSetName[106:117],
+	131072: _SystemTagSetName[117:119],
 }
 
 func (i SystemTagSet) String() string {
@@ -36,7 +37,7 @@ func (i SystemTagSet) String() string {
 	return fmt.Sprintf("SystemTagSet(%d)", i)
 }
 
-var _SystemTagSetValues = []SystemTagSet{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536}
+var _SystemTagSetValues = []SystemTagSet{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072}
 
 var _SystemTagSetNameToValueMap = map[string]SystemTagSet{
 	_SystemTagSetName[0:5]:     1,
@@ -52,10 +53,11 @@ var _SystemTagSetNameToValueMap = map[string]SystemTagSet{
 	_SystemTagSetName[57:68]:   1024,
 	_SystemTagSetName[68:76]:   2048,
 	_SystemTagSetName[76:83]:   4096,
-	_SystemTagSetName[83:87]:   8192,
-	_SystemTagSetName[87:89]:   16384,
-	_SystemTagSetName[89:100]:  32768,
-	_SystemTagSetName[100:102]: 65536,
+	_SystemTagSetName[83:100]:  8192,
+	_SystemTagSetName[100:104]: 16384,
+	_SystemTagSetName[104:106]: 32768,
+	_SystemTagSetName[106:117]: 65536,
+	_SystemTagSetName[117:119]: 131072,
 }
 
 // SystemTagSetString retrieves an enum value from the enum constants string name.

--- a/stats/units.go
+++ b/stats/units.go
@@ -37,3 +37,11 @@ func D(d time.Duration) float64 {
 func ToD(d float64) time.Duration {
 	return time.Duration(d * float64(timeUnit))
 }
+
+// B formats a boolean value for emission.
+func B(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}


### PR DESCRIPTION
This is done through running a callback on every request before emitting
the metrics. Currently only a built-in metric looking at good statuses
is possible, but a possibility for future JS based callbacks is left
open.

The implementation specifically makes it hard to figure out anything
about the returned callback from JS and tries not to change any other
code so it makes it easier for future implementation, but instead tries
to do the bare minimum without imposing any limitations on the future
work.

Additionally because it turned out to be easy, setting the callback to
null will make the http library to neither tag requests as passed nor
emit the new `http_req_failed` metric, essentially giving users a way to
go back to the previous behaviour.

The cloud output is also not changed as the `http_req_li` already is
aggregated based on tags so if an `http_req_li` is received that has tag
`passed:true` then the whole `http_req_li` is about requests that have
"passed".

part of #1828

