### PR TITLE
Drop the SSLv3 support

### DIFF
--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -380,27 +380,27 @@ func TestNewBundle(t *testing.T) {
 				b, err := getSimpleBundle(t, "/script.js", `
 					export let options = {
 						tlsVersion: {
-							min: "ssl3.0",
+							min: "tls1.0",
 							max: "tls1.2"
 						}
 					};
 					export default function() {};
 				`)
 				if assert.NoError(t, err) {
-					assert.Equal(t, b.Options.TLSVersion.Min, lib.TLSVersion(tls.VersionSSL30))
+					assert.Equal(t, b.Options.TLSVersion.Min, lib.TLSVersion(tls.VersionTLS10))
 					assert.Equal(t, b.Options.TLSVersion.Max, lib.TLSVersion(tls.VersionTLS12))
 				}
 			})
 			t.Run("String", func(t *testing.T) {
 				b, err := getSimpleBundle(t, "/script.js", `
 					export let options = {
-						tlsVersion: "ssl3.0"
+						tlsVersion: "tls1.0"
 					};
 					export default function() {};
 				`)
 				if assert.NoError(t, err) {
-					assert.Equal(t, b.Options.TLSVersion.Min, lib.TLSVersion(tls.VersionSSL30))
-					assert.Equal(t, b.Options.TLSVersion.Max, lib.TLSVersion(tls.VersionSSL30))
+					assert.Equal(t, b.Options.TLSVersion.Min, lib.TLSVersion(tls.VersionTLS10))
+					assert.Equal(t, b.Options.TLSVersion.Max, lib.TLSVersion(tls.VersionTLS10))
 				}
 			})
 		})

--- a/js/modules/k6/http/http.go
+++ b/js/modules/k6/http/http.go
@@ -54,7 +54,6 @@ var _ modules.HasModuleInstancePerVU = new(GlobalHTTP)
 // NewModuleInstancePerVU returns an HTTP instance for each VU
 func (g *GlobalHTTP) NewModuleInstancePerVU() interface{} { // this here needs to return interface{}
 	return &HTTP{ // change the below fields to be not writable or not fields
-		SSL_3_0:                            netext.SSL_3_0,
 		TLS_1_0:                            netext.TLS_1_0,
 		TLS_1_1:                            netext.TLS_1_1,
 		TLS_1_2:                            netext.TLS_1_2,
@@ -80,7 +79,6 @@ func (g *GlobalHTTP) NewModuleInstancePerVU() interface{} { // this here needs t
 
 //nolint: golint
 type HTTP struct {
-	SSL_3_0                            string `js:"SSL_3_0"`
 	TLS_1_0                            string `js:"TLS_1_0"`
 	TLS_1_1                            string `js:"TLS_1_1"`
 	TLS_1_2                            string `js:"TLS_1_2"`

--- a/lib/netext/tls.go
+++ b/lib/netext/tls.go
@@ -44,7 +44,6 @@ const (
 	OCSP_REASON_REMOVE_FROM_CRL        = "remove_from_crl"
 	OCSP_REASON_PRIVILEGE_WITHDRAWN    = "privilege_withdrawn"
 	OCSP_REASON_AA_COMPROMISE          = "aa_compromise"
-	SSL_3_0                            = "ssl3.0"
 	TLS_1_0                            = "tls1.0"
 	TLS_1_1                            = "tls1.1"
 	TLS_1_2                            = "tls1.2"
@@ -67,8 +66,6 @@ type OCSP struct {
 func ParseTLSConnState(tlsState *tls.ConnectionState) (TLSInfo, OCSP) {
 	tlsInfo := TLSInfo{}
 	switch tlsState.Version {
-	case tls.VersionSSL30:
-		tlsInfo.Version = SSL_3_0
 	case tls.VersionTLS10:
 		tlsInfo.Version = TLS_1_0
 	case tls.VersionTLS11:

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -170,17 +170,17 @@ func TestOptions(t *testing.T) {
 		t.Run("JSON", func(t *testing.T) {
 			t.Run("Object", func(t *testing.T) {
 				var opts Options
-				jsonStr := `{"tlsVersion":{"min":"ssl3.0","max":"tls1.2"}}`
+				jsonStr := `{"tlsVersion":{"min":"tls1.0","max":"tls1.2"}}`
 				assert.NoError(t, json.Unmarshal([]byte(jsonStr), &opts))
 				assert.Equal(t, &TLSVersions{
-					Min: TLSVersion(tls.VersionSSL30),
+					Min: TLSVersion(tls.VersionTLS10),
 					Max: TLSVersion(tls.VersionTLS12),
 				}, opts.TLSVersion)
 
 				t.Run("Roundtrip", func(t *testing.T) {
 					data, err := json.Marshal(opts.TLSVersion)
 					assert.NoError(t, err)
-					assert.Equal(t, `{"min":"ssl3.0","max":"tls1.2"}`, string(data))
+					assert.Equal(t, `{"min":"tls1.0","max":"tls1.2"}`, string(data))
 					var vers2 TLSVersions
 					assert.NoError(t, json.Unmarshal(data, &vers2))
 					assert.Equal(t, &vers2, opts.TLSVersion)
@@ -209,6 +209,9 @@ func TestOptions(t *testing.T) {
 			t.Run("Unsupported version", func(t *testing.T) {
 				var opts Options
 				jsonStr := `{"tlsVersion":"-1"}`
+				assert.Error(t, json.Unmarshal([]byte(jsonStr), &opts))
+
+				jsonStr = `{"tlsVersion":"ssl3.0"}`
 				assert.Error(t, json.Unmarshal([]byte(jsonStr), &opts))
 			})
 		})

--- a/lib/tlsconfig.go
+++ b/lib/tlsconfig.go
@@ -26,7 +26,6 @@ import "crypto/tls"
 // SupportedTLSVersions is string-to-constant map of available TLS versions.
 //nolint: gochecknoglobals
 var SupportedTLSVersions = map[string]TLSVersion{
-	"ssl3.0": tls.VersionSSL30,
 	"tls1.0": tls.VersionTLS10,
 	"tls1.1": tls.VersionTLS11,
 	"tls1.2": tls.VersionTLS12,
@@ -36,7 +35,6 @@ var SupportedTLSVersions = map[string]TLSVersion{
 // SupportedTLSVersionsToString is constant-to-string map of available TLS versions.
 //nolint: gochecknoglobals
 var SupportedTLSVersionsToString = map[TLSVersion]string{
-	tls.VersionSSL30: "ssl3.0",
 	tls.VersionTLS10: "tls1.0",
 	tls.VersionTLS11: "tls1.1",
 	tls.VersionTLS12: "tls1.2",


### PR DESCRIPTION
SSLv3 has been removed from the supported version list of the crypto protocols.

Closes #1083

<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/loadimpact/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/loadimpact/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
