### PR TITLE
Fix metrics data race in the Engine test run finalization

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -328,6 +328,15 @@ func (e *Engine) processMetrics(globalCtx context.Context, processMetricsAfterRu
 		case <-ticker.C:
 			processSamples()
 		case <-processMetricsAfterRun:
+		getCachedMetrics:
+			for {
+				select {
+				case sc := <-e.Samples:
+					sampleContainers = append(sampleContainers, sc)
+				default:
+					break getCachedMetrics
+				}
+			}
 			e.logger.Debug("Processing metrics and thresholds after the test run has ended...")
 			processSamples()
 			if !e.runtimeOptions.NoThresholds.Bool {


### PR DESCRIPTION
There was a race between these two branches of the `select`: https://github.com/loadimpact/k6/blob/f1413e601b021d19f06d4d72ee14714a46344162/core/engine.go#L330-L339

I didn't add a test, since apparently the xk6 one I added in https://github.com/loadimpact/k6/pull/1885 already covers it - yay for integration tests... :tada:  :sweat_smile: This should close https://github.com/loadimpact/k6/issues/1887
