### PR TITLE
Require cloud scripts to always have a name

### DIFF
--- a/stats/cloud/collector.go
+++ b/stats/cloud/collector.go
@@ -97,11 +97,17 @@ func New(
 	}
 
 	if conf.AggregationPeriod.Duration > 0 && (opts.SystemTags.Has(stats.TagVU) || opts.SystemTags.Has(stats.TagIter)) {
-		return nil, errors.New("Aggregation cannot be enabled if the 'vu' or 'iter' system tag is also enabled")
+		return nil, errors.New("aggregation cannot be enabled if the 'vu' or 'iter' system tag is also enabled")
 	}
 
 	if !conf.Name.Valid || conf.Name.String == "" {
-		conf.Name = null.StringFrom(filepath.Base(scriptURL.String()))
+		scriptPath := scriptURL.String()
+		if scriptPath == "" {
+			// Script from stdin without a name, likely from stdin
+			return nil, errors.New("script name not set, please specify K6_CLOUD_NAME or options.ext.loadimpact.name")
+		}
+
+		conf.Name = null.StringFrom(filepath.Base(scriptPath))
 	}
 	if conf.Name.String == "-" {
 		conf.Name = null.StringFrom(TestName)


### PR DESCRIPTION
This fixes https://github.com/loadimpact/k6/issues/923 and was originally part of https://github.com/loadimpact/k6/pull/1869, but it makes more sense as a separate PR, so I split it apart.