### PR TITLE
Pin InfluxDB version to 1.8 until we add support for 2.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
 
 services:
   influxdb:
-    image: influxdb:latest
+    image: influxdb:1.8
     networks:
       - k6
       - grafana


### PR DESCRIPTION
Reported in https://github.com/loadimpact/k6/issues/1883, this fix should suffice until we get around to https://github.com/loadimpact/k6/issues/1730 and/or https://github.com/loadimpact/k6/issues/1614
